### PR TITLE
Validate  constraints in optimize_acqf

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -10,6 +10,8 @@ Methods for optimizing acquisition functions.
 
 from __future__ import annotations
 
+import warnings
+
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -19,7 +21,7 @@ from botorch.acquisition.acquisition import (
     OneShotAcquisitionFunction,
 )
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
-from botorch.exceptions import InputDataError, UnsupportedError
+from botorch.exceptions import InputDataError, OptimizationWarning, UnsupportedError
 from botorch.generation.gen import gen_candidates_scipy
 from botorch.logging import logger
 from botorch.optim.initializers import (
@@ -29,6 +31,7 @@ from botorch.optim.initializers import (
 from botorch.optim.stopping import ExpMAStoppingCriterion
 from scipy.optimize import linprog
 from torch import Tensor
+
 
 INIT_OPTION_KEYS = {
     # set of options for initialization that we should
@@ -804,7 +807,8 @@ def _validate_constraints(
             raise ValueError("Feasible set unbounded.")
         warnings.warn(
             "Ran into issues when checking for boundedness of feasible set. "
-            f"Optimizer message: {result.message}."
+            f"Optimizer message: {result.message}.",
+            OptimizationWarning,
         )
 
 

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -733,7 +733,10 @@ def _validate_constraints(
     # We solve the following Linear Program to ensure that he constraint set
     # is non-empty and bounded:
     #
-    #   max_x |x|_1 s.t. bounds, inequality_constraints, constraints
+    #   max_x |x|_1
+    #     s.t. bounds(x)
+    #          inequality_constraints(x)
+    #          equality_constraints(x)
     #
     # To do this we can introduce auxiliary variables s and solve the
     # following standard formulation:

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -67,6 +67,7 @@ def optimize_acqf(
     batch_initial_conditions: Optional[Tensor] = None,
     return_best_only: bool = True,
     sequential: bool = False,
+    validate_constraints: bool = True,
     **kwargs: Any,
 ) -> Tuple[Tensor, Tensor]:
     r"""Generate a set of candidates via multi-start optimization.
@@ -105,6 +106,8 @@ def optimize_acqf(
             random restart initializations of the optimization.
         sequential: If False, uses joint optimization, otherwise uses sequential
             optimization.
+        validate_constraints: If True, validate that the constraint set is
+            non-empty and bounded by solving a Linear Program.
         kwargs: Additonal keyword arguments.
 
     Returns:
@@ -130,11 +133,12 @@ def optimize_acqf(
         >>>     qEI, bounds, 3, 15, 256, sequential=True
         >>> )
     """
-    _validate_constraints(
-        bounds=bounds,
-        inequality_constraints=inequality_constraints,
-        equality_constraints=equality_constraints,
-    )
+    if validate_constraints:
+        _validate_constraints(
+            bounds=bounds,
+            inequality_constraints=inequality_constraints,
+            equality_constraints=equality_constraints,
+        )
 
     if sequential and q > 1:
         if not return_best_only:
@@ -164,6 +168,7 @@ def optimize_acqf(
                 batch_initial_conditions=None,
                 return_best_only=True,
                 sequential=False,
+                validate_constraints=False,
             )
             candidate_list.append(candidate)
             acq_value_list.append(acq_value)
@@ -273,6 +278,7 @@ def optimize_acqf_cyclic(
     post_processing_func: Optional[Callable[[Tensor], Tensor]] = None,
     batch_initial_conditions: Optional[Tensor] = None,
     cyclic_options: Optional[Dict[str, Union[bool, float, int, str]]] = None,
+    validate_constraints: bool = True,
 ) -> Tuple[Tensor, Tensor]:
     r"""Generate a set of `q` candidates via cyclic optimization.
 
@@ -300,6 +306,8 @@ def optimize_acqf_cyclic(
             If no initial conditions are provided, the default initialization will
             be used.
         cyclic_options: Options for stopping criterion for outer cyclic optimization.
+        validate_constraints: If True, validate that the constraint set is
+            non-empty and bounded by solving a Linear Program.
 
     Returns:
         A two-element tuple containing
@@ -334,6 +342,7 @@ def optimize_acqf_cyclic(
         batch_initial_conditions=batch_initial_conditions,
         return_best_only=True,
         sequential=True,
+        validate_constraints=validate_constraints,
     )
     if q > 1:
         cyclic_options = cyclic_options or {}
@@ -364,6 +373,7 @@ def optimize_acqf_cyclic(
                     batch_initial_conditions=candidates[i].unsqueeze(0),
                     return_best_only=True,
                     sequential=True,
+                    validate_constraints=False,
                 )
                 candidates[i] = candidate_i
                 acq_vals[i] = acq_val_i
@@ -383,6 +393,7 @@ def optimize_acqf_list(
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
     fixed_features: Optional[Dict[int, float]] = None,
     post_processing_func: Optional[Callable[[Tensor], Tensor]] = None,
+    validate_constraints: bool = True,
 ) -> Tuple[Tensor, Tensor]:
     r"""Generate a list of candidates from a list of acquisition functions.
 
@@ -408,6 +419,8 @@ def optimize_acqf_list(
         post_processing_func: A function that post-processes an optimization
             result appropriately (i.e., according to `round-trip`
             transformations).
+        validate_constraints: If True, validate that the constraint set is
+            non-empty and bounded by solving a Linear Program.
 
     Returns:
         A two-element tuple containing
@@ -419,6 +432,13 @@ def optimize_acqf_list(
     """
     if not acq_function_list:
         raise ValueError("acq_function_list must be non-empty.")
+    if validate_constraints:
+        _validate_constraints(
+            bounds=bounds,
+            inequality_constraints=inequality_constraints,
+            equality_constraints=equality_constraints,
+        )
+
     candidate_list, acq_value_list = [], []
     candidates = torch.tensor([], device=bounds.device, dtype=bounds.dtype)
     base_X_pending = acq_function_list[0].X_pending
@@ -442,6 +462,7 @@ def optimize_acqf_list(
             post_processing_func=post_processing_func,
             return_best_only=True,
             sequential=False,
+            validate_constraints=False,
         )
         candidate_list.append(candidate)
         acq_value_list.append(acq_value)
@@ -461,6 +482,7 @@ def optimize_acqf_mixed(
     equality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
     post_processing_func: Optional[Callable[[Tensor], Tensor]] = None,
     batch_initial_conditions: Optional[Tensor] = None,
+    validate_constraints: bool = True,
     **kwargs: Any,
 ) -> Tuple[Tensor, Tensor]:
     r"""Optimize over a list of fixed_features and returns the best solution.
@@ -491,6 +513,8 @@ def optimize_acqf_mixed(
             transformations).
         batch_initial_conditions: A tensor to specify the initial conditions. Set
             this if you do not want to use default initialization strategy.
+        validate_constraints: If True, validate that the constraint set is
+            non-empty and bounded by solving a Linear Program.
 
     Returns:
         A two-element tuple containing
@@ -508,6 +532,12 @@ def optimize_acqf_mixed(
                 "are currently not supported when `q > 1`. This is needed to "
                 "compute the joint acquisition value."
             )
+    if validate_constraints:
+        _validate_constraints(
+            bounds=bounds,
+            inequality_constraints=inequality_constraints,
+            equality_constraints=equality_constraints,
+        )
 
     if q == 1:
         ff_candidate_list, ff_acq_value_list = [], []
@@ -525,6 +555,7 @@ def optimize_acqf_mixed(
                 post_processing_func=post_processing_func,
                 batch_initial_conditions=batch_initial_conditions,
                 return_best_only=True,
+                validate_constraints=False,
             )
             ff_candidate_list.append(candidate)
             ff_acq_value_list.append(acq_value)

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -663,11 +663,19 @@ class TestOptimizeAcqfCyclic(BotorchTestCase):
                 if i == 0:
                     # first cycle
                     expected_call_args.update(
-                        {"batch_initial_conditions": None, "q": q}
+                        {
+                            "batch_initial_conditions": None,
+                            "q": q,
+                            "validate_constraints": True,
+                        }
                     )
                 else:
                     expected_call_args.update(
-                        {"batch_initial_conditions": orig_candidates[i - 1 : i], "q": 1}
+                        {
+                            "batch_initial_conditions": orig_candidates[i - 1 : i],
+                            "q": 1,
+                            "validate_constraints": False,
+                        }
                     )
                     orig_candidates[i - 1] = candidate_rvs[i]
                 for k, v in call_args_list[i][1].items():
@@ -689,9 +697,6 @@ class TestOptimizeAcqfList(BotorchTestCase):
         options = {}
         tkwargs = {"device": self.device}
         bounds = torch.stack([torch.zeros(3), 4 * torch.ones(3)])
-        inequality_constraints = [
-            [torch.tensor([3]), torch.tensor([4]), torch.tensor(5)]
-        ]
         # reinitialize so that dtype
         mock_acq_function_1 = MockAcquisitionFunction()
         mock_acq_function_2 = MockAcquisitionFunction()
@@ -701,8 +706,8 @@ class TestOptimizeAcqfList(BotorchTestCase):
                 # clear previous X_pending
                 m.set_X_pending(None)
             tkwargs["dtype"] = dtype
-            inequality_constraints[0] = [
-                t.to(**tkwargs) for t in inequality_constraints[0]
+            inequality_constraints = [
+                [torch.tensor([3]), torch.tensor([4.0], **tkwargs), 5.0]
             ]
             mock_optimize_acqf.reset_mock()
             bounds = bounds.to(**tkwargs)
@@ -775,6 +780,7 @@ class TestOptimizeAcqfList(BotorchTestCase):
                 "batch_initial_conditions": None,
                 "return_best_only": True,
                 "sequential": False,
+                "validate_constraints": False,
             }
             for i in range(len(call_args_list)):
                 expected_call_args["acq_function"] = mock_acq_function_list[i]
@@ -855,6 +861,7 @@ class TestOptimizeAcqfMixed(BotorchTestCase):
                 "batch_initial_conditions": None,
                 "return_best_only": True,
                 "sequential": False,
+                "validate_constraints": False,
             }
             for i in range(len(call_args_list)):
                 expected_call_args["fixed_features"] = fixed_features_list[i]

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -109,7 +109,7 @@ class TestOptimizeAcqf(BotorchTestCase):
                 )
             ],
         )
-        # Check hat added equality constraint resolves this
+        # Check that added equality constraint resolves this
         _validate_constraints(
             bounds=bounds,
             equality_constraints=[


### PR DESCRIPTION
In some cases we may allow not using box constraints (e.g. when optimizing Alebo). Also, in general it would be good to the optimziation raise an error if the constraint set is empty.

Will require some unit tests.