### PR TITLE
[RFC] Move input transforms to GPyTorch

### DIFF
--- a/botorch/models/approximate_gp.py
+++ b/botorch/models/approximate_gp.py
@@ -168,6 +168,7 @@ class _SingleTaskVariationalGP(ApproximateGP):
         variational_distribution: Optional[_VariationalDistribution] = None,
         variational_strategy: Type[_VariationalStrategy] = VariationalStrategy,
         inducing_points: Optional[Union[Tensor, int]] = None,
+        input_transform: Optional[InputTransform] = None,
     ) -> None:
         r"""
         Args:
@@ -252,6 +253,8 @@ class _SingleTaskVariationalGP(ApproximateGP):
         super().__init__(variational_strategy=variational_strategy)
         self.mean_module = mean_module
         self.covar_module = covar_module
+        if input_transform is not None:
+            self.input_transform = input_transform
 
     def forward(self, X) -> MultivariateNormal:
         mean_x = self.mean_module(X)
@@ -373,14 +376,13 @@ class SingleTaskVariationalGP(ApproximateGPyTorchModel):
             variational_distribution=variational_distribution,
             variational_strategy=variational_strategy,
             inducing_points=inducing_points,
+            input_transform=input_transform,
         )
 
         super().__init__(model=model, likelihood=likelihood, num_outputs=num_outputs)
 
         if outcome_transform is not None:
             self.outcome_transform = outcome_transform
-        if input_transform is not None:
-            self.input_transform = input_transform
 
         # for model fitting utilities
         # TODO: make this a flag?

--- a/botorch/models/model_list_gp_regression.py
+++ b/botorch/models/model_list_gp_regression.py
@@ -114,13 +114,3 @@ class ModelListGP(IndependentModelList, ModelListGPyTorchModel):
             The current model, subset to the specified output indices.
         """
         return self.__class__(*[deepcopy(self.models[i]) for i in idcs])
-
-    def _set_transformed_inputs(self) -> None:
-        r"""Update training inputs with transformed inputs."""
-        for m in self.models:
-            m._set_transformed_inputs()
-
-    def _revert_to_original_inputs(self) -> None:
-        r"""Revert training inputs back to original."""
-        for m in self.models:
-            m._revert_to_original_inputs()


### PR DESCRIPTION
Summary:
This diff presents a minimal implementation of input transforms in GPyTorch. See cornellius-gp/gpytorch#2114 for GPyTorch side of these changes.

What this does:
* Moves the `transform_inputs` from BoTorch `Model` to GPyTorch `GP` class, with some modifications to explicitly identify whether given inputs are train or test inputs.
* Modifies the `InputTransform.forward` call to use `is_training_input` argument instead of `self.training` check to apply the transforms that have `transform_on_train=True`.
* Removes `preprocess_transform` method since this is no-longer needed.
* For `ExactGP` models, it transforms both train and test inputs in `__call__`. For `train_inputs` it always uses `is_training_input=True`. For generic `inputs`, it uses `is_training_input=self.training` which signals that these are training inputs when the model is in `train` mode, and that these are test inputs when the model is in `eval` mode.
* For `ApproximateGP` models, it applies the transform to `inputs` in `__call__` using `is_training_input=self.training`. This again signifies whether the given inputs are train or test inputs based on the mode of the model. Note that this NEVER transforms `inducing_points`, thus fixes the previous bug with `inducing_points` getting transformed in `train` but not getting transformed in `eval`. It is expected that the user will define inducing points in the appropriate space (mostly the normalized space / unit cube).
* For BoTorch `SingleTaskVariationalGP`, it moves the `input_transform` attribute down to `_SingleTaskVariationalGP`, which is the actual `ApproximateGP` instance. This makes the transform accessible from GPyTorch.

What this doesn't do:
* It doesn't do anything about `DeterministicModel`s. Those will still need to deal with their own transforms, which is not implemented here. If we make `Model` inherit from `GP`, we can keep the existing setup with very minimal changes.
* It does not clean up the call sites for `self.transform_inputs`. This is just made into a no-op and the clean-up is left for later.
* It does not upstream the abstract `InputTransform` classes to GPyTorch. That'll be done if we decide to go forward with this design.
* It does not touch `PairwiseGP`. `PairwiseGP` has some non-standard use of input transforms, so it needs an audit to make sure things still work fine.
* I didn't look into `ApproximateGP.fantasize`. This may need some changes similar to `ExactGP.get_fantasy_model`.
* It does not support `PyroGP` and `DeepGP`.

Differential Revision: D39147547

