### PR TITLE
Move HSS kernel GP and utils into OSS BoTorch (#3284)

### DIFF
--- a/botorch/models/hierarchical/__init__.py
+++ b/botorch/models/hierarchical/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from botorch.models.hierarchical.conditional_kernel_gp import (
+    HierarchicalConditionalKernel,
+    HierarchicalConditionalKernelGP,
+    HierarchicalConditionalKernelMultiTaskGP,
+)
+
+
+__all__ = [
+    "HierarchicalConditionalKernel",
+    "HierarchicalConditionalKernelGP",
+    "HierarchicalConditionalKernelMultiTaskGP",
+]

--- a/botorch/models/hierarchical/conditional_kernel_gp.py
+++ b/botorch/models/hierarchical/conditional_kernel_gp.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+import torch
+from botorch.models import SingleTaskGP
+from botorch.models.hierarchical.utils import get_blocks_with_paths
+from botorch.models.map_saas import add_saas_prior
+from botorch.models.multitask import MultiTaskGP
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from botorch.models.utils.gpytorch_modules import get_covar_module_with_dim_scaled_prior
+from botorch.utils.constraints import LogTransformedInterval
+from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
+from botorch.utils.types import _DefaultType, DEFAULT
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.priors.prior import Prior
+from torch import Tensor
+from torch.nn import ModuleList
+
+
+LOG_OUTPUTSCALE_CONSTRAINT = LogTransformedInterval(1e-2, 1e4, initial_value=10)
+
+RTOL = 1e-5
+ATOL = 1e-8
+
+
+def _row_equal(
+    tensor: Tensor,
+    target: Tensor,
+    rtol: float = RTOL,
+    atol: float = ATOL,
+) -> Tensor:
+    """
+    Check if each row of ``tensor`` is approximately equal to ``target``.
+
+    Uses ``torch.isclose`` with configurable tolerances to handle both integer
+    and float comparisons. For integer hierarchical parameters, the small
+    tolerance ensures near-exact matching while handling minor numerical
+    precision issues. For float hierarchical parameters, the tolerance defines
+    the minimum separation required.
+
+    Args:
+        tensor: A tensor whose shape is ``(..., n, d)``. It's typically in
+            double precision.
+        target: A tensor whose shape is ``(d,)``. Can be integer or float dtype.
+        rtol: Relative tolerance for comparisons.
+        atol: Absolute tolerance for comparisons.
+
+    Returns:
+        A tensor whose shape is ``(..., n)`` indicating if each row of the
+        input ``tensor`` is approximately equal to ``target``.
+    """
+    target = target.to(tensor)
+    return torch.isclose(tensor, target, rtol=rtol, atol=atol).all(dim=-1)
+
+
+class HierarchicalConditionalKernel(Kernel):
+    """
+    A conditional kernel that exploits correlations in hierarchical search spaces.
+
+    It is best to describe its behavior by walking through an example. Let's say the
+    hierarchical search space tree is as follows::
+
+        ROOT
+        ├── C1
+        ├── C2
+        └── P1
+            ├── (0) C3
+            └── (1) P2
+                    ├── (0) C4
+                    └── (1) C5
+
+    Let's say the input X is a vector of the form ``(C1, C2, C3, C4, C5, P1, P2)``.
+    The entries do not necessarily need to follow this particular order, though.
+
+    As a concrete example, this kernel computes::
+
+        # Ex1:
+        k([C1, C2, C3, C4, C5, P1=0, P2=0], [C1', C2', C3', C4', C5', P1'=1, P2'=1]) =
+            k([C1, C2], [C1', C2']) + k(P1, P1').
+        # Ex2:
+        k([C1, C2, C3, C4, C5, P1=1, P2=0], [C1', C2', C3', C4', C5', P1'=1, P2'=1]) =
+            k([C1, C2], [C1', C2']) + k(P1, P1') + k(P2, P2').
+        # Ex3:
+        k([C1, C2, C3, C4, C5, P1=1, P2=1], [C1', C2', C3', C4', C5', P1'=1, P2'=1]) =
+            k([C1, C2], [C1', C2']) + k(C5, C5') + k(P1, P1') + k(P2, P2').
+
+    More generally, the kernel finds all common active features and sums the kernel
+    values over them.
+
+    1. This kernel supports arbitrary tree depths.
+    2. Each parent node is allowed to have multiple child nodes.
+    3. In particular, single-child parents are allowed. In this case, the parent is
+       a boolean flag.
+    4. Dimensions that correspond to parent nodes must be discrete or categorical.
+       Approximate equality is used to compare them for branching logic, which
+       requires the values to be separated by at least a tolerance of
+       ``rtol=RTOL``, ``atol=ATOL``.
+
+    Internally, this kernel determines if a child node is active by checking the
+    values of its ancestors (not just its parent). Examples:
+
+    1. C3 is active if and only if ``P1 == 0``;
+    2. C4 is active if and only if ``P1 == 1`` and ``P2 == 0``.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        hierarchical_dependencies: dict[int, dict[int | float, list[int]]],
+        eval_hierarchical_features: bool = True,
+        separate_hierarchical_features: bool = True,
+        use_saas_prior: bool = True,
+        use_outputscale: bool = True,
+    ):
+        """
+        Args:
+            dim: The dimension of the feature vector.
+            hierarchical_dependencies: A dictionary of the form
+                ``{parent_index: {parent_value: children_indices}}``.
+            eval_hierarchical_features: Whether to evaluate correlations over
+                hierarchical features or not. If false, the hierarchical features
+                are merely used as flags to determine the active features, but
+                they do not directly contribute to the kernel values.
+            separate_hierarchical_features: This is relevant only if
+                ``eval_hierarchical_features=True``. If true, the correlations of
+                hierarchical features will be captured by a separate additive
+                kernel. Otherwise, they are treated together with
+                non-hierarchical features.
+            use_saas_prior: Whether to use the SAAS prior. If false, use the log-normal
+                prior instead.
+            use_outputscale: Whether to use the outputscale parameter. If false, the
+                outputscales of each sub-kernels are fixed to 1.
+        """
+        super().__init__()
+
+        # Check that parent values are not too close to each other to avoid issues
+        # with _row_equal checks used in branching.
+        all_parent_values = sorted(
+            {
+                p
+                for dependencies in hierarchical_dependencies.values()
+                for p in dependencies.keys()
+            }
+        )
+        for i in range(len(all_parent_values) - 1):
+            val1, val2 = all_parent_values[i : i + 2]
+            # This is the same check as torch.isclose.
+            if val2 - val1 <= ATOL + RTOL * max(abs(val1), abs(val2)):
+                raise ValueError(
+                    f"Float parent values {val1} and {val2} are closer than the "
+                    f"default tolerance (rtol={RTOL}, atol={ATOL}). This will cause "
+                    "ambiguity in hierarchical branching. "
+                )
+
+        self.hierarchical_dependencies = hierarchical_dependencies
+        self.use_saas_prior = use_saas_prior
+        self.use_outputscale = use_outputscale
+        self.partition, self.paths = get_blocks_with_paths(
+            dim=dim,
+            hierarchical_dependencies=hierarchical_dependencies,
+            keep_hierarchical_features=eval_hierarchical_features,
+            separate_hierarchical_features=separate_hierarchical_features,
+        )
+
+        # Extract two data structures from `self.path`:
+        # 1. The ancestors of each block in `self.partition`;
+        # 2. The target ancestor values for each block.
+        # A block is active if and only if all of its ancestors have values equal to the
+        # target values specified in `ancester_values`.
+        self.ancestor_indices = [[index for index, _ in path] for path in self.paths]
+        self.ancestor_values = [
+            torch.tensor([value for _, value in path], dtype=torch.float64)
+            for path in self.paths
+        ]
+        self.kernels = self.construct_individual_kernels()
+
+    def forward(self, x1: Tensor, x2: Tensor, diag: bool = False, **params) -> Tensor:
+        if diag:
+            # Not doing any validation here. x1 & x2 will be validated in the
+            # sub-kernel calls anyway.
+            res = torch.zeros(*x1.shape[:-1], dtype=x1.dtype, device=x1.device)
+        else:
+            res = torch.zeros(
+                *x1.shape[:-1], x2.shape[-2], dtype=x1.dtype, device=x1.device
+            )
+
+        for kernel, indices, values in zip(
+            self.kernels,
+            self.ancestor_indices,
+            self.ancestor_values,
+        ):
+            # No need for indexing here. It has already been taken care of by
+            # `active_dims` of `kernel`.
+            mat = kernel(x1, x2, diag=diag, **params)
+
+            is_active_x1 = _row_equal(x1[..., indices], values)
+            is_active_x2 = _row_equal(x2[..., indices], values)
+            if diag:
+                delta = is_active_x1.logical_and(is_active_x2)
+            else:
+                delta = is_active_x1.unsqueeze(-1) * is_active_x2.unsqueeze(-2)
+
+            res = res + delta * mat
+
+        return res
+
+    def construct_individual_kernels(self) -> ModuleList:
+        covar_modules = ModuleList()
+
+        for indices in self.partition:
+            if self.use_saas_prior:
+                base_kernel = MaternKernel(
+                    nu=2.5, ard_num_dims=len(indices), active_dims=indices
+                )
+                add_saas_prior(base_kernel)
+
+            else:
+                base_kernel = get_covar_module_with_dim_scaled_prior(
+                    ard_num_dims=len(indices), use_rbf_kernel=False, active_dims=indices
+                )
+                base_kernel.lengthscale = 1.0
+
+            if self.use_outputscale:
+                covar_modules.append(
+                    ScaleKernel(
+                        base_kernel,
+                        outputscale_constraint=LOG_OUTPUTSCALE_CONSTRAINT,
+                    )
+                )
+            else:
+                covar_modules.append(base_kernel)
+
+        return covar_modules
+
+
+def _transform_hierarchical_dependencies(
+    train_X: Tensor,
+    hierarchical_dependencies: dict[int, dict[int | float, list[int]]],
+    input_transform: InputTransform | None,
+) -> dict[int, dict[int | float, list[int]]]:
+    """Transform hierarchical_dependencies values according to the input transform.
+
+    The hierarchical_dependencies dict contains parent indices and their values
+    in the original input space. When an input transform is applied, we need to
+    transform these values to match the transformed inputs that the kernel sees.
+
+    Args:
+        train_X: Training inputs of shape ``n x d``, used as a template for
+            creating dummy X tensors.
+        hierarchical_dependencies: A dictionary of the form
+            ``{parent_index: {parent_value: children_indices}}``.
+        input_transform: The input transform to apply.
+
+    Returns:
+        A new hierarchical_dependencies dict with transformed parent values.
+    """
+    if input_transform is None:
+        return hierarchical_dependencies
+
+    # Collect all (parent_index, parent_value) pairs.
+    parent_value_pairs = [
+        (parent_idx, parent_value)
+        for parent_idx, value_to_children in hierarchical_dependencies.items()
+        for parent_value in value_to_children.keys()
+    ]
+
+    if not parent_value_pairs:  # pragma: no cover
+        raise ValueError(
+            "Something went wrong. No parent values could be extracted from "
+            f"{hierarchical_dependencies=}."
+        )
+
+    # Create dummy X tensors with the parent values in the appropriate columns.
+    n_pairs = len(parent_value_pairs)
+    dummy_X = train_X[0:1].repeat(n_pairs, 1)
+    row_indices = torch.arange(n_pairs)
+    col_indices = torch.tensor([p[0] for p in parent_value_pairs])
+    values = torch.tensor([p[1] for p in parent_value_pairs], dtype=dummy_X.dtype)
+    dummy_X[row_indices, col_indices] = values
+
+    # Apply the input transform to get the transformed values.
+    # Use preprocess_transform to ensure the transform is applied in the same way
+    # as it is applied to model training data, without modifying buffers.
+    transformed_X = input_transform.preprocess_transform(dummy_X)
+
+    # Extract transformed parent values.
+    transformed_values = transformed_X[row_indices, col_indices].tolist()
+
+    # Build the new dict.
+    result = {}
+    for i, (parent_idx, original_value) in enumerate(parent_value_pairs):
+        result.setdefault(parent_idx, {})
+        # Replace the parent value with the transformed value, mapping to the
+        # same dependent indices as before.
+        result[parent_idx][transformed_values[i]] = hierarchical_dependencies[
+            parent_idx
+        ][original_value]
+    return result
+
+
+class HierarchicalConditionalKernelGP(SingleTaskGP):
+    r"""
+    A GP model with a conditional kernel that exploits correlations in hierarchical
+    search spaces.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        hierarchical_dependencies: dict[int, dict[int | float, list[int]]],
+        eval_hierarchical_features: bool = True,
+        separate_hierarchical_features: bool = True,
+        train_Yvar: Tensor | None = None,
+        use_saas_prior: bool = True,
+        use_outputscale: bool = True,
+        input_transform: InputTransform | None = None,
+        outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
+    ) -> None:
+        r"""Single-Task GP model using a hierarchical conditional kernel.
+
+        Args:
+            train_X: A ``batch_shape x n x d`` tensor of training features, where
+                ``d`` is the number of features in the search space. Column
+                indices in ``hierarchical_dependencies`` refer to columns of
+                ``train_X``.
+            train_Y: A ``batch_shape x n x m`` tensor of training observations.
+            hierarchical_dependencies: A dictionary of the form
+                ``{parent_index: {parent_value: children_indices}}`` that defines
+                the hierarchical structure of the search space. All indices must
+                be valid column indices into ``train_X`` (i.e., in ``[0, d)``).
+            eval_hierarchical_features: Whether to evaluate correlations over
+                hierarchical features or not. If false, the hierarchical features
+                are merely used as flags to determine the active features, but
+                they do not directly contribute to the kernel values.
+            separate_hierarchical_features: This is relevant only if
+                ``eval_hierarchical_features=True``. If true, the correlations of
+                hierarchical features will be captured by a separate additive
+                kernel.
+            train_Yvar: An optional ``batch_shape x n x m`` tensor of observed
+                measurement noise. If None, the noise is inferred.
+            use_saas_prior: Whether to use the SAAS prior. If false, use the
+                log-normal prior instead.
+            use_outputscale: Whether to use the outputscale parameter. If false,
+                the outputscales of each sub-kernel are fixed to 1.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference.
+        """
+        # Transform hierarchical_dependencies values to match the transformed inputs.
+        transformed_dependencies = _transform_hierarchical_dependencies(
+            train_X=train_X,
+            hierarchical_dependencies=hierarchical_dependencies,
+            input_transform=input_transform,
+        )
+        covar_module = HierarchicalConditionalKernel(
+            dim=train_X.shape[-1],
+            hierarchical_dependencies=transformed_dependencies,
+            eval_hierarchical_features=eval_hierarchical_features,
+            separate_hierarchical_features=separate_hierarchical_features,
+            use_saas_prior=use_saas_prior,
+            use_outputscale=use_outputscale,
+        )
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            covar_module=covar_module,
+            input_transform=input_transform,
+            outcome_transform=outcome_transform,
+        )
+
+    @classmethod
+    def construct_inputs(
+        cls,
+        training_data: SupervisedDataset,
+        hierarchical_dependencies: dict[int, dict[int | float, list[int]]],
+        eval_hierarchical_features: bool = True,
+        separate_hierarchical_features: bool = True,
+        use_saas_prior: bool = True,
+        use_outputscale: bool = True,
+    ) -> dict[str, Any]:
+        return {
+            **super().construct_inputs(training_data=training_data),
+            "hierarchical_dependencies": hierarchical_dependencies,
+            "eval_hierarchical_features": eval_hierarchical_features,
+            "separate_hierarchical_features": separate_hierarchical_features,
+            "use_saas_prior": use_saas_prior,
+            "use_outputscale": use_outputscale,
+        }
+
+
+class HierarchicalConditionalKernelMultiTaskGP(MultiTaskGP):
+    r"""Multi-Task GP with a conditional kernel that exploits correlations in
+    hierarchical search spaces.
+
+    This model extends ``MultiTaskGP`` by using a ``HierarchicalConditionalKernel``
+    for the data covariance instead of the default kernel. Task correlations are
+    still captured via a ``PositiveIndexKernel`` as in the parent class.
+
+    The model can be single-output or multi-output, determined by ``output_tasks``.
+    It supports dimension-scaled priors on the Kernel hyperparameters, which work best
+    when covariates are normalized to the unit cube and outcomes are standardized
+    (zero mean, unit variance). The standardization should be applied in a stratified
+    fashion at the level of the tasks, rather than across all data points.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        task_feature: int,
+        hierarchical_dependencies: dict[int, dict[int | float, list[int]]],
+        train_Yvar: Tensor | None = None,
+        eval_hierarchical_features: bool = True,
+        separate_hierarchical_features: bool = True,
+        use_saas_prior: bool = True,
+        use_outputscale: bool = True,
+        likelihood: Likelihood | None = None,
+        task_covar_prior: Prior | None = None,
+        output_tasks: list[int] | None = None,
+        rank: int | None = None,
+        all_tasks: list[int] | None = None,
+        outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
+        input_transform: InputTransform | None = None,
+        validate_task_values: bool = True,
+    ) -> None:
+        r"""Multi-Task GP model using a hierarchical conditional kernel.
+
+        Args:
+            train_X: A ``n x (d + 1)`` tensor of training data. One of the columns
+                should contain the task features (see ``task_feature`` argument).
+            train_Y: A ``n x 1`` tensor of training observations.
+            task_feature: The index of the task feature
+                (``-d <= task_feature <= d``).
+            hierarchical_dependencies: A dictionary of the form
+                ``{parent_index: {parent_value: children_indices}}`` that defines
+                the hierarchical structure of the search space. Parent indices
+                should refer to the feature indices AFTER removing the task feature.
+            train_Yvar: An optional ``n`` tensor of observed measurement noise.
+                If None, we infer the noise. Note that the inferred noise is
+                common across all tasks.
+            eval_hierarchical_features: Whether to evaluate correlations over
+                hierarchical features or not. If false, the hierarchical features
+                are merely used as flags to determine the active features, but
+                they do not directly contribute to the kernel values.
+            separate_hierarchical_features: This is relevant only if
+                ``eval_hierarchical_features=True``. If true, the correlations of
+                hierarchical features will be captured by a separate additive
+                kernel.
+            use_saas_prior: Whether to use the SAAS prior. If false, use the
+                log-normal prior instead.
+            use_outputscale: Whether to use the outputscale parameter. If false,
+                the outputscales of each sub-kernel are fixed to 1.
+            likelihood: A likelihood. The default is selected based on
+                ``train_Yvar``. If ``train_Yvar`` is None, a
+                ``HadamardGaussianLikelihood`` with inferred noise level is used.
+                Otherwise, a ``FixedNoiseGaussianLikelihood`` is used.
+            task_covar_prior: A Prior on the task covariance matrix. Must operate
+                on p.s.d. matrices. A common prior for this is the ``LKJ`` prior.
+            output_tasks: A list of task indices for which to compute model
+                outputs for. If omitted, return outputs for all task indices.
+            rank: The rank to be used for the index kernel. If omitted, use a
+                full rank (i.e. number of tasks) kernel.
+            all_tasks: By default, multi-task GPs infer the list of all tasks from
+                the task features in ``train_X``. This is an experimental feature
+                that enables creation of multi-task GPs with tasks that don't
+                appear in the training data.
+            outcome_transform: An outcome transform that is applied to the
+                training data during instantiation and to the posterior during
+                inference. We use a ``Standardize`` transform if no
+                ``outcome_transform`` is specified. Pass down ``None`` to use no
+                outcome transform.
+            input_transform: An input transform that is applied in the model's
+                forward pass.
+            validate_task_values: If True, validate that the task values supplied
+                in the input are expected task values.
+        """
+        # Determine num_non_task_features for constructing the hierarchical kernel.
+        # We need this before calling super().__init__().
+        num_non_task_features = train_X.shape[-1] - 1
+
+        # Transform hierarchical_dependencies values to match the transformed inputs.
+        transformed_dependencies = _transform_hierarchical_dependencies(
+            train_X=train_X,
+            hierarchical_dependencies=hierarchical_dependencies,
+            input_transform=input_transform,
+        )
+
+        # Construct the hierarchical conditional kernel for data covariance.
+        covar_module = HierarchicalConditionalKernel(
+            dim=num_non_task_features,
+            hierarchical_dependencies=transformed_dependencies,
+            eval_hierarchical_features=eval_hierarchical_features,
+            separate_hierarchical_features=separate_hierarchical_features,
+            use_saas_prior=use_saas_prior,
+            use_outputscale=use_outputscale,
+        )
+
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            task_feature=task_feature,
+            train_Yvar=train_Yvar,
+            covar_module=covar_module,
+            likelihood=likelihood,
+            task_covar_prior=task_covar_prior,
+            output_tasks=output_tasks,
+            rank=rank,
+            all_tasks=all_tasks,
+            outcome_transform=outcome_transform,
+            input_transform=input_transform,
+            validate_task_values=validate_task_values,
+        )
+
+    @classmethod
+    def construct_inputs(
+        cls,
+        training_data: SupervisedDataset | MultiTaskDataset,
+        task_feature: int,
+        hierarchical_dependencies: dict[int, dict[int | float, list[int]]],
+        eval_hierarchical_features: bool = True,
+        separate_hierarchical_features: bool = True,
+        use_saas_prior: bool = True,
+        use_outputscale: bool = True,
+        output_tasks: list[int] | None = None,
+        task_covar_prior: Prior | None = None,
+        rank: int | None = None,
+    ) -> dict[str, Any]:
+        r"""Construct ``Model`` keyword arguments from a dataset and other args.
+
+        Args:
+            training_data: A ``SupervisedDataset`` or a ``MultiTaskDataset``.
+            task_feature: Column index of embedded task indicator features.
+            hierarchical_dependencies: A dictionary of the form
+                ``{parent_index: {parent_value: children_indices}}`` that defines
+                the hierarchical structure of the search space.
+            eval_hierarchical_features: Whether to evaluate correlations over
+                hierarchical features or not.
+            separate_hierarchical_features: Whether to capture the correlations of
+                hierarchical features with a separate additive kernel.
+            use_saas_prior: Whether to use the SAAS prior.
+            use_outputscale: Whether to use the outputscale parameter.
+            output_tasks: A list of task indices for which to compute model
+                outputs for. If omitted, return outputs for all task indices.
+            task_covar_prior: A GPyTorch ``Prior`` object to use as prior on
+                the cross-task covariance matrix.
+            rank: The rank of the cross-task covariance matrix.
+        """
+        base_inputs = MultiTaskGP.construct_inputs(
+            training_data=training_data,
+            task_feature=task_feature,
+            output_tasks=output_tasks,
+            task_covar_prior=task_covar_prior,
+            rank=rank,
+        )
+        base_inputs["hierarchical_dependencies"] = hierarchical_dependencies
+        base_inputs["eval_hierarchical_features"] = eval_hierarchical_features
+        base_inputs["separate_hierarchical_features"] = separate_hierarchical_features
+        base_inputs["use_saas_prior"] = use_saas_prior
+        base_inputs["use_outputscale"] = use_outputscale
+        return base_inputs

--- a/botorch/models/hierarchical/utils.py
+++ b/botorch/models/hierarchical/utils.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This file defines some helper functions for parsing hierarchical dependencies. We will
+use a running example to illustrate the functionality of each helper function::
+
+    ROOT
+    ├── C0, C1
+    └── P2
+        ├── (0) C3
+        └── (1) P4
+                ├── (0) C5
+                └── (1) C6
+
+- C0, C1, C3, C5, and C6 are child nodes (similar to non-hierarchical parameters in Ax).
+- P2 and P4 are parent nodes (similar to hierarchical parameters in Ax).
+- Each node, except ROOT, corresponds to a dimension in the feature vector X.
+
+Let's say the input X is a vector of the form ``(C0, C1, P2, C3, P4, C5, C6)``. The
+features do not necessarily need to follow this particular order, but we will stick to
+this order as an example. Then, the hierarchical tree is represented by a list of
+dictionaries as follows::
+
+    hierarchical_dependencies = {
+        2: {0: [3], 1: [4]},  # P2 == 0 --> C3 is activated; P2 == 1 -> P4 is activated.
+        4: {0: [5], 1: [6]},  # P4 == 0 --> C5 is activated; P4 == 1 -> C6 is activated.
+    }
+
+Note that, in the above example, ROOT does not actually exist in the representation. It
+is an imaginary node that is the parent of all orphan nodes, e.g., C0, C1, and P2. But
+all functions in this file supports both rootless trees and rooted trees.
+"""
+
+
+def get_orphan_feature_indices(
+    dim: int,
+    hierarchical_dependencies: dict[int, dict[int, list[int]]],
+) -> list[int]:
+    """
+    Construct the indices of the orphan nodes by parsing the hierarchical dependencies.
+    They are precisely the children of the (imaginary) root node.
+
+    Args:
+        dim: The full dimension of the feature vector.
+        hierarchical_dependencies: A dictionary specifying the hierarchical structure.
+
+    Returns:
+        A list of indices of the orphan nodes sorted in ascending order.
+    """
+    grouped_non_orphan_feature_indices = [
+        children_indices
+        for dependents in hierarchical_dependencies.values()
+        for children_indices in dependents.values()
+    ]
+    non_orphan_feature_indices = sum(grouped_non_orphan_feature_indices, [])
+
+    if len(set(non_orphan_feature_indices)) != len(non_orphan_feature_indices):
+        raise ValueError(
+            f"{non_orphan_feature_indices=} contains duplicate indices. This is likely"
+            f"a mistake in the hierarchical dependencies."
+        )
+
+    return sorted(set(range(dim)) - set(non_orphan_feature_indices))
+
+
+def get_index_to_path(
+    dim: int,
+    hierarchical_dependencies: dict[int, dict[int, list[int]]],
+) -> dict[int, list[tuple[int, int]]]:
+    """
+    Construct a dictionary that maps the index of each node (feature) to its
+    root-to-node path.
+
+    Args:
+        dim: The full dimension of the feature vector.
+        hierarchical_dependencies: A dictionary specifying the hierarchical structure.
+
+    Returns:
+        A dictionary that maps the node (or feature) index ``fid`` to its
+        root-to-node path. The path is represented by a list of tuples of the
+        form ``(index, value)``. If we follow the path by setting
+        ``X[index] = value`` for all ``(index, value)`` in the path, then
+        ``X[fid]`` is activated.
+    """
+
+    def has_children(fid: int) -> bool:
+        return fid in hierarchical_dependencies and hierarchical_dependencies[fid]
+
+    fid_to_path = {}
+
+    # depth-first traversal
+    def dfs(fid: int, path: list[tuple[int, int]]) -> None:
+        """
+        Depth-first search starting from ``fid``.
+
+        Args:
+            fid: The feature index to be visited.
+            path: A list of tuples of the form ``(index, value)``. They are the
+                indices and values of the ancestors of ``fid``, which represent
+                the path in the hierarchical tree that leads to ``fid``.
+        """
+        fid_to_path[fid] = path
+
+        if not has_children(fid):
+            return
+
+        for parent_value, children_indices in hierarchical_dependencies[fid].items():
+            for child in children_indices:
+                dfs(child, path + [(fid, parent_value)])
+
+    orphan_feature_indices = get_orphan_feature_indices(dim, hierarchical_dependencies)
+
+    for idx in orphan_feature_indices:
+        dfs(idx, [])
+
+    return fid_to_path
+
+
+def get_blocks_with_paths(
+    dim: int,
+    hierarchical_dependencies: dict[int, dict[int, list[int]]],
+    keep_hierarchical_features: bool = True,
+    separate_hierarchical_features: bool = True,
+) -> tuple[list[list[int], list[list[tuple[int, int]]]]]:
+    """
+    A helper function parsing the hierarchical dependencies. This function does two
+    things:
+
+    1. Partition the indices ``{0, 1, 2, ..., dim - 1}`` into blocks. Features
+       in the same block are always activated together---either they are all
+       active or all inactive.
+    2. Construct the path from the root to each block. This will be helpful in
+       checking if a block is active or not.
+
+    The partition will be used in ``HierarchicalConditionalKernel``, which
+    creates a kernel for each block. The trivial partition
+    ``{{0}, {1}, ..., {dim - 1}}`` is bad, because then the kernel would be
+    *completely* additive. The goal is to construct a partition where each
+    block is as large as possible. Two nodes end up in the same block if and
+    only if they share the same parent node and are activated by the same
+    parent node value.
+
+    Args:
+        dim: The full dimension of the feature vector.
+        hierarchical_dependencies: A list that specifies the hierarchical dependencies.
+        keep_hierarchical_features: If true, the hierarchical features are kept in the
+            partition.
+        separate_hierarchical_features: If true, hierarchical features are not grouped
+            with non-hierarchical features. This flag is relevant only if
+            ``keep_hierarchical_features`` is true.
+
+    Returns:
+        A tuple of two lists:
+
+        - A partition of the indices ``{0, 1, 2, ..., dim - 1}``. Each block in
+          the partition is a list of indices of features that are activated at
+          the same time.
+        - A list of root-to-block paths in the tree. Each path is represented by
+          a list of tuples of the form ``(index, value)``. The block is
+          activated if following the path by setting the ``index``-th feature to
+          ``value``.
+    """
+
+    def has_children(fid: int) -> bool:
+        return fid in hierarchical_dependencies and hierarchical_dependencies[fid]
+
+    orphan_feature_indices = get_orphan_feature_indices(dim, hierarchical_dependencies)
+
+    partition_non_orphans = [
+        children_indices
+        for dependents in hierarchical_dependencies.values()
+        for children_indices in dependents.values()
+        if children_indices  # If the children list is empty, do not include it.
+    ]
+    partition = partition_non_orphans + [orphan_feature_indices]
+
+    # Refine the partition if needed. Here, refinement means separate hierarchical
+    # nodes from non-hierarchical nodes. Hierarchical nodes are boolean, discrete or
+    # categorical, and thus may require a separate kernel for modeling.
+    if not keep_hierarchical_features or (
+        keep_hierarchical_features and separate_hierarchical_features
+    ):
+        # This filters out the hierarchical nodes.
+        refined_partition = [
+            [fid for fid in block if not has_children(fid)] for block in partition
+        ]
+
+        if keep_hierarchical_features and separate_hierarchical_features:
+            refined_partition += [
+                [fid for fid in block if has_children(fid)] for block in partition
+            ]
+
+        # Some blocks might be empty due to the refinement. Filter them out.
+        refined_partition = [block for block in refined_partition if block]
+
+    else:
+        refined_partition = partition
+
+    # Sorting is techcnical not necessary. But it does simplify testing substantially.
+    refined_partition = sorted([sorted(block) for block in refined_partition])
+
+    fid_to_path = get_index_to_path(dim, hierarchical_dependencies)
+
+    # For each block, construct the path from the root to the block. Note that nodes in
+    # the same block, by definition, are activated by the same path. Hence, it suffices
+    # to grab any root-to-node path in the block.
+    paths = [fid_to_path[block[0]] for block in refined_partition]
+
+    return refined_partition, paths

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -99,6 +99,14 @@ Heterogeneous Search Space Multitask GP Models
 .. automodule:: botorch.models.heterogeneous_mtgp
     :members:
 
