### PR TITLE
Move Target Aware GP to OSS (#3013)

### DIFF
--- a/botorch/models/__init__.py
+++ b/botorch/models/__init__.py
@@ -29,6 +29,7 @@ from botorch.models.model import ModelList
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import KroneckerMultiTaskGP, MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP, PairwiseLaplaceMarginalLogLikelihood
+from botorch.models.target_aware_gp import TargetAwareEnsembleGP
 
 __all__ = [
     "add_saas_prior",
@@ -52,4 +53,5 @@ __all__ = [
     "SingleTaskGP",
     "SingleTaskMultiFidelityGP",
     "SingleTaskVariationalGP",
+    "TargetAwareEnsembleGP",
 ]

--- a/botorch/models/target_aware_gp.py
+++ b/botorch/models/target_aware_gp.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from botorch.models.fully_bayesian import MCMC_DIM
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.gpytorch import GPyTorchModel
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
+from botorch.utils.datasets import SupervisedDataset
+from gpytorch.constraints import Interval
+from gpytorch.distributions.multivariate_normal import MultivariateNormal
+from gpytorch.means.mean import Mean
+from gpytorch.priors import HalfCauchyPrior, Prior
+from linear_operator.operators import PsdSumLinearOperator
+from torch import Tensor
+from torch.nn import Module, Parameter
+from torch.nn.modules import ModuleDict
+
+r"""
+Target-aware GP models.
+
+References
+
+.. [Feng2025experimenting]
+    Q. Feng, S. Daulton, B. Letham, M. Balandat, and E. Bakshy.
+    Experimenting, Fast and Slow: Bayesian Optimization of Long-term Outcomes
+    with Online Experiments. Proceedings of the 31st ACM SIGKDD Conference on
+    Knowledge Discovery and Data Mining, 2025.
+"""
+
+WEIGHT_THRESHOLD = 0.01
+
+
+class TargetAwareEnsembleGP(SingleTaskGP):
+    r"""A target-aware ensemble GP that takes a set of GPs pre-trained on the
+    auxiliary data to improve prediction accuracy of the target task.
+
+    The target outputs are modeled as weighted sum of an offset function and
+    functions of each auxiliary sources. The offset function is unknown.
+    The ensemble model jointly optimizes the kernel hyperparameters of the
+    target task together with the weights.
+
+    This model is described in [Feng2025experimenting]_.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        base_model_dict: dict[str, GPyTorchModel],
+        train_Yvar: Tensor | None = None,
+        covar_module: Module | None = None,
+        mean_module: Mean | None = None,
+        outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
+        ensemble_weight_prior: Prior | None = None,
+    ) -> None:
+        r"""A dictionary kernel with a scale kernel.
+
+        Args:
+            train_X: (n x d) X training data of target task.
+            train_Y: (n x 1) Y training data of target task.
+            train_Yvar: (n x 1) Noise variances of each training Y.
+            base_model_dict: Dict of GP models that each corresponds to a model trained
+                on an auxiliary dataset. Keys are the name of auxiliary dataset.
+            covar_module: The module computing the covariance (Kernel) matrix for the
+                target data. If omitted, use a `MaternKernel`.
+            mean_module: The mean function to be used for the target data. If omitted,
+                use a `ConstantMean`.
+            ensemble_weight_prior: The prior over the weights of the ensemble model.
+                If omitted, use default HalfCauchyPrior with scale = 1.0.
+        """
+        if ensemble_weight_prior is None:
+            ensemble_weight_prior = HalfCauchyPrior(scale=1.0)
+
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            covar_module=covar_module,
+            mean_module=mean_module,
+            outcome_transform=outcome_transform,
+            input_transform=input_transform,
+        )
+
+        self.base_model_dict = ModuleDict(base_model_dict)
+        self.base_model_dict.eval()
+
+        # register ensemble weights
+        self.register_parameter(
+            name="raw_weight",
+            parameter=Parameter(
+                torch.zeros(len(self.base_model_dict), device=train_X.device)
+            ),
+        )
+        self.register_constraint(
+            param_name="raw_weight",
+            constraint=Interval(-10, 10, initial_value=0.1),
+            replace=True,
+        )
+        # set prior on weights so that the unimportant auxiliary
+        # sources can be shrunk to 0.
+        self.register_prior(
+            "weight_prior",
+            ensemble_weight_prior.to(train_X),
+            lambda m: m.weight**2,
+            lambda m, v: m._set_weight(v),
+        )
+        self.to(train_X)
+
+    @property
+    def weight(self) -> Tensor:
+        return self.raw_weight_constraint.transform(self.raw_weight)
+
+    @weight.setter
+    def weight(self, value: Tensor) -> None:
+        value = torch.as_tensor(value).to(self.raw_weight)
+        self.initialize(raw_weight=self.raw_weight_constraint.inverse_transform(value))
+
+    def _set_weight(self, value: Tensor) -> None:
+        # Prior closure: prior is registered on `weight ** 2`, so `value` here is a
+        # sample of `weight ** 2`. Take the sqrt to recover `weight` before setting.
+        self.weight = torch.as_tensor(value).to(self.raw_weight).sqrt()
+
+    def train(self, mode: bool = True) -> None:
+        r"""Puts the model in `train` mode."""
+        self.training = mode
+        for module in self.children():
+            if module is self.base_model_dict:
+                # set base_model module training always be False
+                module.training = False
+                module.requires_grad_(False)
+            else:
+                module.train(mode)
+
+    def forward(self, x: Tensor) -> MultivariateNormal:
+        if self.training:
+            x = self.transform_inputs(x)
+        weighted_means = []
+        weighted_covars = []
+        for i, m in enumerate(self.base_model_dict.values()):
+            posterior = m.posterior(x)
+            if abs(self.weight[i]) < WEIGHT_THRESHOLD:  # Or some appropriate threshold
+                continue
+            if isinstance(posterior, GaussianMixturePosterior):
+                mean = posterior.mixture_mean
+                covar = posterior.mvn.covariance_matrix.mean(dim=MCMC_DIM)
+            else:
+                mean = posterior.mean
+                covar = posterior.mvn.covariance_matrix
+            weighted_means.append(self.weight[i] * mean)
+            weighted_covars.append(covar * (self.weight[i] ** 2))
+        # obtain mean and covar from the offset function
+        weighted_means.append(self.mean_module(x).unsqueeze(-1))
+        weighted_covars.append(self.covar_module(x))
+        # average across a list of posteriors
+        mean_x = torch.stack(weighted_means).sum(dim=0).squeeze(-1)
+        covar_x = PsdSumLinearOperator(*weighted_covars)
+        return MultivariateNormal(mean_x, covar_x)
+
+    @classmethod
+    def construct_inputs(
+        cls,
+        training_data: SupervisedDataset,
+        base_model_dict: dict[str, GPyTorchModel],
+        covar_module: Module | None = None,
+        mean_module: Mean | None = None,
+        ensemble_weight_prior: Prior | None = None,
+    ) -> dict[str, Any]:
+        r"""Construct `Model` keyword arguments from a dict of `SupervisedDataset`.
+
+        Args:
+            training_data: A `SupervisedDataset` containing the training data for the
+                target task only.
+            base_model_dict: Dict of GP models that each corresponds to a model trained
+                on an auxiliary dataset. Keys are the name of auxiliary dataset.
+            covar_module: The module computing the covariance (Kernel) matrix for the
+                target data. If omitted, use a `MaternKernel`.
+            mean_module: The mean function to be used for the target data. If omitted,
+                use a `ConstantMean`.
+            ensemble_weight_prior: The prior over the weights of the ensemble model.
+                If omitted, use default HalfCauchyPrior with scale = 1.0.
+        """
+        base_inputs = super().construct_inputs(training_data=training_data)
+        return {
+            **base_inputs,
+            "base_model_dict": base_model_dict,
+            "covar_module": covar_module,
+            "mean_module": mean_module,
+            "ensemble_weight_prior": ensemble_weight_prior,
+        }

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -114,6 +114,11 @@ Relevance Pursuit Models
 .. automodule:: botorch.models.relevance_pursuit
     :members:
 
+Target-Aware GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.target_aware_gp
+    :members:
+
 Sparse Axis-Aligned Subspaces (SAAS) GP Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.map_saas

--- a/test/models/test_target_aware_gp.py
+++ b/test/models/test_target_aware_gp.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import warnings
+from copy import deepcopy
+
+import torch
+from botorch.exceptions.warnings import OptimizationWarning
+from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_mll
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.target_aware_gp import TargetAwareEnsembleGP
+from botorch.models.transforms import Normalize, Standardize
+from botorch.posteriors import GPyTorchPosterior
+from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import RBFKernel
+from gpytorch.means import ZeroMean
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from gpytorch.priors import HalfCauchyPrior
+from torch.nn.modules import ModuleDict
+
+
+class TestTargetAwareEnsembleGP(BotorchTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.tkwargs = {"device": self.device, "dtype": torch.double}
+        self.train_X = torch.rand(10, 1, **self.tkwargs)
+        self.train_Y = torch.rand(10, 1, **self.tkwargs)
+        self.train_Yvar = torch.full_like(self.train_Y, 0.01, **self.tkwargs)
+        self.base_model_dict = {
+            "auxiliary_metric1": SingleTaskGP(
+                self.train_X, self.train_Y, self.train_Yvar
+            ),
+            "auxiliary_metric2": SingleTaskGP(
+                self.train_X, self.train_Y, self.train_Yvar
+            ),
+        }
+        for m in self.base_model_dict.values():
+            mll = ExactMarginalLogLikelihood(m.likelihood, m)
+            fit_gpytorch_mll(
+                mll, optimizer_kwargs={"options": {"maxiter": 5}}, max_attempts=1
+            )
+        self.base_model_state_dict = {
+            metric_name: m.state_dict()
+            for metric_name, m in self.base_model_dict.items()
+        }
+
+    def test_init(self) -> None:
+        mean_module = ZeroMean()
+        covar_module = RBFKernel(use_ard=False)
+        bounds = torch.tensor([[-1.0], [1.0]], **self.tkwargs)
+        octf = Standardize(m=1)
+        intf = Normalize(d=1, bounds=bounds)
+        weight_prior = HalfCauchyPrior(torch.tensor(0.1, **self.tkwargs))
+
+        for prior in [None, weight_prior]:
+            tw_model = TargetAwareEnsembleGP(
+                train_X=self.train_X,
+                train_Y=self.train_Y,
+                train_Yvar=self.train_Yvar,
+                base_model_dict=self.base_model_dict,
+                mean_module=mean_module,
+                covar_module=covar_module,
+                outcome_transform=octf,
+                input_transform=intf,
+                ensemble_weight_prior=prior,
+            )
+            self.assertEqual(tw_model.mean_module, mean_module)
+            self.assertEqual(tw_model.covar_module, covar_module)
+            self.assertIsInstance(tw_model.base_model_dict, ModuleDict)
+
+            self.assertIsInstance(tw_model.outcome_transform, Standardize)
+            self.assertIsInstance(tw_model.input_transform, Normalize)
+
+    def test_model(self) -> None:
+        # pass a mixed type of base model dict
+        new_model_dict = deepcopy(self.base_model_dict)
+        m = SaasFullyBayesianSingleTaskGP(self.train_X, self.train_Y, self.train_Yvar)
+        fit_fully_bayesian_model_nuts(
+            m, warmup_steps=8, num_samples=5, thinning=2, disable_progbar=True
+        )
+        new_model_dict["auxiliary_metric3"] = m
+
+        for base_model_dict in [self.base_model_dict, new_model_dict]:
+            tw_model = TargetAwareEnsembleGP(
+                train_X=self.train_X,
+                train_Y=self.train_Y,
+                train_Yvar=self.train_Yvar,
+                base_model_dict=base_model_dict,
+            )
+
+            mll = ExactMarginalLogLikelihood(tw_model.likelihood, tw_model)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=OptimizationWarning)
+                fit_gpytorch_mll(
+                    mll, optimizer_kwargs={"options": {"maxiter": 5}}, max_attempts=4
+                )
+
+            # check there is no training done on base_model_dict
+            for (
+                metric_name,
+                base_model_state_dict,
+            ) in self.base_model_state_dict.items():
+                self.assertDictEqual(
+                    tw_model.base_model_dict[metric_name].state_dict(),
+                    base_model_state_dict,
+                )
+
+            # check posterior
+            X_list = [
+                torch.rand(torch.Size([3, 1]), **self.tkwargs),
+                torch.rand(torch.Size([5, 3, 1]), **self.tkwargs),
+            ]
+            for X in X_list:
+                posterior = tw_model.posterior(X)
+                self.assertIsInstance(posterior, GPyTorchPosterior)
+                self.assertEqual(posterior.mean.shape, X.shape)
+                self.assertEqual(posterior.variance.shape, X.shape)
+
+    def test_construct_inputs(self) -> None:
+        datasets = SupervisedDataset(
+            X=self.train_X,
+            Y=self.train_Y,
+            Yvar=self.train_Yvar,
+            feature_names=[f"x{i}" for i in range(self.train_X.shape[-1])],
+            outcome_names=["y"],
+        )
+
+        model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=self.base_model_dict,
+        )
+
+        mean_module = ZeroMean()
+        covar_module = RBFKernel(use_ard=False)
+        weight_prior = HalfCauchyPrior(torch.tensor(0.1, **self.tkwargs))
+        data_dict = model.construct_inputs(
+            training_data=datasets,
+            base_model_dict=self.base_model_dict,
+            mean_module=mean_module,
+            covar_module=covar_module,
+            ensemble_weight_prior=weight_prior,
+        )
+        self.assertTrue(self.train_X.equal(data_dict["train_X"]))
+        self.assertTrue(self.train_Y.equal(data_dict["train_Y"]))
+        self.assertTrue(self.train_Yvar.equal(data_dict["train_Yvar"]))
+        self.assertIs(data_dict["base_model_dict"], self.base_model_dict)
+        self.assertEqual(data_dict["mean_module"], mean_module)
+        self.assertEqual(data_dict["covar_module"], covar_module)
+        self.assertIsInstance(data_dict["ensemble_weight_prior"], HalfCauchyPrior)
+
+    def test_weight_property(self) -> None:
+        """Test weight property getter and setter."""
+        tw_model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=self.base_model_dict,
+        )
+        # Test getter returns tensor of correct shape
+        weight = tw_model.weight
+        self.assertEqual(weight.shape, torch.Size([len(self.base_model_dict)]))
+
+        # Test setter: public setter is an identity round-trip
+        new_weight = torch.tensor([0.5, 1.5], **self.tkwargs)
+        tw_model.weight = new_weight
+        self.assertTrue(torch.allclose(tw_model.weight, new_weight))
+
+    def test_train_mode(self) -> None:
+        """Test that base models stay in eval mode during training."""
+        tw_model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=self.base_model_dict,
+        )
+        # Put model in train mode
+        tw_model.train(True)
+        self.assertTrue(tw_model.training)
+        # Base models should remain in eval mode
+        for m in tw_model.base_model_dict.values():
+            self.assertFalse(m.training)
+            for param in m.parameters():
+                self.assertFalse(param.requires_grad)
+
+        # Put model in eval mode
+        tw_model.train(False)
+        self.assertFalse(tw_model.training)
+        for m in tw_model.base_model_dict.values():
+            self.assertFalse(m.training)
+
+    def test_weight_threshold(self) -> None:
+        """Test that weights below threshold are excluded from forward pass."""
+        from botorch.models.target_aware_gp import WEIGHT_THRESHOLD
+
+        tw_model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=self.base_model_dict,
+        )
+        # Set one weight below threshold and one above
+        tw_model.weight = torch.tensor(
+            [WEIGHT_THRESHOLD / 2, WEIGHT_THRESHOLD * 2], **self.tkwargs
+        )
+        # Forward pass should work and only use the second model
+        X_test = torch.rand(3, 1, **self.tkwargs)
+        posterior = tw_model.posterior(X_test)
+        self.assertIsInstance(posterior, GPyTorchPosterior)
+        self.assertEqual(posterior.mean.shape, X_test.shape)
+
+    def test_state_dict(self) -> None:
+        """Test serialization via state_dict and load_state_dict."""
+        tw_model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=self.base_model_dict,
+        )
+        # Set a specific weight
+        original_weight = torch.tensor([0.3, 0.7], **self.tkwargs)
+        tw_model.weight = original_weight
+
+        # Save state dict
+        state_dict = tw_model.state_dict()
+
+        # Create new model and load state dict
+        new_model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=self.base_model_dict,
+        )
+        new_model.load_state_dict(state_dict)
+
+        # Verify weights match
+        self.assertTrue(torch.allclose(new_model.weight, original_weight))
+
+    def test_single_base_model(self) -> None:
+        """Test with a single base model (edge case)."""
+        single_model_dict = {
+            "auxiliary_metric1": SingleTaskGP(
+                self.train_X, self.train_Y, self.train_Yvar
+            )
+        }
+        mll = ExactMarginalLogLikelihood(
+            single_model_dict["auxiliary_metric1"].likelihood,
+            single_model_dict["auxiliary_metric1"],
+        )
+        fit_gpytorch_mll(
+            mll, optimizer_kwargs={"options": {"maxiter": 5}}, max_attempts=1
+        )
+
+        tw_model = TargetAwareEnsembleGP(
+            train_X=self.train_X,
+            train_Y=self.train_Y,
+            train_Yvar=self.train_Yvar,
+            base_model_dict=single_model_dict,
+        )
+        # Test posterior
+        X_test = torch.rand(3, 1, **self.tkwargs)
+        posterior = tw_model.posterior(X_test)
+        self.assertIsInstance(posterior, GPyTorchPosterior)
+        self.assertEqual(posterior.mean.shape, X_test.shape)


### PR DESCRIPTION
Summary:

Moves TargetAwareGP to OSS BoTorch and updates internal references. The model has been published in https://dl.acm.org/doi/10.1145/3690624.3709419

Differential Revision: D82453481
