### PR TITLE
Add map_heterogeneous_to_full to MultiTaskGP.construct_inputs (#3286)

### DIFF
--- a/botorch/models/heterogeneous_mtgp.py
+++ b/botorch/models/heterogeneous_mtgp.py
@@ -295,25 +295,13 @@ class HeterogeneousMTGP(MultiTaskGP):
                 "Heterogeneous MTGP currently only supports output_tasks=[0]. "
                 "The target task will be given the task value of 0."
             )
-        child_datasets = training_data.datasets.copy()
-        target_dataset = child_datasets.pop(training_data.target_outcome_name)
-        all_datasets = [target_dataset] + list(child_datasets.values())
-        # Use target's feature order as canonical (NO alphabetical sort).
-        # Source-only features are appended at the end.
-        all_features: list[str] = list(target_dataset.feature_names[:-1])
-        for ds in all_datasets[1:]:
-            for fn in ds.feature_names[:-1]:
-                if fn not in all_features:
-                    all_features.append(fn)
-        # Get indices mapping the features from a given dataset to all features.
-        feature_indices = [
-            [all_features.index(fn) for fn in ds.feature_names[:-1]]
-            for ds in all_datasets
-        ]
+        all_datasets, feature_indices, full_feature_dim = (
+            training_data.get_heterogeneous_feature_mapping()
+        )
         Xs = [ds.X[..., :-1] for ds in all_datasets]
         Ys = [ds.Y for ds in all_datasets]
         Yvars = (
-            None if target_dataset.Yvar is None else [ds.Yvar for ds in all_datasets]
+            None if all_datasets[0].Yvar is None else [ds.Yvar for ds in all_datasets]
         )
         all_tasks = list(range(len(all_datasets)))
         return {
@@ -321,7 +309,7 @@ class HeterogeneousMTGP(MultiTaskGP):
             "train_Ys": Ys,
             "train_Yvars": Yvars,
             "feature_indices": feature_indices,
-            "full_feature_dim": len(all_features),
+            "full_feature_dim": full_feature_dim,
             "rank": rank,
             "use_saas_prior": use_saas_prior,
             "use_combinatorial_kernel": use_combinatorial_kernel,

--- a/botorch/models/multitask.py
+++ b/botorch/models/multitask.py
@@ -486,6 +486,7 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
         task_covar_prior: Prior | _DefaultType | None = DEFAULT,
         prior_config: dict | None = None,
         rank: int | None = None,
+        map_heterogeneous_to_full: bool = False,
     ) -> dict[str, Any]:
         r"""Construct ``Model`` keyword arguments from a dataset and other args.
 
@@ -503,6 +504,13 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
                 Must contain ``use_LKJ_prior`` indicator and should contain float
                 value ``eta``.
             rank: The rank of the cross-task covariance matrix.
+            map_heterogeneous_to_full: If True and ``training_data`` is a
+                ``MultiTaskDataset`` with heterogeneous features, zero-pad each
+                task's features into the union feature space and concatenate into
+                a single ``train_X`` tensor. The zero-padded entries are intended
+                to be overwritten by a ``LearnedFeatureImputation`` input
+                transform. If False (default), heterogeneous features will raise
+                ``UnsupportedError`` via ``training_data.X``.
         """
         if (
             task_covar_prior is not DEFAULT
@@ -524,6 +532,50 @@ class MultiTaskGP(ExactGP, MultiTaskGPyTorchModel, FantasizeMixin):
             if not isinstance(eta, float) and not isinstance(eta, int):
                 raise ValueError(f"eta must be a real number, your eta was {eta}.")
             task_covar_prior = LKJCovariancePrior(num_tasks, eta, sd_prior)
+
+        # Handle heterogeneous MultiTaskDataset by zero-padding into the union
+        # feature space. This branch bypasses super().construct_inputs() since
+        # training_data.X would raise UnsupportedError.
+        if (
+            map_heterogeneous_to_full
+            and isinstance(training_data, MultiTaskDataset)
+            and training_data.has_heterogeneous_features
+        ):
+            all_datasets, feature_indices, full_feature_dim = (
+                training_data.get_heterogeneous_feature_mapping()
+            )
+
+            # Zero-pad each task's X into the full feature space + task column.
+            all_Xs = []
+            for task_idx, (ds, fi) in enumerate(
+                zip(all_datasets, feature_indices, strict=True)
+            ):
+                X_task = ds.X[..., :-1]  # strip task feature column
+                X_full = torch.zeros(
+                    *X_task.shape[:-1],
+                    full_feature_dim + 1,
+                    dtype=X_task.dtype,
+                    device=X_task.device,
+                )
+                X_full[..., fi] = X_task
+                X_full[..., -1] = task_idx
+                all_Xs.append(X_full)
+
+            all_Yvars = [ds.Yvar for ds in all_datasets]
+            base_inputs: dict[str, Any] = {
+                "train_X": torch.cat(all_Xs, dim=0),
+                "train_Y": torch.cat([ds.Y for ds in all_datasets], dim=0),
+            }
+            if all_Yvars[0] is not None:
+                base_inputs["train_Yvar"] = torch.cat(all_Yvars, dim=0)
+            base_inputs["task_feature"] = -1
+            base_inputs["all_tasks"] = list(range(len(all_datasets)))
+            base_inputs["output_tasks"] = output_tasks
+            if task_covar_prior is not DEFAULT:
+                base_inputs["task_covar_prior"] = task_covar_prior
+            if rank is not None:
+                base_inputs["rank"] = rank
+            return base_inputs
 
         # Call Model.construct_inputs to parse training data
         base_inputs = super().construct_inputs(training_data=training_data)

--- a/botorch/models/transforms/__init__.py
+++ b/botorch/models/transforms/__init__.py
@@ -7,6 +7,7 @@
 from botorch.models.transforms.factory import get_rounding_input_transform
 from botorch.models.transforms.input import (
     ChainedInputTransform,
+    LearnedFeatureImputation,
     Normalize,
     Round,
     Warp,
@@ -25,6 +26,7 @@ __all__ = [
     "Bilog",
     "ChainedInputTransform",
     "ChainedOutcomeTransform",
+    "LearnedFeatureImputation",
     "Log",
     "Normalize",
     "Power",

--- a/botorch/models/transforms/input.py
+++ b/botorch/models/transforms/input.py
@@ -35,7 +35,7 @@ from botorch.models.transforms.utils import (
 from botorch.models.utils import fantasize
 from botorch.utils.rounding import approximate_round, OneHotArgmaxSTE, RoundSTE
 from gpytorch import Module as GPyTorchModule
-from gpytorch.constraints import GreaterThan
+from gpytorch.constraints import GreaterThan, Interval
 from gpytorch.priors import Prior
 from torch import LongTensor, nn, Tensor
 from torch.nn import Module, ModuleDict
@@ -1915,3 +1915,222 @@ class OneHotToNumeric(InputTransform):
             and (self.transform_on_fantasize == other.transform_on_fantasize)
             and self.categorical_features == other.categorical_features
         )
+
+
+class LearnedFeatureImputation(InputTransform, GPyTorchModule):
+    r"""An input transform that learns imputation values for missing features
+    in heterogeneous multi-task settings.
+
+    In multi-task problems where different tasks observe different subsets of
+    features, this transform fills in the unobserved feature columns with
+    learned parameter values. This enables using a standard ``MultiTaskGP``
+    with composable input transforms instead of specialized model classes.
+
+    The input tensor ``X`` is expected to have shape ``batch_shape x n x (d+1)``,
+    where the column at ``task_feature_index`` contains the task identifier.
+    For each task, feature columns not listed in ``feature_indices[task_value]``
+    are replaced with the corresponding learned imputation values. Task values
+    need not be contiguous or 0-indexed.
+    """
+
+    def __init__(
+        self,
+        feature_indices: dict[int, list[int]],
+        d: int,
+        task_feature_index: int = -1,
+        target_task: int | None = None,
+        bounds: Tensor | None = None,
+        transform_on_train: bool = True,
+        transform_on_eval: bool = True,
+        transform_on_fantasize: bool = True,
+        dtype: torch.dtype = torch.float64,
+        device: torch.device | None = None,
+    ) -> None:
+        r"""Initialize LearnedFeatureImputation.
+
+        Args:
+            feature_indices: A mapping from integer task values (as they appear
+                in the task column of ``X``) to lists of observed X-column
+                indices for that task. Indices refer directly to columns of the
+                input tensor ``X`` and must not include the task column. When
+                ``task_feature_index=-1`` (the common case), the ``d`` feature
+                columns are ``0, 1, ..., d-1``. Task values need not be
+                contiguous or 0-indexed.
+            d: The total number of feature columns (excluding the task column).
+            task_feature_index: The column index in ``X`` that contains the
+                task identifier. Must be ``-1`` (last column). Defaults to ``-1``.
+            target_task: The task identifier to use when ``X`` has ``d``
+                columns (no task column). Required for d-dim inputs since the
+                task cannot be inferred from shape alone — two tasks may share
+                the same number of active dimensions. Must be a key in
+                ``feature_indices``. If ``None``, only ``(d+1)``-dim inputs
+                are supported.
+            bounds: A ``2 x d`` tensor of ``[lower, upper]`` bounds for each
+                feature. If provided, imputation values are constrained to lie
+                within these bounds via a GPyTorch ``Interval`` constraint.
+                Defaults to ``None`` (unconstrained). This transform is designed
+                to operate on normalized inputs; if bounds differ from
+                ``[0, 1]^d``, a warning is emitted suggesting to chain
+                ``Normalize`` before this transform.
+            transform_on_train: If ``True``, apply the transform in train mode.
+            transform_on_eval: If ``True``, apply the transform in eval mode.
+            transform_on_fantasize: If ``True``, apply the transform inside
+                ``fantasize`` calls.
+            dtype: The dtype for the imputation parameters.
+            device: The device for the imputation parameters.
+        """
+        super().__init__()
+        self.transform_on_train = transform_on_train
+        self.transform_on_eval = transform_on_eval
+        self.transform_on_fantasize = transform_on_fantasize
+
+        if target_task is not None and target_task not in feature_indices:
+            raise ValueError(
+                f"target_task={target_task} is not a key in feature_indices. "
+                f"Available tasks: {sorted(feature_indices.keys())}."
+            )
+        self.target_task = target_task
+
+        if task_feature_index != -1:
+            raise ValueError(
+                "LearnedFeatureImputation requires task_feature_index=-1 "
+                "(task column last). Different tasks may have different "
+                "feature counts, so a fixed non-last position is ambiguous."
+            )
+
+        task_values_sorted = sorted(feature_indices.keys())
+        self.num_tasks = len(task_values_sorted)
+        self.d = d
+
+        # Sorted task identifiers as they appear in the task column of X.
+        self.register_buffer(
+            "_task_values",
+            torch.tensor(task_values_sorted, dtype=torch.long, device=device),
+        )
+
+        if bounds is not None:
+            if bounds.shape != (2, d):
+                raise ValueError(f"bounds must have shape (2, {d}), got {bounds.shape}")
+            bounds = bounds.to(dtype=dtype, device=device)
+            if not ((bounds[0] == 0).all() and (bounds[1] == 1).all()):
+                warn(
+                    "Non-default bounds passed to LearnedFeatureImputation. "
+                    "This transform expects normalized [0, 1] inputs -- chain "
+                    "Normalize before this transform so that the default "
+                    "bounds=[0, 1]^d are appropriate.",
+                    UserInputWarning,
+                    stacklevel=2,
+                )
+            self.register_buffer("bounds", bounds)
+        else:
+            self.register_buffer("bounds", None)
+
+        # Validate that no feature index overlaps with the task column.
+        for task_value, feat_cols in feature_indices.items():
+            if d in feat_cols:
+                raise ValueError(
+                    f"feature_indices[{task_value}] contains the task column "
+                    f"index {d}. Feature indices must not include the "
+                    f"task column."
+                )
+
+        missing_mask = torch.ones(
+            self.num_tasks, d + 1, dtype=torch.bool, device=device
+        )
+        missing_mask[:, -1] = False
+        for task_pos, task_value in enumerate(task_values_sorted):
+            missing_mask[task_pos, feature_indices[task_value]] = False
+        self.register_buffer("missing_mask", missing_mask)
+
+        # Learnable imputation values, shape (num_tasks, d+1). The task column
+        # slot is unused but kept for index alignment with X columns.
+        self.register_parameter(
+            "raw_imputation_values",
+            nn.Parameter(
+                torch.zeros(self.num_tasks, d + 1, dtype=dtype, device=device)
+            ),
+        )
+        if bounds is not None:
+            # Pad bounds with dummy [0, 1] for the task column so the Interval
+            # constraint has shape (d+1,) matching raw_imputation_values.
+            padded_lower = torch.zeros(d + 1, dtype=dtype, device=device)
+            padded_upper = torch.ones(d + 1, dtype=dtype, device=device)
+            padded_lower[:d] = bounds[0]
+            padded_upper[:d] = bounds[1]
+            self.register_constraint(
+                "raw_imputation_values",
+                Interval(
+                    lower_bound=padded_lower,
+                    upper_bound=padded_upper,
+                ),
+            )
+
+    @property
+    def imputation_values(self) -> Tensor:
+        r"""The imputation values, mapped through the Interval constraint when
+        bounds are present, or the raw values otherwise."""
+        if self.bounds is not None:
+            return self.raw_imputation_values_constraint.transform(
+                self.raw_imputation_values
+            )
+        return self.raw_imputation_values
+
+    def transform(self, X: Tensor) -> Tensor:
+        r"""Impute missing features with learned values.
+
+        Args:
+            X: A ``batch_shape x n x (d+1)``-dim tensor of inputs where the
+                last column contains integer task identifiers, or a
+                ``batch_shape x n x d``-dim tensor when ``target_task`` was
+                configured at init (the task column is appended automatically).
+
+        Returns:
+            A ``batch_shape x n x (d+1)``-dim tensor with missing features
+            replaced by learned imputation values.
+        """
+        x_dim = X.shape[-1]
+        if x_dim == self.d:
+            if self.target_task is None:
+                raise ValueError(
+                    f"Received d-dim input (X.shape[-1]={self.d}) but no "
+                    "target_task was configured. When X lacks a task column, "
+                    "target_task must be specified at init so the transform "
+                    "knows which task's imputation pattern to apply."
+                )
+            task_col = torch.full(
+                X.shape[:-1] + (1,),
+                self.target_task,
+                dtype=X.dtype,
+                device=X.device,
+            )
+            X = torch.cat([X, task_col], dim=-1)
+        elif x_dim != self.d + 1:
+            raise ValueError(
+                f"Expected X.shape[-1] to be {self.d} (no task column) or "
+                f"{self.d + 1} (with task column), got {x_dim}."
+            )
+
+        X_new = X.clone()
+
+        task_ids = X_new[..., -1].long()
+        imputation_vals = self.imputation_values
+
+        # For each task, replace unobserved feature columns with learned values.
+        # torch.where with task_mask ensures rows belonging to other tasks are
+        # left untouched, even if the same column is observed for those tasks.
+        for task_pos in range(self.num_tasks):
+            task_value = self._task_values[task_pos]
+            task_mask = task_ids == task_value
+            if not task_mask.any():
+                continue
+            missing_cols = (
+                self.missing_mask[task_pos].nonzero(as_tuple=False).squeeze(-1)
+            )
+            if missing_cols.numel() == 0:
+                continue
+            X_new[..., missing_cols] = torch.where(
+                task_mask.unsqueeze(-1),
+                imputation_vals[task_pos, missing_cols],
+                X_new[..., missing_cols],
+            )
+        return X_new

--- a/botorch/utils/datasets.py
+++ b/botorch/utils/datasets.py
@@ -542,6 +542,46 @@ class MultiTaskDataset(SupervisedDataset):
             and self.task_feature_index == other.task_feature_index
         )
 
+    def get_heterogeneous_feature_mapping(
+        self,
+    ) -> tuple[list["SupervisedDataset"], list[list[int]], int]:
+        """Compute canonical feature ordering for heterogeneous datasets.
+
+        Target features come first (preserving order), then source-only
+        features are appended. The task column (at ``task_feature_index``)
+        is excluded from the mapping.
+
+        Returns:
+            A 3-tuple of:
+            - Ordered datasets (target first, then sources).
+            - Feature indices mapping each dataset's non-task features
+              to the canonical ordering.
+            - Full feature dimensionality (number of unique non-task features).
+
+        Raises:
+            NotImplementedError: If ``task_feature_index`` is not ``-1``.
+        """
+        if self.task_feature_index != -1:
+            raise NotImplementedError(
+                "Heterogeneous feature mapping requires `task_feature_index` to be -1."
+            )
+        child_datasets = self.datasets.copy()
+        target_dataset = child_datasets.pop(self.target_outcome_name)
+        all_datasets = [target_dataset] + list(child_datasets.values())
+
+        # Target's feature order is canonical; source-only features appended.
+        all_features: list[str] = list(target_dataset.feature_names[:-1])
+        for ds in all_datasets[1:]:
+            for fn in ds.feature_names[:-1]:
+                if fn not in all_features:
+                    all_features.append(fn)
+
+        feature_indices = [
+            [all_features.index(fn) for fn in ds.feature_names[:-1]]
+            for ds in all_datasets
+        ]
+        return all_datasets, feature_indices, len(all_features)
+
     def clone(
         self, deepcopy: bool = False, mask: Tensor | None = None
     ) -> MultiTaskDataset:

--- a/test/models/test_multitask.py
+++ b/test/models/test_multitask.py
@@ -25,6 +25,7 @@ from botorch.models.transforms.outcome import OutcomeTransform, Standardize
 from botorch.models.utils.priors import BetaPrior
 from botorch.posteriors import GPyTorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
+from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from botorch.utils.test_helpers import gen_multi_task_dataset
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
@@ -802,6 +803,209 @@ class TestMultiTaskGP(BotorchTestCase):
         # Verify we can sample from the posterior
         samples = posterior.rsample(sample_shape=torch.Size([2]))
         self.assertEqual(samples.shape, torch.Size([2, 3, 1]))
+
+    def test_construct_inputs_heterogeneous(self) -> None:
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
+
+        # Build a heterogeneous MultiTaskDataset: target has features [a, b],
+        # source has features [a, c].
+        n_target, n_source = 10, 8
+        X_target = torch.rand(n_target, 2, **tkwargs)
+        X_source = torch.rand(n_source, 2, **tkwargs)
+        Y_target = torch.rand(n_target, 1, **tkwargs)
+        Y_source = torch.rand(n_source, 1, **tkwargs)
+
+        ds_target = SupervisedDataset(
+            X=torch.cat([X_target, torch.zeros(n_target, 1, **tkwargs)], dim=-1),
+            Y=Y_target,
+            feature_names=["a", "b", "task"],
+            outcome_names=["target"],
+        )
+        ds_source = SupervisedDataset(
+            X=torch.cat([X_source, torch.ones(n_source, 1, **tkwargs)], dim=-1),
+            Y=Y_source,
+            feature_names=["a", "c", "task"],
+            outcome_names=["source"],
+        )
+        mt_dataset = MultiTaskDataset(
+            datasets=[ds_target, ds_source],
+            target_outcome_name="target",
+            task_feature_index=-1,
+        )
+        self.assertTrue(mt_dataset.has_heterogeneous_features)
+
+        # map_heterogeneous_to_full=False (default) → raises UnsupportedError
+        with self.assertRaises(UnsupportedError):
+            MultiTaskGP.construct_inputs(mt_dataset, task_feature=-1)
+
+        # map_heterogeneous_to_full=True → zero-padded train_X
+        data_dict = MultiTaskGP.construct_inputs(
+            mt_dataset, task_feature=-1, map_heterogeneous_to_full=True
+        )
+        train_X = data_dict["train_X"]
+        # Full features: [a, b, c] + task → 4 columns
+        self.assertEqual(train_X.shape, (n_target + n_source, 4))
+        # Task column is last
+        self.assertTrue((train_X[:n_target, -1] == 0).all())
+        self.assertTrue((train_X[n_target:, -1] == 1).all())
+        # Target rows: a, b filled; c (index 2) is zero
+        self.assertAllClose(train_X[:n_target, 0], X_target[:, 0])
+        self.assertAllClose(train_X[:n_target, 1], X_target[:, 1])
+        self.assertTrue((train_X[:n_target, 2] == 0).all())
+        # Source rows: a filled at index 0; b (index 1) is zero; c at index 2
+        self.assertAllClose(train_X[n_target:, 0], X_source[:, 0])
+        self.assertTrue((train_X[n_target:, 1] == 0).all())
+        self.assertAllClose(train_X[n_target:, 2], X_source[:, 1])
+
+        self.assertEqual(data_dict["task_feature"], -1)
+        self.assertEqual(data_dict["all_tasks"], [0, 1])
+        self.assertTrue(
+            torch.equal(data_dict["train_Y"], torch.cat([Y_target, Y_source]))
+        )
+
+        # Cover rank and task_covar_prior conditional branches.
+        data_dict = MultiTaskGP.construct_inputs(
+            mt_dataset, task_feature=-1, map_heterogeneous_to_full=True, rank=2
+        )
+        self.assertEqual(data_dict["rank"], 2)
+        prior = LKJCovariancePrior(2, 1.0, SmoothedBoxPrior(0.1, 2.0))
+        data_dict = MultiTaskGP.construct_inputs(
+            mt_dataset,
+            task_feature=-1,
+            map_heterogeneous_to_full=True,
+            task_covar_prior=prior,
+        )
+        self.assertIs(data_dict["task_covar_prior"], prior)
+
+        # task_feature_index != -1 → NotImplementedError
+        mt_bad = MultiTaskDataset(
+            datasets=[ds_target, ds_source],
+            target_outcome_name="target",
+            task_feature_index=0,
+        )
+        mt_bad.has_heterogeneous_features = True
+        with self.assertRaises(NotImplementedError):
+            MultiTaskGP.construct_inputs(
+                mt_bad, task_feature=-1, map_heterogeneous_to_full=True
+            )
+
+    def test_construct_inputs_heterogeneous_with_yvar(self) -> None:
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
+
+        n_target, n_source = 6, 4
+        ds_target = SupervisedDataset(
+            X=torch.cat(
+                [
+                    torch.rand(n_target, 2, **tkwargs),
+                    torch.zeros(n_target, 1, **tkwargs),
+                ],
+                dim=-1,
+            ),
+            Y=torch.rand(n_target, 1, **tkwargs),
+            Yvar=torch.full((n_target, 1), 0.1, **tkwargs),
+            feature_names=["a", "b", "task"],
+            outcome_names=["target"],
+        )
+        ds_source = SupervisedDataset(
+            X=torch.cat(
+                [
+                    torch.rand(n_source, 1, **tkwargs),
+                    torch.ones(n_source, 1, **tkwargs),
+                ],
+                dim=-1,
+            ),
+            Y=torch.rand(n_source, 1, **tkwargs),
+            Yvar=torch.full((n_source, 1), 0.2, **tkwargs),
+            feature_names=["a", "task"],
+            outcome_names=["source"],
+        )
+        mt_dataset = MultiTaskDataset(
+            datasets=[ds_target, ds_source],
+            target_outcome_name="target",
+            task_feature_index=-1,
+        )
+        data_dict = MultiTaskGP.construct_inputs(
+            mt_dataset, task_feature=-1, map_heterogeneous_to_full=True
+        )
+        # Full features: [a, b] + task → 3 columns
+        self.assertEqual(data_dict["train_X"].shape, (n_target + n_source, 3))
+        self.assertIn("train_Yvar", data_dict)
+        self.assertEqual(data_dict["train_Yvar"].shape, (n_target + n_source, 1))
+
+    def test_e2e_multitask_gp_with_learned_feature_imputation(self) -> None:
+        from botorch.models.transforms.input import (
+            ChainedInputTransform,
+            LearnedFeatureImputation,
+        )
+
+        tkwargs: dict[str, Any] = {"device": self.device, "dtype": torch.double}
+
+        # Heterogeneous dataset: target has [a, b], source has [a, c].
+        n_target, n_source = 15, 10
+        X_target = torch.rand(n_target, 2, **tkwargs)
+        X_source = torch.rand(n_source, 2, **tkwargs)
+        Y_target = torch.sin(X_target.sum(dim=-1, keepdim=True))
+        Y_source = torch.cos(X_source.sum(dim=-1, keepdim=True))
+
+        ds_target = SupervisedDataset(
+            X=torch.cat([X_target, torch.zeros(n_target, 1, **tkwargs)], dim=-1),
+            Y=Y_target,
+            feature_names=["a", "b", "task"],
+            outcome_names=["target"],
+        )
+        ds_source = SupervisedDataset(
+            X=torch.cat([X_source, torch.ones(n_source, 1, **tkwargs)], dim=-1),
+            Y=Y_source,
+            feature_names=["a", "c", "task"],
+            outcome_names=["source"],
+        )
+        mt_dataset = MultiTaskDataset(
+            datasets=[ds_target, ds_source],
+            target_outcome_name="target",
+            task_feature_index=-1,
+        )
+
+        model_inputs = MultiTaskGP.construct_inputs(
+            mt_dataset, task_feature=-1, map_heterogeneous_to_full=True
+        )
+
+        # Full features = [a, b, c], d=3, task at -1.
+        d = 3
+        feature_indices = {0: [0, 1], 1: [0, 2]}
+        input_transform = ChainedInputTransform(
+            normalize=Normalize(d=d + 1, indices=list(range(d))),
+            impute=LearnedFeatureImputation(
+                feature_indices=feature_indices,
+                d=d,
+                task_feature_index=-1,
+                **tkwargs,
+            ),
+        )
+        model = MultiTaskGP(**model_inputs, input_transform=input_transform)
+
+        # Verify the model can produce posteriors.
+        test_X = torch.cat(
+            [torch.rand(5, 2, **tkwargs), torch.zeros(5, 1, **tkwargs)], dim=-1
+        )
+        # Posterior call on target-task-dimensioned input won't work directly
+        # because MultiTaskGP expects full-dimensional input; test with full X.
+        test_X_full = torch.zeros(5, d + 1, **tkwargs)
+        test_X_full[:, :2] = test_X[:, :2]
+        test_X_full[:, -1] = 0
+        posterior = model.posterior(test_X_full)
+        self.assertEqual(posterior.mean.shape, torch.Size([5, 1]))
+        self.assertFalse(torch.isnan(posterior.mean).any())
+
+        # Fit the model briefly and verify imputation values change.
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        initial_imp = model.input_transform.impute.imputation_values.clone().detach()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=OptimizationWarning)
+            fit_gpytorch_mll(
+                mll, optimizer_kwargs={"options": {"maxiter": 5}}, max_attempts=1
+            )
+        final_imp = model.input_transform.impute.imputation_values.detach()
+        self.assertFalse(torch.allclose(initial_imp, final_imp, atol=1e-6))
 
 
 class TestKroneckerMultiTaskGP(BotorchTestCase):

--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+import warnings
 from abc import ABC
 from copy import deepcopy
 from functools import partial
@@ -24,6 +25,7 @@ from botorch.models.transforms.input import (
     InputStandardize,
     InputTransform,
     InteractionFeatures,
+    LearnedFeatureImputation,
     Log10,
     Normalize,
     NumericToCategoricalEncoding,
@@ -1632,6 +1634,355 @@ class TestInputTransforms(BotorchTestCase):
             dim=dim, categorical_features={}, transform_on_train=False
         )
         self.assertFalse(tf3.equals(tf2))
+
+    def test_learned_feature_imputation(self) -> None:
+        with self.subTest("public_import"):
+            from botorch.models.transforms import LearnedFeatureImputation as _LFI
+
+            self.assertIs(_LFI, LearnedFeatureImputation)
+
+        # Setup: 2 tasks, 4 features total.
+        # Task 0 observes features [0, 1, 2], task 1 observes [0, 1, 3].
+        feature_indices = {0: [0, 1, 2], 1: [0, 1, 3]}
+        d = 4
+
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
+
+            with self.subTest("init", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices=feature_indices,
+                    d=d,
+                    task_feature_index=-1,
+                    **tkwargs,
+                )
+                self.assertEqual(tf.num_tasks, 2)
+                self.assertEqual(tf.raw_imputation_values.shape, torch.Size([2, d + 1]))
+                # missing_mask: shape (num_tasks, d+1), task col always False.
+                self.assertTrue(tf.missing_mask[0, 3].item())
+                self.assertFalse(tf.missing_mask[0, 0].item())
+                self.assertTrue(tf.missing_mask[1, 2].item())
+                self.assertFalse(tf.missing_mask[:, d].any().item())
+
+            with self.subTest("transform_correctness", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices=feature_indices,
+                    d=d,
+                    **tkwargs,
+                )
+                tf.raw_imputation_values.data = torch.tensor(
+                    [
+                        [0.0, 0.0, 0.0, 0.5, 0.0],
+                        [0.0, 0.0, 0.7, 0.0, 0.0],
+                    ],
+                    **tkwargs,
+                )
+                X = torch.tensor(
+                    [
+                        [1.0, 2.0, 3.0, 9.0, 0.0],  # task 0, feat 3 is junk
+                        [4.0, 5.0, 6.0, 9.0, 0.0],  # task 0
+                        [7.0, 8.0, 9.0, 9.0, 1.0],  # task 1, feat 2 is junk
+                        [0.1, 0.2, 9.0, 0.4, 1.0],  # task 1
+                    ],
+                    **tkwargs,
+                )
+                X_tf = tf(X)
+                # Task 0: features 0-2 unchanged, feat 3 imputed.
+                self.assertEqual(X_tf[0, :3].tolist(), [1.0, 2.0, 3.0])
+                self.assertAlmostEqual(X_tf[0, 3].item(), 0.5)
+                self.assertAlmostEqual(X_tf[1, 3].item(), 0.5)
+                # Task 1: features 0,1,3 unchanged, feat 2 imputed.
+                self.assertAlmostEqual(X_tf[2, 2].item(), 0.7)
+                self.assertAlmostEqual(X_tf[3, 2].item(), 0.7)
+                self.assertEqual(X_tf[2, 3].item(), 9.0)
+                # Task column unchanged, original X unmodified.
+                self.assertTrue(torch.equal(X_tf[:, -1], X[:, -1]))
+                self.assertEqual(X[0, 3].item(), 9.0)
+
+                # Batch: same transform works with leading batch dim.
+                X_batch = X[:3].unsqueeze(0).expand(2, -1, -1).clone()
+                X_tf_batch = tf(X_batch)
+                self.assertEqual(X_tf_batch.shape, X_batch.shape)
+                self.assertAlmostEqual(X_tf_batch[0, 0, 3].item(), 0.5)
+                self.assertAlmostEqual(X_tf_batch[1, 2, 2].item(), 0.7)
+
+            with self.subTest("task_feature_index_not_last_raises", dtype=dtype):
+                with self.assertRaisesRegex(ValueError, "task_feature_index=-1"):
+                    LearnedFeatureImputation(
+                        feature_indices={0: [1, 2], 1: [1]},
+                        d=2,
+                        task_feature_index=0,
+                        **tkwargs,
+                    )
+
+            with self.subTest("train_eval_modes", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices={0: [0], 1: [1]},
+                    d=2,
+                    transform_on_train=True,
+                    transform_on_eval=False,
+                    **tkwargs,
+                )
+                X_simple = torch.tensor(
+                    [[1.0, 9.0, 0.0], [9.0, 2.0, 1.0]],
+                    **tkwargs,
+                )
+                tf.train()
+                self.assertAlmostEqual(tf(X_simple)[0, 1].item(), 0.0)
+                tf.eval()
+                self.assertEqual(tf(X_simple)[0, 1].item(), 9.0)
+
+            with self.subTest("gradient_flow", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices={0: [0, 1], 1: [0]},
+                    d=2,
+                    **tkwargs,
+                )
+                X_grad = torch.tensor(
+                    [[1.0, 2.0, 0.0], [3.0, 9.0, 1.0]],
+                    **tkwargs,
+                )
+                tf.train()
+                tf(X_grad).sum().backward()
+                grad = tf.raw_imputation_values.grad
+                self.assertIsNotNone(grad)
+                self.assertNotEqual(grad[1, 1].item(), 0.0)
+                # Task 0 observes both features → no imputation → no grad.
+                self.assertEqual(grad[0, 0].item(), 0.0)
+                self.assertEqual(grad[0, 1].item(), 0.0)
+
+            with self.subTest("untransform_raises", dtype=dtype):
+                tf = LearnedFeatureImputation(feature_indices={0: [0]}, d=1, **tkwargs)
+                with self.assertRaises(NotImplementedError):
+                    tf.untransform(torch.zeros(1, 2, **tkwargs))
+
+            with self.subTest("task_col_overlap_raises", dtype=dtype):
+                with self.assertRaisesRegex(ValueError, "task column index"):
+                    LearnedFeatureImputation(
+                        feature_indices={0: [0, 1, 2]}, d=2, **tkwargs
+                    )
+
+            with self.subTest("asymmetric_feature_counts", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices={0: [0, 1, 2], 1: [0, 1, 3, 4]},
+                    d=5,
+                    **tkwargs,
+                )
+                tf.raw_imputation_values.data = torch.tensor(
+                    [
+                        [0.0, 0.0, 0.0, 0.5, 0.6, 0.0],
+                        [0.0, 0.0, 0.7, 0.0, 0.0, 0.0],
+                    ],
+                    **tkwargs,
+                )
+                # Imputation with asymmetric observed feature counts.
+                X_full = torch.tensor([[1.0, 2.0, 3.0, 9.0, 9.0, 0.0]], **tkwargs)
+                X_tf = tf(X_full)
+                self.assertAlmostEqual(X_tf[0, 3].item(), 0.5)
+                self.assertAlmostEqual(X_tf[0, 4].item(), 0.6)
+
+            with self.subTest("bounds", dtype=dtype):
+                # Unit bounds: no warning.
+                unit_bounds = torch.stack(
+                    [torch.zeros(d, **tkwargs), torch.ones(d, **tkwargs)]
+                )
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    tf = LearnedFeatureImputation(
+                        feature_indices=feature_indices,
+                        d=d,
+                        bounds=unit_bounds,
+                        **tkwargs,
+                    )
+                self.assertEqual(
+                    [w for w in caught if issubclass(w.category, UserInputWarning)],
+                    [],
+                )
+                self.assertIsNotNone(tf.bounds)
+
+                # Non-unit bounds: warning.
+                non_unit = torch.stack(
+                    [torch.zeros(d, **tkwargs), 2 * torch.ones(d, **tkwargs)]
+                )
+                with self.assertWarnsRegex(UserInputWarning, "Non-default bounds"):
+                    LearnedFeatureImputation(
+                        feature_indices=feature_indices,
+                        d=d,
+                        bounds=non_unit,
+                        **tkwargs,
+                    )
+
+                # Shape validation.
+                with self.assertRaisesRegex(ValueError, "bounds must have shape"):
+                    LearnedFeatureImputation(
+                        feature_indices=feature_indices,
+                        d=d,
+                        bounds=torch.ones(2, d + 1, **tkwargs),
+                        **tkwargs,
+                    )
+
+                # Interval constraint: raw=0 → sigmoid(0)=0.5 → midpoint.
+                bounds = torch.tensor(
+                    [[0.0, 0.0, 1.0, 2.0], [1.0, 1.0, 3.0, 4.0]], **tkwargs
+                )
+                with self.assertWarns(UserInputWarning):
+                    tf = LearnedFeatureImputation(
+                        feature_indices=feature_indices,
+                        d=d,
+                        bounds=bounds,
+                        **tkwargs,
+                    )
+                # Imputation values have shape (num_tasks, d+1). Feature cols
+                # 0..d-1 are constrained; task col d has dummy [0,1] constraint.
+                expected_features = bounds[0] + (bounds[1] - bounds[0]) * 0.5
+                imp = tf.imputation_values
+                self.assertTrue(
+                    torch.allclose(imp[:, :d], expected_features.expand(2, d))
+                )
+
+                # Gradient flows through constraint.
+                tf_g = LearnedFeatureImputation(
+                    feature_indices={0: [0, 1], 1: [0]},
+                    d=2,
+                    bounds=torch.stack(
+                        [torch.zeros(2, **tkwargs), torch.ones(2, **tkwargs)]
+                    ),
+                    **tkwargs,
+                )
+                tf_g.train()
+                tf_g(
+                    torch.tensor([[1.0, 2.0, 0.0], [3.0, 9.0, 1.0]], **tkwargs)
+                ).sum().backward()
+                self.assertNotEqual(tf_g.raw_imputation_values.grad[1, 1].item(), 0.0)
+
+            with self.subTest("three_tasks", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices={0: [0, 1], 1: [1, 2], 2: [0, 2]},
+                    d=3,
+                    **tkwargs,
+                )
+                tf.raw_imputation_values.data = torch.tensor(
+                    [
+                        [0.0, 0.0, 0.3, 0.0],
+                        [0.4, 0.0, 0.0, 0.0],
+                        [0.0, 0.5, 0.0, 0.0],
+                    ],
+                    **tkwargs,
+                )
+                X_three_tasks = torch.tensor(
+                    [
+                        [1.0, 2.0, 9.0, 0.0],
+                        [9.0, 3.0, 4.0, 1.0],
+                        [5.0, 9.0, 6.0, 2.0],
+                    ],
+                    **tkwargs,
+                )
+                X_tf = tf(X_three_tasks)
+                self.assertAlmostEqual(X_tf[0, 2].item(), 0.3)
+                self.assertAlmostEqual(X_tf[1, 0].item(), 0.4)
+                self.assertAlmostEqual(X_tf[2, 1].item(), 0.5)
+
+            with self.subTest("non_contiguous_task_values", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices={5: [0, 1, 2], 12: [0, 1, 3]},
+                    d=d,
+                    **tkwargs,
+                )
+                self.assertTrue(
+                    torch.equal(
+                        tf._task_values,
+                        torch.tensor([5, 12], dtype=torch.long),
+                    )
+                )
+                tf.raw_imputation_values.data = torch.tensor(
+                    [[0.0, 0.0, 0.0, 0.5, 0.0], [0.0, 0.0, 0.7, 0.0, 0.0]],
+                    **tkwargs,
+                )
+                X_noncontig = torch.tensor(
+                    [
+                        [1.0, 2.0, 3.0, 9.0, 5.0],
+                        [7.0, 8.0, 9.0, 9.0, 12.0],
+                    ],
+                    **tkwargs,
+                )
+                X_tf = tf(X_noncontig)
+                self.assertAlmostEqual(X_tf[0, 3].item(), 0.5)
+                self.assertAlmostEqual(X_tf[1, 2].item(), 0.7)
+                self.assertTrue(torch.equal(X_tf[:, -1], X_noncontig[:, -1]))
+
+            with self.subTest("batch_dim", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices=feature_indices,
+                    d=d,
+                    **tkwargs,
+                )
+                tf.raw_imputation_values.data = torch.tensor(
+                    [[0.0, 0.0, 0.0, 0.5, 0.0], [0.0, 0.0, 0.7, 0.0, 0.0]],
+                    **tkwargs,
+                )
+                X_batch = torch.tensor(
+                    [
+                        [[1.0, 2.0, 3.0, 9.0, 0.0], [7.0, 8.0, 9.0, 9.0, 1.0]],
+                        [[0.1, 0.2, 0.3, 9.0, 0.0], [0.4, 0.5, 9.0, 0.6, 1.0]],
+                    ],
+                    **tkwargs,
+                )
+                X_tf = tf(X_batch)
+                self.assertEqual(X_tf.shape, torch.Size([2, 2, 5]))
+                self.assertAlmostEqual(X_tf[0, 0, 3].item(), 0.5)
+                self.assertAlmostEqual(X_tf[1, 1, 2].item(), 0.7)
+
+            with self.subTest("d_dim_input_with_target_task", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices=feature_indices,
+                    d=d,
+                    target_task=0,
+                    **tkwargs,
+                )
+                tf.raw_imputation_values.data = torch.tensor(
+                    [[0.0, 0.0, 0.0, 0.5, 0.0], [0.0, 0.0, 0.7, 0.0, 0.0]],
+                    **tkwargs,
+                )
+                X_no_task = torch.tensor(
+                    [[1.0, 2.0, 3.0, 9.0], [4.0, 5.0, 6.0, 9.0]],
+                    **tkwargs,
+                )
+                X_tf = tf(X_no_task)
+                self.assertEqual(X_tf.shape[-1], d + 1)
+                self.assertAlmostEqual(X_tf[0, 3].item(), 0.5)
+                self.assertAlmostEqual(X_tf[1, 3].item(), 0.5)
+                self.assertTrue((X_tf[:, -1] == 0).all())
+
+            with self.subTest("d_dim_input_without_target_task_raises", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices=feature_indices,
+                    d=d,
+                    **tkwargs,
+                )
+                X_no_task = torch.tensor(
+                    [[1.0, 2.0, 3.0, 9.0]],
+                    **tkwargs,
+                )
+                with self.assertRaisesRegex(ValueError, "target_task"):
+                    tf(X_no_task)
+
+            with self.subTest("target_task_not_in_feature_indices_raises", dtype=dtype):
+                with self.assertRaisesRegex(ValueError, "target_task=99"):
+                    LearnedFeatureImputation(
+                        feature_indices=feature_indices,
+                        d=d,
+                        target_task=99,
+                        **tkwargs,
+                    )
+
+            with self.subTest("wrong_x_dim_raises", dtype=dtype):
+                tf = LearnedFeatureImputation(
+                    feature_indices=feature_indices,
+                    d=d,
+                    **tkwargs,
+                )
+                with self.assertRaisesRegex(ValueError, "Expected X.shape"):
+                    tf(torch.zeros(2, d + 3, **tkwargs))
 
 
 class TestAppendFeatures(BotorchTestCase):

--- a/test/utils/test_datasets.py
+++ b/test/utils/test_datasets.py
@@ -491,6 +491,31 @@ class TestDatasets(BotorchTestCase):
             MultiTaskDataset(datasets=[dataset_1, dataset_5], target_outcome_name="z"),
         )
 