+Hierarchical Search Space GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.hierarchical.conditional_kernel_gp
+    :members:
+
+.. automodule:: botorch.models.hierarchical.utils
+    :members:
+
 Multi-Fidelity GP Regression Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.gp_regression_fidelity

--- a/test/models/hierarchical/__init__.py
+++ b/test/models/hierarchical/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/models/hierarchical/test_conditional_kernel_gp.py
+++ b/test/models/hierarchical/test_conditional_kernel_gp.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+import gpytorch
+import torch
+from botorch.models.hierarchical.conditional_kernel_gp import (
+    _row_equal,
+    HierarchicalConditionalKernel,
+    HierarchicalConditionalKernelGP,
+    HierarchicalConditionalKernelMultiTaskGP,
+)
+from botorch.models.transforms.input import Normalize
+from botorch.models.transforms.outcome import Standardize
+from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
+
+
+# This is the search space of the Jenatton test function.
+DIM = 9
+HIERARCHICAL_DEPENDENCIES = {
+    0: {0: [1, 7], 1: [2, 8]},
+    1: {0: [3], 1: [4]},
+    2: {0.0: [5], 1.0: [6]},
+}
+
+
+class TestHierarchicalConditionalKernel(BotorchTestCase):
+    def test_kernel_creation(self):
+        lst_eval_and_separate_hierarchical = [
+            (False, False),  # blocks [[3], [4], [5], [6], [7], [8]]
+            (False, True),  # same as above
+            (True, False),  # blocks [[0], [1, 7], [2, 8], [3], [4], [5], [6]]
+            (True, True),  # blocks [[0], [1], [2], [3], [4], [5], [6], [7], [8]]
+        ]
+        lst_num_kernels = [6, 6, 7, 9]
+
+        # Make sure the number of sub-kernels is correct.
+        for (
+            eval_hierarchical_features,
+            separate_hierarchical_features,
+        ), num_kernels in zip(lst_eval_and_separate_hierarchical, lst_num_kernels):
+            with self.subTest(
+                eval_hierarchical_features=eval_hierarchical_features,
+                separate_hierarchical_features=separate_hierarchical_features,
+            ):
+                covar_module = HierarchicalConditionalKernel(
+                    dim=DIM,
+                    hierarchical_dependencies=HIERARCHICAL_DEPENDENCIES,
+                    eval_hierarchical_features=eval_hierarchical_features,
+                    separate_hierarchical_features=separate_hierarchical_features,
+                )
+                self.assertEqual(len(covar_module.kernels), num_kernels)
+
+    def test_parent_value_types(self):
+        """Test that kernel works with integer, float, and mixed parent values."""
+        test_cases = [
+            (
+                "integer_values",
+                {0: {0: [1, 7], 1: [2, 8]}, 1: {0: [3], 1: [4]}, 2: {0: [5], 1: [6]}},
+            ),
+            (
+                "float_values",
+                {
+                    0: {0.0: [1, 7], 1.0: [2, 8]},
+                    1: {0.0: [3], 1.0: [4]},
+                    2: {0.0: [5], 1.0: [6]},
+                },
+            ),
+            (
+                "mixed_values",
+                {
+                    0: {0: [1, 7], 1: [2, 8]},
+                    1: {0.0: [3], 1.0: [4]},
+                    2: {0.0: [5], 1.0: [6]},
+                },
+            ),
+        ]
+
+        for name, hierarchical_deps in test_cases:
+            with self.subTest(name=name):
+                covar_module = HierarchicalConditionalKernel(
+                    dim=9,
+                    hierarchical_dependencies=hierarchical_deps,
+                    eval_hierarchical_features=False,
+                    use_saas_prior=False,
+                    use_outputscale=False,
+                )
+
+                # Verify kernel creation succeeded
+                self.assertEqual(len(covar_module.kernels), 6)
+
+                # Verify ancestor_values are always stored as float64
+                for ancestor_vals in covar_module.ancestor_values:
+                    if len(ancestor_vals) > 0:
+                        self.assertEqual(ancestor_vals.dtype, torch.float64)
+
+    def test_kernel_evaluation(self):
+        torch.manual_seed(42)
+        covar_module = HierarchicalConditionalKernel(
+            dim=DIM,
+            hierarchical_dependencies=HIERARCHICAL_DEPENDENCIES,
+            eval_hierarchical_features=False,
+            use_saas_prior=False,
+            use_outputscale=False,
+        )
+
+        # Testing is easier if we fix all lengthscales to 1.
+        for kernel in covar_module.kernels:
+            kernel.lengthscale = 1.0
+
+        # Create test data for different branches
+        X00_ = torch.rand(3, DIM)  # (x1=0, x2=0) -> x4, r8 active
+        X00_[..., 0], X00_[..., 1] = 0.0, 0.0
+        X00_[..., 2] = torch.tensor([0.0, 0.5, 1.0])
+
+        X01_ = torch.rand(3, DIM)  # (x1=0, x2=1) -> x5, r8 active
+        X01_[..., 0], X01_[..., 1] = 0.0, 1.0
+        X01_[..., 2] = torch.tensor([0.0, 0.5, 1.0])
+
+        X1_0 = torch.rand(3, DIM)  # (x1=1, x3=0) -> x6, r9 active
+        X1_0[..., 0], X1_0[..., 2] = 1.0, 0.0
+        X1_0[..., 1] = torch.tensor([0.0, 0.5, 1.0])
+
+        X1_1 = torch.rand(3, DIM)  # (x1=1, x3=1) -> x7, r9 active
+        X1_1[..., 0], X1_1[..., 2] = 1.0, 1.0
+        X1_1[..., 1] = torch.tensor([0.0, 0.5, 1.0])
+
+        base_cls = covar_module.kernels[0].__class__
+        isotropic_covar_module = base_cls()
+        isotropic_covar_module.lengthscale = 1.0
+
+        # Due to symmetry, we only check the kernel matrices between X00_ and the other
+        # three tensors.
+        # Both x4 and r8 are shared
+        self.assertAllClose(
+            covar_module(X00_, X00_).to_dense(),
+            isotropic_covar_module(X00_[..., 3], X00_[..., 3]).to_dense()
+            + isotropic_covar_module(X00_[..., 7], X00_[..., 7]).to_dense(),
+        )
+
+        # Only r8 is shared
+        expected = isotropic_covar_module(X00_[..., 7], X01_[..., 7]).to_dense()
+        self.assertAllClose(covar_module(X00_, X01_).to_dense(), expected)
+
+        # Make sure it evaluates the diagonal correctly.
+        self.assertAllClose(
+            covar_module(X00_, X01_, diag=True).to_dense(), expected.diagonal()
+        )
+
+        # No shared common parameter
+        self.assertAllClose(covar_module(X00_, X1_0).to_dense(), torch.zeros(3, 3))
+
+        # No shared common parameter
+        self.assertAllClose(covar_module(X00_, X1_1).to_dense(), torch.zeros(3, 3))
+
+        # Make sure the kernel evaluates the diagonal correctly.
+        self.assertAllClose(
+            covar_module(X00_, X1_1, diag=True).to_dense(), torch.zeros(3)
+        )
+
+    def test_float_value_separation(self):
+        """Test proximity validation for float parent values."""
+        with self.assertRaisesRegex(ValueError, "closer than the default tolerance"):
+            HierarchicalConditionalKernel(
+                dim=3, hierarchical_dependencies={0: {0.0: [1], 1e-9: [2]}}
+            )
+        # Sufficient separation constructs fine
+        covar_module = HierarchicalConditionalKernel(
+            dim=5,
+            hierarchical_dependencies={0: {0.0: [1], 0.001: [2], 0.5: [3], 1.0: [4]}},
+            eval_hierarchical_features=False,
+        )
+        self.assertEqual(len(covar_module.kernels), 4)
+
+
+class TestHierarchicalConditionalKernelGP(BotorchTestCase):
+    def test_multi_output_and_batched(self):
+        """Exercise multi-output (m > 1) and batched (batch_shape != ()) inputs."""
+        hierarchical_deps = {
+            0: {0: [1, 7], 1: [2, 8]},
+            1: {0: [3], 1: [4]},
+            2: {0: [5], 1: [6]},
+        }
+        hierarchical_vals = [
+            [0, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [1, 0, 1],
+        ]
+        single_batch_X = torch.cat(
+            [torch.tensor(hierarchical_vals), torch.rand(4, 6)], dim=-1
+        )
+
+        for name, train_X, train_Y, expected_mean_shape in [
+            (
+                "multi_output_unbatched",
+                single_batch_X,
+                torch.randn(4, 3),
+                (4, 3),
+            ),
+            (
+                "batched_single_output",
+                torch.stack([single_batch_X, single_batch_X]),
+                torch.randn(2, 4, 1),
+                (2, 4, 1),
+            ),
+        ]:
+            with self.subTest(name=name):
+                model = HierarchicalConditionalKernelGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    hierarchical_dependencies=hierarchical_deps,
+                )
+                posterior = model.posterior(train_X)
+                self.assertEqual(posterior.mean.shape, expected_mean_shape)
+
+    def test_model_creation(self):
+        """Test GP model creation with integer and float hierarchical parameters."""
+        cases = [
+            (
+                "integer_values",
+                {0: {0: [1, 7], 1: [2, 8]}, 1: {0: [3], 1: [4]}, 2: {0: [5], 1: [6]}},
+                [[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 1]],
+            ),
+            (
+                "float_values",
+                {
+                    0: {0.0: [1, 7], 1.0: [2, 8]},
+                    1: {0.0: [3], 1.0: [4]},
+                    2: {0.0: [5], 1.0: [6]},
+                },
+                [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 1.0]],
+            ),
+        ]
+        for name, hierarchical_deps, hierarchical_vals in cases:
+            with self.subTest(name=name):
+                train_X = torch.cat(
+                    [torch.tensor(hierarchical_vals), torch.rand(4, 6)], dim=-1
+                )
+                train_Y = torch.randn(4, 1)
+                model = HierarchicalConditionalKernelGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    hierarchical_dependencies=hierarchical_deps,
+                )
+                self.assertIsInstance(model.covar_module, HierarchicalConditionalKernel)
+                posterior = model.posterior(train_X)
+                self.assertEqual(posterior.covariance_matrix.shape, (4, 4))
+                self.assertEqual(posterior.variance.shape, (4, 1))
+
+                # Exercise construct_inputs against a SupervisedDataset that uses
+                # these same tensors, and verify the returned kwargs build a
+                # structurally identical model.
+                dataset = SupervisedDataset(
+                    X=train_X,
+                    Y=train_Y,
+                    feature_names=[f"x{i}" for i in range(train_X.shape[-1])],
+                    outcome_names=["y"],
+                )
+                inputs = HierarchicalConditionalKernelGP.construct_inputs(
+                    training_data=dataset,
+                    hierarchical_dependencies=hierarchical_deps,
+                    eval_hierarchical_features=False,
+                    separate_hierarchical_features=False,
+                    use_saas_prior=False,
+                    use_outputscale=False,
+                )
+                self.assertAllClose(inputs["train_X"], train_X)
+                self.assertAllClose(inputs["train_Y"], train_Y)
+                self.assertEqual(inputs["hierarchical_dependencies"], hierarchical_deps)
+                self.assertEqual(inputs["eval_hierarchical_features"], False)
+                self.assertEqual(inputs["separate_hierarchical_features"], False)
+                self.assertEqual(inputs["use_saas_prior"], False)
+                self.assertEqual(inputs["use_outputscale"], False)
+                # Make sure the model construction succeeds with these inputs.
+                HierarchicalConditionalKernelGP(
+                    **inputs, outcome_transform=Standardize(m=1)
+                )
+
+    def test_with_input_transforms(self) -> None:
+        """Test model creation with input transforms, focusing on correct
+        dependency transforms and kernel evaluations.
+        """
+        hierarchical_dependencies = {
+            0: {0: [1], 1: [8], 2: [3, 9]},
+            1: {-2: [4], 3: [5]},
+            2: {0: [6], 1: [7]},
+        }
+        train_X = torch.cat(
+            [torch.tensor([[0, -2, 0], [1, 3, 1], [2, 0, 0]]), torch.rand(3, 7)], dim=-1
+        )
+        bounds = torch.tensor(
+            [
+                [0, -2, 0, 0, 0, 0, 0, 0, 0, 0],
+                [3, 3, 1, 1, 1, 1, 1, 1, 1, 1],
+            ]
+        )
+        model = HierarchicalConditionalKernelGP(
+            train_X=train_X,
+            train_Y=torch.randn(3, 1),
+            hierarchical_dependencies=hierarchical_dependencies,
+            input_transform=Normalize(d=10, bounds=bounds),
+        )
+        expected_dependencies = {
+            0: {0.0: [1], 1.0 / 3.0: [8], 2.0 / 3.0: [3, 9]},
+            1: {0.0: [4], 1.0: [5]},
+            2: {0.0: [6], 1.0: [7]},
+        }
+        for idx, expected_value_to_deps in expected_dependencies.items():
+            value_to_deps = model.covar_module.hierarchical_dependencies[idx]
+            for (expected_value, expected_deps), (value, deps) in zip(
+                expected_value_to_deps.items(), value_to_deps.items()
+            ):
+                # Use the same comparison used within the kernel.
+                self.assertTrue(
+                    _row_equal(torch.tensor(value), torch.tensor(expected_value))
+                )
+                self.assertEqual(deps, expected_deps)
+        # Check that the kernel evaluates correctly.
+        # Using X[..., 0] = 1.0 here since division by 3 causes floating point errors.
+        X = train_X[1:2]
+        with (
+            mock.patch(
+                "botorch.models.hierarchical.conditional_kernel_gp._row_equal",
+                wraps=_row_equal,
+            ) as mock_row_equal,
+            gpytorch.settings.lazily_evaluate_kernels(False),
+        ):
+            model.forward(X)
+        # Row equal should evaluate to following, twice for each value:
+        expected_res = [
+            True,  # base
+            False,  # x0=0
+            False,  # x0=2/3
+            False,  # x0=0, x1=0
+            False,  # x0=0, x1=1
+            False,  # x2=0
+            True,  # x2=1
+            True,  # x0=1/3
+        ]
+        for i, call_args in enumerate(mock_row_equal.call_args_list):
+            res = bool(_row_equal(*call_args.args, **call_args.kwargs))
+            self.assertEqual(res, expected_res[i // 2])
+
+
+class TestHierarchicalConditionalKernelMultiTaskGP(BotorchTestCase):
+    def _get_multitask_data(
+        self,
+        n_per_task: int = 5,
+        n_tasks: int = 2,
+        dim_non_task: int = 4,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Generate multitask training data with hierarchical structure."""
+        torch.manual_seed(42)
+        data_list = []
+        for task in range(n_tasks):
+            X_task = torch.rand(n_per_task, dim_non_task)
+            X_task[:, 0] = torch.randint(0, 2, (n_per_task,)).float()
+            task_col = torch.full((n_per_task, 1), float(task))
+            data_list.append(torch.cat([X_task, task_col], dim=-1))
+        train_X = torch.cat(data_list, dim=0)
+        train_Y = torch.randn(n_tasks * n_per_task, 1)
+        return train_X, train_Y
+
+    def test_model(self):
+        """Test model instantiation, forward pass, posterior, and various options."""
+        hierarchical_deps = {0: {0: [1], 1: [2]}}
+        train_X, train_Y = self._get_multitask_data(n_tasks=3)
+
+        # Basic instantiation and structure checks
+        model = HierarchicalConditionalKernelMultiTaskGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            task_feature=-1,
+            hierarchical_dependencies=hierarchical_deps,
+        )
+        self.assertEqual(model.num_tasks, 3)
+        self.assertEqual(model.num_non_task_features, 4)
+        self.assertEqual(model._num_outputs, 3)
+        self.assertEqual(model._task_feature, 4)
+        self.assertIsInstance(
+            model.covar_module.kernels[0], HierarchicalConditionalKernel
+        )
+
+        # Forward pass
+        output = model(train_X)
+        self.assertEqual(output.mean.shape, (15,))
+        self.assertEqual(output.covariance_matrix.shape, (15, 15))
+
+        # Posterior
+        # Only get posterior for the specified task.
+        self.assertEqual(model.posterior(train_X[:3]).mean.shape, (3, 1))
+        # Output for all tasks when evaluated without a task feature.
+        self.assertEqual(model.posterior(train_X[:3, :-1]).mean.shape, (3, 3))
+
+        # Test with fixed noise
+        model_fixed = HierarchicalConditionalKernelMultiTaskGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            task_feature=-1,
+            hierarchical_dependencies=hierarchical_deps,
+            train_Yvar=torch.full_like(train_Y, 0.01),
+        )
+        self.assertIsInstance(model_fixed.likelihood, FixedNoiseGaussianLikelihood)
+        self.assertEqual(model_fixed.posterior(train_X[:2]).mean.shape, (2, 1))
+
+        # Test with output_tasks and rank
+        train_X_3, train_Y_3 = self._get_multitask_data(n_tasks=3)
+        model_opts = HierarchicalConditionalKernelMultiTaskGP(
+            train_X=train_X_3,
+            train_Y=train_Y_3,
+            task_feature=-1,
+            hierarchical_dependencies=hierarchical_deps,
+            output_tasks=[0, 2],
+            rank=2,
+        )
+        self.assertEqual(model_opts._num_outputs, 2)
+        self.assertEqual(model_opts._output_tasks, [0, 2])
+        self.assertEqual(model_opts._rank, 2)
+        # Should get output for all output tasks when evaluated without a task feature.
+        self.assertEqual(model_opts.posterior(train_X[:2, :-1]).mean.shape, (2, 2))
+
+    def test_construct_inputs(self):
+        """Test construct_inputs class method with MultiTaskDataset."""
+        hierarchical_deps = {0: {0: [1], 1: [2]}}
+        torch.manual_seed(42)
+        dim_non_task = 4
+        n_per_task = 5
+        train_X, train_Y = self._get_multitask_data(
+            n_per_task=n_per_task, dim_non_task=dim_non_task
+        )
+
+        # Create individual datasets for each task (without task feature column)
+        datasets = []
+        for task in range(2):
+            datasets.append(
+                SupervisedDataset(
+                    X=train_X[task * n_per_task : (task + 1) * n_per_task],
+                    Y=train_Y[task * n_per_task : (task + 1) * n_per_task],
+                    feature_names=[f"x{i}" for i in range(dim_non_task)] + ["task"],
+                    outcome_names=[f"y{task}"],
+                )
+            )
+
+        mt_dataset = MultiTaskDataset(
+            datasets=datasets, target_outcome_name="y0", task_feature_index=-1
+        )
+
+        inputs = HierarchicalConditionalKernelMultiTaskGP.construct_inputs(
+            training_data=mt_dataset,
+            task_feature=-1,
+            hierarchical_dependencies=hierarchical_deps,
+            eval_hierarchical_features=False,
+            use_saas_prior=True,
+            rank=1,
+        )
+        self.assertAllClose(inputs["train_X"], train_X)
+        self.assertAllClose(inputs["train_Y"], train_Y)
+        self.assertEqual(inputs["task_feature"], -1)
+        self.assertEqual(inputs["hierarchical_dependencies"], hierarchical_deps)
+        self.assertEqual(inputs["eval_hierarchical_features"], False)
+        self.assertEqual(inputs["use_saas_prior"], True)
+        self.assertEqual(inputs["rank"], 1)
+        # Make sure the model construction succeeds.
+        HierarchicalConditionalKernelMultiTaskGP(**inputs)

--- a/test/models/hierarchical/test_utils.py
+++ b/test/models/hierarchical/test_utils.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from botorch.models.hierarchical.utils import get_blocks_with_paths
+from botorch.utils.testing import BotorchTestCase
+
+
+class TestHierarchicalUtils(BotorchTestCase):
+    test_cases = []
+
+    # ```
+    # ROOT
+    # ├── C0, C1
+    # ├── P2
+    # │   ├── (0) EMPTY
+    # │   └── (1) C4, C5
+    # └── P3
+    #     ├── (0) EMPTY
+    #     └── (1) C6, C7
+    # ```
+    # The features are ordered in the vector as `(C0, C1, P2, P3, C4, C5, C6, C7)`.
+    test_cases.append(
+        {
+            "dim": 8,
+            "hierarchical_dependencies": {
+                # C0 does not have any dependents. It's okay to include it as a key
+                # with an empty dict, or exclude it altogether.
+                2: {0: [], 1: [4, 5]},  # dependents of P2
+                3: {0: [], 1: [6, 7]},  # dependents of P3
+            },
+            "separate_hierarchical_features": True,
+            "blocks": [[0, 1], [2, 3], [4, 5], [6, 7]],
+            "paths": [
+                [],
+                [],
+                [(2, 1)],  # The path (P2 == 1) makes C4 and C5 active.
+                [(3, 1)],  # The path (P3 == 1) makes C6 and C7 active.
+            ],
+        }
+    )
+
+    # The ultimate test.
+    # ```
+    # ROOT
+    # ├── C0
+    # ├── P1
+    # │   ├── (0) C3, C4
+    # │   └── (1) P5
+    # │           ├── (0) C7
+    # │           ├── (1) C8
+    # │           └── (2) C9
+    # └── P2
+    #     ├── (0) EMPTY
+    #     └── (1) C6
+    # ```
+    # The features are ordered as `(C0, P1, P2, C3, C4, P5, C6, C7, C8, C9)`.
+    test_cases.append(
+        {
+            "dim": 10,
+            "hierarchical_dependencies": {
+                1: {0: [3, 4], 1: [5]},  # dependents of P1
+                2: {0: [], 1: [6]},  # dependents of P2
+                5: {0: [7], 1: [8], 2: [9]},  # dependents of P5
+                6: {},  # C6 does not have any dependents.
+            },
+            "separate_hierarchical_features": True,
+            "blocks": [[0], [1, 2], [3, 4], [5], [6], [7], [8], [9]],
+            "paths": [
+                [],  # C0 is always active.
+                [],  # So do P1 and P2.
+                [(1, 0)],  # The path (P1 == 0) makes C3 and C4 active.
+                [(1, 1)],  # The path (P1 == 1) makes P5 active.
+                [(2, 1)],  # The path (P2 == 1) makes C6 active.
+                [(1, 1), (5, 0)],  # The path (P1 == 1, P5 == 0) makes C7 active.
+                [(1, 1), (5, 1)],  # The path (P1 == 1, P5 == 1) makes C8 active.
+                [(1, 1), (5, 2)],  # The path (P1 == 1, P5 == 2) makes C9 active.
+            ],
+        }
+    )
+
+    # This is obtained from the Jenatton test function in
+    # `ax.benchmark.problems.synthetic.hss.jenatton`.
+    test_cases.append(
+        {
+            "dim": 9,
+            "hierarchical_dependencies": {
+                0: {0: [1, 7], 1: [2, 8]},
+                1: {0: [3], 1: [4]},
+                2: {0: [5], 1: [6]},
+                3: {},
+                4: {},
+                5: {},
+                6: {},
+                7: {},
+                8: {},
+            },
+            "separate_hierarchical_features": False,
+            "blocks": [[0], [1, 7], [2, 8], [3], [4], [5], [6]],
+            "paths": [
+                [],
+                [(0, 0)],
+                [(0, 1)],
+                [(0, 0), (1, 0)],
+                [(0, 0), (1, 1)],
+                [(0, 1), (2, 0)],
+                [(0, 1), (2, 1)],
+            ],
+        }
+    )
+
+    def test_blocks_and_paths(self):
+        for i, test_case in enumerate(self.test_cases):
+            with self.subTest(case=i, dim=test_case["dim"]):
+                blocks, paths = get_blocks_with_paths(
+                    dim=test_case["dim"],
+                    hierarchical_dependencies=test_case["hierarchical_dependencies"],
+                    separate_hierarchical_features=test_case[
+                        "separate_hierarchical_features"
+                    ],
+                )
+
+                # There should be no empty block.
+                self.assertTrue(all(len(block) > 0 for block in blocks))
+
+                # The returned `blocks` has been sorted in ascending order.
+                # So it is safe to directly assert equality. No permutation needed.
+                self.assertEqual(blocks, test_case["blocks"])
+                self.assertEqual(paths, test_case["paths"])
+
+    def test_duplicate_child_indices_rejected(self):
+        """A child index appearing under two different parents is a malformed
+        hierarchy and should raise."""
+        # Index 3 is listed as a child of both parent 0 and parent 1.
+        hierarchical_dependencies = {
+            0: {0: [3], 1: [4]},
+            1: {0: [3], 1: [5]},
+        }
+        with self.assertRaisesRegex(ValueError, "contains duplicate indices"):
+            get_blocks_with_paths(
+                dim=6, hierarchical_dependencies=hierarchical_dependencies
+            )


### PR DESCRIPTION
Summary:

Move the hierarchical search space (HSS) conditional kernel GP and helper
utilities from `botorch_fb.models.hss` into open-source BoTorch at
`botorch.models.hierarchical`.

Moves (history preserved via `sl mv`):
- `botorch_fb/models/hss/hierarchical_conditional_kernel_gp.py` →
  `botorch/models/hierarchical/conditional_kernel_gp.py`
- `botorch_fb/models/hss/utils.py` →
  `botorch/models/hierarchical/utils.py`
- Corresponding tests under
  `botorch_fb/test/models/hss/` → `botorch/test/models/hierarchical/`.

New `__init__.py` at `botorch/models/hierarchical/` exports
`HierarchicalConditionalKernel`, `HierarchicalConditionalKernelGP`, and
`HierarchicalConditionalKernelMultiTaskGP`.

License headers swapped to the OSS MIT license header.

Differential Revision: D101814586
