### PR TITLE
Add previous winner support to qEUBO

### DIFF
--- a/botorch/acquisition/input_constructors.py
+++ b/botorch/acquisition/input_constructors.py
@@ -1677,6 +1677,7 @@ def construct_inputs_qeubo(
     sampler: MCSampler | None = None,
     objective: MCAcquisitionObjective | None = None,
     posterior_transform: PosteriorTransform | None = None,
+    previous_winner: Tensor | None = None,
     X_pending: Tensor | None = None,
 ) -> dict[str, Any]:
     r"""Construct kwargs for the ``qExpectedUtilityOfBestOption`` (qEUBO) constructor.
@@ -1697,6 +1698,7 @@ def construct_inputs_qeubo(
         pref_model: The preference model to be used in preference exploration as in
             BOPE; if None, we are doing PBO and model is the preference model.
         sample_multiplier: The scale factor for the single-sample model.
+        previous_winner: The previous winner of the best option.
 
     Returns:
         A dict mapping kwarg names of the constructor to values.
@@ -1708,6 +1710,7 @@ def construct_inputs_qeubo(
             "sampler": sampler,
             "objective": objective,
             "posterior_transform": posterior_transform,
+            "previous_winner": previous_winner,
             "X_pending": X_pending,
         }
     else:
@@ -1725,6 +1728,7 @@ def construct_inputs_qeubo(
             "sampler": sampler,
             "objective": objective,
             "posterior_transform": posterior_transform,
+            "previous_winner": previous_winner,
             "X_pending": X_pending,
         }
 

--- a/botorch/acquisition/preference.py
+++ b/botorch/acquisition/preference.py
@@ -150,6 +150,7 @@ class qExpectedUtilityOfBestOption(MCAcquisitionFunction):
         sampler: MCSampler | None = None,
         objective: MCAcquisitionObjective | None = None,
         posterior_transform: PosteriorTransform | None = None,
+        previous_winner: Tensor | None = None,
         X_pending: Tensor | None = None,
     ) -> None:
         r"""MC-based Expected Utility of Best Option (qEUBO) as proposed
@@ -167,6 +168,7 @@ class qExpectedUtilityOfBestOption(MCAcquisitionFunction):
             objective: The MCAcquisitionObjective under which the samples are evaluated.
                 Defaults to ``IdentityMCObjective()``.
             posterior_transform: A PosteriorTransform (optional).
+            previous_winner: Tensor representing the previous winner in the Y space.
             X_pending:  A ``m x d``-dim Tensor of ``m`` design points that have been
                 submitted for function evaluation but have not yet been evaluated.
                 Concatenated into X upon forward call. Copied and set
@@ -181,6 +183,7 @@ class qExpectedUtilityOfBestOption(MCAcquisitionFunction):
         )
         # ensure the model is in eval mode
         self.add_module("outcome_model", outcome_model)
+        self.register_buffer("previous_winner", previous_winner)
 
     @concatenate_pending_points
     @t_batch_mode_transform()
@@ -198,6 +201,9 @@ class qExpectedUtilityOfBestOption(MCAcquisitionFunction):
             of model and input ``X``.
         """
         Y = X if self.outcome_model is None else self.outcome_model(X)
+
+        if self.previous_winner is not None:
+            Y = torch.cat([Y, match_batch_shape(self.previous_winner, Y)], dim=-2)
 
         _, obj = self._get_samples_and_objectives(Y)
         obj_best = obj.max(dim=-1).values


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation
I want to use EUBO with a previous_winner while also applying a posterior_transform (e.g., a weighted sum). 
There were two options: 
- add posterior_transform to AnalyticEUBO
- add previous_winner to qEUBO. 

AnalyticEUBO doesn’t naturally support posterior_transform because it assumes a single‑output preference model, while qEUBO already accepts posterior_transform and can follow the same previous_winner handling as in AnalyticEUBO. So I added previous_winner support in qExpectedUtilityOfBestOption to enable that workflow.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. 

## Test Plan
I have conducted tests here:
test_preference.py
test_input_constructors.py

## Related PRs
N/A
