### PR TITLE
Project initial conditions onto equality constraint manifold (#3278)

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -29,6 +29,7 @@ from botorch.optim.parameter_constraints import (
     make_scipy_bounds,
     make_scipy_linear_constraints,
     make_scipy_nonlinear_inequality_constraints,
+    project_to_equality_constraints,
 )
 from botorch.optim.stopping import ExpMAStoppingCriterion
 from botorch.optim.utils import (
@@ -321,6 +322,23 @@ def gen_candidates_scipy(
                 f_np_wrapper,
                 fixed_features=fixed_features_,
             )
+
+            # Project initial conditions onto the equality constraint
+            # manifold so they satisfy constraints to numerical precision.
+            # MCMC-sampled initial conditions (from HitAndRunPolytopeSampler)
+            # may only approximately satisfy equality constraints.
+            unfixed_eq = _no_fixed_features.equality_constraints
+            if unfixed_eq:
+                candidates_ = project_to_equality_constraints(
+                    X=candidates_, equality_constraints=unfixed_eq
+                )
+                # Re-clamp after projection to stay within bounds.
+                candidates_ = columnwise_clamp(
+                    X=candidates_,
+                    lower=lower_bounds,
+                    upper=upper_bounds,
+                    raise_on_violation=False,
+                )
 
             x0 = candidates_.flatten()
 

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -527,6 +527,71 @@ def _make_f_and_grad_nonlinear_inequality_constraints(
     return f_obj, f_grad
 
 
+def project_to_equality_constraints(
+    X: Tensor,
+    equality_constraints: list[tuple[Tensor, Tensor, float]],
+) -> Tensor:
+    r"""Project X onto the equality constraint manifold via least-squares.
+
+    For linear equality constraints of the form ``Ax = b``, this finds the
+    closest point to X (in L2 sense) that satisfies all constraints, using
+    the closed-form least-squares projection:
+    ``X_proj = X + A^T (A A^T)^{-1} (b - A X)``.
+
+    This operates on each point in the q-batch independently (intra-point
+    constraints only).
+
+    Args:
+        X: A ``... x q x d``-dim tensor of inputs.
+        equality_constraints: A list of tuples (indices, coefficients, rhs),
+            with each tuple encoding an equality constraint of the form
+            ``sum_i (X[indices[i]] * coefficients[i]) = rhs``. Only supports
+            1-d indices (intra-point constraints).
+
+    Returns:
+        A tensor of the same shape as X, projected onto the constraint manifold.
+    """
+    if not equality_constraints:
+        return X
+
+    # Filter to intra-point constraints only (1-d indices).
+    intra_constraints = [
+        (indices, coefficients, rhs)
+        for indices, coefficients, rhs in equality_constraints
+        if indices.ndim <= 1
+    ]
+    if not intra_constraints:
+        return X
+
+    d = X.shape[-1]
+    n_constraints = len(intra_constraints)
+
+    # Build constraint matrix A and rhs vector b
+    A = torch.zeros(n_constraints, d, dtype=X.dtype, device=X.device)
+    b = torch.zeros(n_constraints, dtype=X.dtype, device=X.device)
+
+    for i, (indices, coefficients, rhs) in enumerate(intra_constraints):
+        A[i, indices.long()] = coefficients.to(dtype=X.dtype, device=X.device)
+        b[i] = rhs
+
+    # Compute residual = b - A @ x for each point.
+    # A: (n_constraints, d), X: (... x q x d)
+    # residual: (... x q x n_constraints)
+    residual = b - torch.einsum("cd,...qd->...qc", A, X)
+
+    # Compute correction = A^T @ (A A^T)^{-1} @ residual
+    AAT = A @ A.T  # (n_constraints, n_constraints)
+    # Solve AAT @ lam = residual^T for lam
+    # lam: (... x q x n_constraints)
+    lam = torch.linalg.solve(AAT, residual.unsqueeze(-1)).squeeze(-1)
+
+    # correction = A^T @ lam, i.e., sum over constraints
+    # A.T: (d, n_constraints), lam: (... x q x n_constraints)
+    correction = torch.einsum("dc,...qc->...qd", A.T, lam)
+
+    return X + correction
+
+
 def nonlinear_constraint_is_feasible(
     nonlinear_inequality_constraint: Callable,
     is_intrapoint: bool,

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -26,6 +26,7 @@ from botorch.optim.parameter_constraints import (
     make_scipy_linear_constraints,
     make_scipy_nonlinear_inequality_constraints,
     nonlinear_constraint_is_feasible,
+    project_to_equality_constraints,
     project_to_feasible_space_via_slsqp,
 )
 from botorch.utils.testing import BotorchTestCase
@@ -711,6 +712,100 @@ class TestMakeScipyBounds(BotorchTestCase):
         self.assertIsInstance(bounds, Bounds)
         self.assertTrue(np.all(np.equal(bounds.lb, np.zeros((3, 1, 2)).flatten())))
         self.assertTrue(np.all(np.equal(bounds.ub, np.ones((3, 1, 2)).flatten())))
+
+
+class TestProjectToEqualityConstraints(BotorchTestCase):
+    def test_project_to_equality_constraints(self):
+        for dtype in (torch.float, torch.double):
+            # Test 1: Single equality constraint x[0] + x[1] = 1.0
+            X = torch.tensor(
+                [[[0.6, 0.6]]], dtype=dtype, device=self.device
+            )  # violates: sum = 1.2
+            eq_constraints = [
+                (
+                    torch.tensor([0, 1], device=self.device),
+                    torch.tensor([1.0, 1.0], dtype=dtype, device=self.device),
+                    1.0,
+                )
+            ]
+            projected = project_to_equality_constraints(X, eq_constraints)
+            # Check constraint is satisfied
+            self.assertAlmostEqual(
+                projected[..., 0].item() + projected[..., 1].item(), 1.0, places=6
+            )
+            # Check it's the closest point (equal correction to both dims)
+            self.assertAlmostEqual(projected[0, 0, 0].item(), 0.5, places=6)
+            self.assertAlmostEqual(projected[0, 0, 1].item(), 0.5, places=6)
+
+            # Test 2: Already feasible point
+            X_feasible = torch.tensor([[[0.3, 0.7]]], dtype=dtype, device=self.device)
+            projected = project_to_equality_constraints(X_feasible, eq_constraints)
+            self.assertAllClose(projected, X_feasible, atol=1e-6)
+
+            # Test 3: Multiple constraints
+            # x[0] + x[1] + x[2] = 1.0 and x[0] - x[1] = 0.0
+            X3 = torch.tensor([[[0.5, 0.3, 0.4]]], dtype=dtype, device=self.device)
+            eq_constraints_multi = [
+                (
+                    torch.tensor([0, 1, 2], device=self.device),
+                    torch.tensor([1.0, 1.0, 1.0], dtype=dtype, device=self.device),
+                    1.0,
+                ),
+                (
+                    torch.tensor([0, 1], device=self.device),
+                    torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
+                    0.0,
+                ),
+            ]
+            projected = project_to_equality_constraints(X3, eq_constraints_multi)
+            # Check both constraints
+            p = projected[0, 0]
+            self.assertAlmostEqual((p[0] + p[1] + p[2]).item(), 1.0, places=5)
+            self.assertAlmostEqual((p[0] - p[1]).item(), 0.0, places=5)
+
+            # Test 4: Batch of q-points
+            X_batch = torch.tensor(
+                [[[0.6, 0.6], [0.8, 0.8]]], dtype=dtype, device=self.device
+            )
+            projected = project_to_equality_constraints(X_batch, eq_constraints)
+            for j in range(2):
+                self.assertAlmostEqual(
+                    (projected[0, j, 0] + projected[0, j, 1]).item(),
+                    1.0,
+                    places=6,
+                )
+
+    def test_project_to_equality_constraints_skips_inter_point(self):
+        for dtype in (torch.float, torch.double):
+            inter_constraint = (
+                torch.tensor([[0, 0], [1, 1]], device=self.device),
+                torch.tensor([1.0, -1.0], dtype=dtype, device=self.device),
+                0.0,
+            )
+            intra_constraint = (
+                torch.tensor([0, 1], device=self.device),
+                torch.tensor([1.0, 1.0], dtype=dtype, device=self.device),
+                1.0,
+            )
+
+            # Only inter-point constraints: X should be returned unchanged.
+            X = torch.tensor([[[0.6, 0.6]]], dtype=dtype, device=self.device)
+            result = project_to_equality_constraints(X, [inter_constraint])
+            self.assertAllClose(result, X)
+
+            # Mixed: inter-point constraint should be skipped, intra applied.
+            projected = project_to_equality_constraints(
+                X, [intra_constraint, inter_constraint]
+            )
+            self.assertAlmostEqual(
+                (projected[0, 0, 0] + projected[0, 0, 1]).item(), 1.0, places=5
+            )
+
+    def test_project_to_equality_constraints_empty(self):
+        X = torch.tensor([[[0.5, 0.5]]], device=self.device)
+        # Empty list should return X unchanged
+        result = project_to_equality_constraints(X, [])
+        self.assertAllClose(result, X)
 
 
 class TestProjectToFeasibleSpace(BotorchTestCase):


### PR DESCRIPTION
Summary:

When optimizing acquisition functions with equality constraints, SLSQP
can fail because initial conditions from `HitAndRunPolytopeSampler` only
satisfy equality constraints to floating-point precision. SLSQP
internally converts equalities into two opposing inequalities and may
reject starting points that violate them even slightly.

This diff adds a `project_to_equality_constraints` function that uses
the closed-form least-squares projection
`X_proj = X + A^T (A A^T)^{-1} (b - A X)` to project initial
conditions onto the equality constraint manifold before passing them to
SLSQP. After projection, the points are re-clamped to stay within
bounds.

Reviewed By: esantorella

Differential Revision: D100256479


