### PR TITLE
Enable loading checkpoints from automl/PFNs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pytest-cov",
     "requests",
     "pymoo",
+    "pfns"
 ]
 
 dev = [


### PR DESCRIPTION
Summary: Enable our impelementation of PFNs as surrogate to load checkpoints from trainings done with the automl/PFNs repository.

Differential Revision: D82313030


