### PR TITLE
Add ScaleKernel to get_covar_module_with_dim_scaled_prior

### DIFF
--- a/botorch/models/utils/gpytorch_modules.py
+++ b/botorch/models/utils/gpytorch_modules.py
@@ -102,8 +102,8 @@ def get_covar_module_with_dim_scaled_prior(
     batch_shape: torch.Size | None = None,
     use_rbf_kernel: bool = True,
     active_dims: Sequence[int] | None = None,
-) -> MaternKernel | RBFKernel:
-    """Returns an RBF or Matern kernel with priors
+) -> ScaleKernel:
+    """Returns an ScaleKernel based on RBF or Matern kernel with priors
     from  [Hvarfner2024vanilla]_.
 
     Args:
@@ -130,4 +130,8 @@ def get_covar_module_with_dim_scaled_prior(
         # pyre-ignore[6] GPyTorch type is unnecessarily restrictive.
         active_dims=active_dims,
     )
-    return base_kernel
+    return ScaleKernel(
+        base_kernel=base_kernel,
+        batch_shape=batch_shape,
+        outputscale_prior=GammaPrior(2.0, 0.15),
+    )


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation
Since version 0.12.0, dim_scaled_lognormal_prior[Hvarfner2024vanilla] has become the default. However, as ScaleKernel is not applied in `get_covar_module_with_dim_scaled_prior()`, performance may deteriorate in some cases.
(The selection of the prior distribution depends on the task, but adjusting the scale seems beneficial and unproblematic across tasks.)

An example is shown below. 
Run the task of finding the minimum of [Styblinski-Tang ](https://www.sfu.ca/~ssurjano/stybtang.html) (D=40) three times and compare the average performance.
![StyblinskiTang40_performance-1](https://github.com/user-attachments/assets/2957b0a8-3edc-423c-ac01-a050550c63e5)
![StyblinskiTang40_all-1](https://github.com/user-attachments/assets/3271e1c4-43c2-47ec-bd0e-c7a7d7617651)




### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

I have read it.

## Test Plan

Since this is a performance-related change, testing will involve a performance comparison on benchmark functions (such as Styblinski-Tang).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