+    def test_get_heterogeneous_feature_mapping(self):
+        ds_target = make_dataset(
+            d=3, feature_names=["a", "b", "task"], outcome_names=["y"]
+        )
+        ds_source = make_dataset(
+            d=3, feature_names=["a", "c", "task"], outcome_names=["z"]
+        )
+        mt_err = MultiTaskDataset(
+            datasets=[ds_target, ds_source],
+            target_outcome_name="y",
+            task_feature_index=0,
+        )
+        with self.assertRaises(NotImplementedError):
+            mt_err.get_heterogeneous_feature_mapping()
+
+        mt = MultiTaskDataset(
+            datasets=[ds_target, ds_source],
+            target_outcome_name="y",
+            task_feature_index=-1,
+        )
+        all_datasets, feature_indices, full_dim = mt.get_heterogeneous_feature_mapping()
+        self.assertEqual(len(all_datasets), 2)
+        self.assertEqual(full_dim, 3)
+        self.assertEqual(feature_indices, [[0, 1], [0, 2]])
+
     def test_clone_multitask(self) -> None:
         for has_yvar in [False, True]:
             dataset_1 = make_dataset(outcome_names=["y"], has_yvar=has_yvar)


### PR DESCRIPTION
Summary:

Adds a `map_heterogeneous_to_full` parameter to `MultiTaskGP.construct_inputs` that zero-pads heterogeneous `MultiTaskDataset` features into the union feature space, enabling `MultiTaskGP` + `LearnedFeatureImputation` as a drop-in replacement for `ImputedMultiTaskGP`.

Reviewed By: sdaulton

Differential Revision: D101903488
