### PR TITLE
Fix Docusaurus versioning error in publish_website workflow

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -65,20 +65,22 @@ jobs:
         # Delete existing versions for same Major and Minor version numbers.
         # We do this to keep only the latest patch for a given major/minor version.
         MAJOR_MINOR_VERSION=$(cut -d '.' -f 1-2 <<< ${{ inputs.new_version }}) # remove patch number
-        MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION#v}                           # remove optional "v" prefix
-        for dir in website/versioned_docs/version-$MAJOR_MINOR_VERSION.*; do
-            if [ -d "$dir" ]; then
-                OLD_VERSION=$(basename "$dir" | sed 's/^version-//') # remove "version-" prefix from the directory name
-                echo "Deleting older version $OLD_VERSION with the same major and minor version numbers as $NEW_VERSION"
-                # Delete version from the three locations Docusaurus uses:
-                #   - versioned_docs/version-X.Y.Z/
-                #   - versioned_sidebars/version-X.Y.Z-sidebars.json
-                #   - versions.json
-                # https://docusaurus.io/docs/versioning#deleting-an-existing-version
-                rm -rf "$dir"
-                rm "website/versioned_sidebars/version-$OLD_VERSION-sidebars.json"
-                sed -i "/\"$OLD_VERSION\"/d" website/versions.json
-            fi
+        # Search for both with and without 'v' prefix since docusaurus preserves the prefix from the version tag
+        for pattern in "version-$MAJOR_MINOR_VERSION.*" "version-${MAJOR_MINOR_VERSION#v}.*"; do
+            for dir in website/versioned_docs/$pattern; do
+                if [ -d "$dir" ]; then
+                    OLD_VERSION=$(basename "$dir" | sed 's/^version-//') # remove "version-" prefix from the directory name
+                    echo "Deleting older version $OLD_VERSION with the same major and minor version numbers as ${{ inputs.new_version }}"
+                    # Delete version from the three locations Docusaurus uses:
+                    #   - versioned_docs/version-X.Y.Z/
+                    #   - versioned_sidebars/version-X.Y.Z-sidebars.json
+                    #   - versions.json
+                    # https://docusaurus.io/docs/versioning#deleting-an-existing-version
+                    rm -rf "$dir"
+                    rm -f "website/versioned_sidebars/version-$OLD_VERSION-sidebars.json"
+                    sed -i "/\"$OLD_VERSION\"/d" website/versions.json
+                fi
+            done
         done
     - if: ${{ inputs.new_version && !inputs.dry_run }}
       name: Create new docusaurus version


### PR DESCRIPTION
Summary:
Fix Docusaurus versioning error when release workflow is re-run

## Problem
The 'Create new docusaurus version' step in publish_website.yml fails with:
```
Error: [docs]: this version already exists! Use a version tag that does not already exist.
```

This occurs when the release workflow is re-run for the same version (e.g., after a partial failure or manual re-trigger), because the version was already created and pushed to gh-pages in a previous run.

## Solution
Make the versioning step idempotent by checking if the version already exists in versions.json before attempting to create it:

1. Extract the version tag and remove the optional 'v' prefix
2. Check if versions.json exists and contains the version
3. Skip versioning if the version already exists, otherwise proceed normally

This allows the workflow to be safely re-run without failing.

Differential Revision: D95305476


