### PR TITLE
docs: force no trailing slash

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,6 +42,7 @@ module.exports={
     "wrapPagesHTML": true
   },
   "onBrokenLinks": "throw",
+  "trailingSlash": false,
   "presets": [
     [
       "@docusaurus/preset-classic",


### PR DESCRIPTION
## Motivation

I noticed on the documentation site that some links appeared to be broken. Looking into it, I think it's due to the trailing slash of addresses being rendered in some cases and not in others.

For example, going to the main site > Docs > Basic Concepts > Acquisition Functions

The address is then 
`https://botorch.org/docs/acquisition`
but when I refresh (on Firefox), the address becomes 
`https://botorch.org/docs/acquisition/`
so that the relative link ("... counterpart qExpectedImprovement can be found in **this tutorial**.") goes to 
`https://botorch.org/docs/acquisition/tutorials/compare_mc_analytic_acquisition`
instead of 
`https://botorch.org/docs/tutorials/compare_mc_analytic_acquisition`

I reproduced this locally by adding a [setting](https://docusaurus.io/docs/api/docusaurus-config#trailingSlash) of
`"trailingSlash": true`

To keep using relative links, I think the easiest fix is to specify 
`"trailingSlash": false`

But just thought I'd point it out.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Reproduced site issue locally and tested fix locally.

## Related PRs

None found.