### PR TITLE
Add MCAcquisition support to PFN

### DIFF
--- a/test_community/posteriors/test_riemann.py
+++ b/test_community/posteriors/test_riemann.py
@@ -54,7 +54,7 @@ class TestRiemannPosterior(BotorchTestCase):
             posterior = BoundedRiemannPosterior(borders, probabilities)
 
             # Check that the mean and variance of the samples are correct
-            samples = posterior.rsample(torch.Size([10000]))
+            samples = posterior.rsample(torch.Size([5000000]))
             self.assertLess((samples.mean(dim=0) - dist_mean).abs().item(), 0.02)
             self.assertLess((samples.std(dim=0) - dist_std).abs().item(), 0.02)
 
@@ -85,18 +85,23 @@ class TestRiemannPosterior(BotorchTestCase):
         for dtype in (torch.float, torch.double):
             tkwargs = {"device": self.device, "dtype": dtype}
 
+            borders = torch.linspace(-10, 10, 26, **tkwargs)
+            probabilities = torch.rand(3, 25, **tkwargs)
+            probabilities = probabilities / probabilities.sum(-1, keepdim=True)
             posterior = BoundedRiemannPosterior(
-                torch.tensor([0.0, 1.0], **tkwargs),
-                torch.tensor([1.0], **tkwargs),
+                borders,
+                probabilities.expand(
+                    12, 3, 25
+                ),  # Two batch dimensions, with shapes 12 and 3
             )
 
-            base_samples = torch.rand(10, 2)
+            base_samples = torch.rand(30, 12, 3)  # 30 samples
             samples = posterior.rsample_from_base_samples(
-                torch.Size([10, 2]), base_samples
+                torch.Size([30, 12, 3]), base_samples
             )
-            self.assertEqual(samples.shape, torch.Size([10, 2, 1]))
+            self.assertEqual(samples.shape, torch.Size([30, 12, 3, 1]))
 
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(ValueError):
                 posterior.rsample_from_base_samples(torch.Size([10, 4]), base_samples)
 
     def test_mean(self):
@@ -170,8 +175,43 @@ class TestRiemannPosterior(BotorchTestCase):
                 test_samples, torch.linspace(0, 1, n_buckets + 1, **tkwargs)
             )
             probabilities = torch.ones(n_buckets, **tkwargs) / n_buckets
+            probabilities = probabilities.unsqueeze(0)
             posterior = BoundedRiemannPosterior(borders, probabilities)
 
             lower, upper = posterior.confidence_region(confidence_level=0.954)
             self.assertLess((lower - (dist_mean - 2 * dist_std)).abs().item(), 0.02)
             self.assertLess((upper - (dist_mean + 2 * dist_std)).abs().item(), 0.02)
+
+    def test_icdf(self):
+        torch.manual_seed(13)
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            probabilities = torch.tensor([0.5, 0.5], **tkwargs)
+            probabilities = probabilities.unsqueeze(0).unsqueeze(0)
+            posterior = BoundedRiemannPosterior(
+                borders=torch.tensor([0.0, 1.0, 2.0], **tkwargs),
+                probabilities=probabilities,
+            )
+            value = torch.tensor([0.6], **tkwargs)
+            value = value.unsqueeze(0).unsqueeze(0)
+            true_res = torch.tensor([1.2], **tkwargs)
+            self.assertTrue(
+                torch.allclose(posterior.icdf(value=value).squeeze(), true_res)
+            )
+            # And batch dimensions (5, 12)
+            probabilities = probabilities.expand(torch.Size([5, 12, 2]))
+            value = value.expand(torch.Size([30, 5, 12]))
+            posterior = BoundedRiemannPosterior(
+                borders=torch.tensor([0.0, 1.0, 2.0], **tkwargs),
+                probabilities=probabilities,
+            )
+            res = posterior.icdf(value=value)
+            self.assertEqual(res.shape, torch.Size([30, 5, 12, 1]))
+            true_res = true_res.expand(30, 5, 12, 1)
+            self.assertTrue(torch.allclose(res, true_res))
+            # Test with float
+            value = 0.6
+            true_res = torch.tensor([1.2], **tkwargs)
+            self.assertTrue(
+                torch.allclose(posterior.icdf(value=value).squeeze(), true_res)
+            )


### PR DESCRIPTION
Summary:
Makes all of the necessary changes to use MCAcquisitions, particularly qLogNoisyExpectedImprovement, with PFNModel and its BoundedRiemannPosterior, and to use PFN with multiple metrics in MBM. Including:

* Redo batch handling in PFNModel.posterior to do the right thing with the batch shapes sent in by Botorch MCAcquisition
* Change BoundedRiemannPosterior.rsample_from_base_samples to use N(0, I) base samples, and thus work with Botorch Samplers, and register the appropriate sampler.
* Add multi-batch handling to BoundedRiemannPosterior.icdf.
* MBM uses a ModelList if models are not GPs.

The PFNModel does not correctly handle q-batches yet. When MCAcquisition asks for a q-batch, it treats it the same as a t-batch, and in particular, the posteriors for each point in the q-batch are independent. This means that:
* Batch optimization does not work correctly. It will run and generate multiple points, but those points won't actually be properly conditioned on the earlier points in the batch.
* Handling of the incumbent best for EI in the noisy case is not correctly handled either, in that we are using an independent estimate for f_best rather than one jointly sampled. This is equivalent to using a plug-in estimate for f_best, which is the current behavior of DiscretizedExpectedImprovement.

Both of these will need to be addressed in the future, but I think this diff where things at least run end-to-end will be an easier starting point for that work.

Differential Revision: D79667144


