### PR TITLE
Add untransform support to efficient LOO cross-validation (#3288)

### DIFF
--- a/botorch/cross_validation.py
+++ b/botorch/cross_validation.py
@@ -16,9 +16,13 @@ import torch
 from botorch.exceptions.errors import UnsupportedError
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.gpytorch import GPyTorchModel
+from botorch.models.likelihoods.sparse_outlier_noise import (
+    SparseOutlierGaussianLikelihood,
+)
 from botorch.models.multitask import MultiTaskGP
 from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.posteriors.posterior import Posterior
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -51,10 +55,15 @@ class CVResults(NamedTuple):
     For ``efficient_loo_cv``, the posterior has the same shape structure to maintain
     consistency, though the underlying distribution is constructed from the
     efficient LOO formulas rather than from separate model fits.
+
+    NOTE: When ``untransform=True`` is used with a nonlinear outcome transform
+    (e.g., ``Log``), the posterior will be a ``TransformedPosterior`` rather than
+    a ``GPyTorchPosterior``. For ensemble models, it will be a
+    ``GaussianMixturePosterior``.
     """
 
     model: GPyTorchModel
-    posterior: GPyTorchPosterior
+    posterior: Posterior
     observed_Y: Tensor
     observed_Yvar: Tensor | None = None
 
@@ -95,8 +104,7 @@ def gen_loo_cv_folds(
         >>> cv_folds.train_X.shape
         torch.Size([10, 9, 1])
     """
-    masks = torch.eye(train_X.shape[-2], dtype=torch.uint8, device=train_X.device)
-    masks = masks.to(dtype=torch.bool)
+    masks = torch.eye(train_X.shape[-2], dtype=torch.bool, device=train_X.device)
     if train_Y.dim() < train_X.dim():
         # add output dimension
         train_Y = train_Y.unsqueeze(-1)
@@ -223,7 +231,11 @@ def batch_cross_validation(
     )
 
 
-def loo_cv(model: GPyTorchModel, observation_noise: bool = True) -> CVResults:
+def loo_cv(
+    model: GPyTorchModel,
+    observation_noise: bool = True,
+    untransform: bool = True,
+) -> CVResults:
     r"""Compute efficient Leave-One-Out cross-validation for a GP model.
 
     This is a high-level convenience function that automatically dispatches to
@@ -243,6 +255,11 @@ def loo_cv(model: GPyTorchModel, observation_noise: bool = True) -> CVResults:
     LOO CV. For models where hyperparameter changes are significant, consider
     using ``batch_cross_validation`` instead.
 
+    NOTE: The ``untransform`` parameter defaults to True, which means results
+    are returned in the original outcome space. Callers that previously relied
+    on results in the model's internal (transformed) space should pass
+    ``untransform=False`` explicitly.
+
     Args:
         model: A fitted GPyTorchModel. The model type determines which LOO CV
             implementation is used.
@@ -252,6 +269,12 @@ def loo_cv(model: GPyTorchModel, observation_noise: bool = True) -> CVResults:
             observation noise). The posterior variance is computed by
             subtracting the observation noise from the posterior predictive
             variance.
+        untransform: If True (default), untransform the LOO predictions and
+            observed values back to the original outcome space when the model
+            has an outcome transform (e.g., ``Standardize``). This makes the
+            results consistent with ``model.posterior()`` and
+            ``batch_cross_validation``. If False, return results in the
+            model's internal (transformed) space.
 
     Returns:
         CVResults: A named tuple containing:
@@ -283,15 +306,16 @@ def loo_cv(model: GPyTorchModel, observation_noise: bool = True) -> CVResults:
         - ``ensemble_loo_cv``: Direct access to the ensemble model implementation.
         - ``batch_cross_validation``: Full LOO CV with model refitting.
     """
-    if getattr(model, "_is_ensemble", False):
-        return ensemble_loo_cv(model, observation_noise=observation_noise)
-    else:
-        return efficient_loo_cv(model, observation_noise=observation_noise)
+    loo_fun = (
+        ensemble_loo_cv if getattr(model, "_is_ensemble", False) else efficient_loo_cv
+    )
+    return loo_fun(model, observation_noise=observation_noise, untransform=untransform)
 
 
 def efficient_loo_cv(
     model: GPyTorchModel,
     observation_noise: bool = True,
+    untransform: bool = True,
 ) -> CVResults:
     r"""Compute efficient Leave-One-Out cross-validation for a GP model.
 
@@ -332,12 +356,20 @@ def efficient_loo_cv(
             predictive variance (including observation noise). If False,
             return the posterior variance of the latent function (excluding
             observation noise).
+        untransform: If True (default), untransform the LOO predictions and
+            observed values back to the original outcome space when the model
+            has an outcome transform (e.g., ``Standardize``). This makes the
+            results consistent with ``model.posterior()`` and
+            ``batch_cross_validation``. If False, return results in the
+            model's internal (transformed) space.
 
     Returns:
         CVResults: A named tuple containing:
             - model: The fitted GP model.
-            - posterior: A GPyTorchPosterior with the LOO predictive distributions.
-              The posterior mean and variance have shape ``n x 1 x m`` or
+            - posterior: The LOO predictive distributions (typically a
+              ``GPyTorchPosterior``; with nonlinear outcome transforms like
+              ``Log``, a ``TransformedPosterior``). The posterior mean and
+              variance have shape ``n x 1 x m`` or
               ``batch_shape x n x 1 x m``, matching the structure of
               ``batch_cross_validation`` (n folds, 1 held-out point per fold,
               m outputs). The underlying distribution has diagonal covariance
@@ -385,12 +417,93 @@ def efficient_loo_cv(
     if isinstance(model.likelihood, FixedNoiseGaussianLikelihood):
         observed_Yvar = _reshape_to_loo_cv_format(model.likelihood.noise, num_outputs)
 
+    # Untransform predictions and observed values back to original space
+    if untransform and hasattr(model, "outcome_transform"):
+        posterior, observed_Y, observed_Yvar = _untransform_loo_results(
+            model=model,
+            posterior=posterior,
+            observed_Y=observed_Y,
+            observed_Yvar=observed_Yvar,
+        )
+
     return CVResults(
         model=model,
         posterior=posterior,
         observed_Y=observed_Y,
         observed_Yvar=observed_Yvar,
     )
+
+
+def _untransform_loo_results(
+    model: GPyTorchModel,
+    posterior: Posterior,
+    observed_Y: Tensor,
+    observed_Yvar: Tensor | None,
+) -> tuple[Posterior, Tensor, Tensor | None]:
+    r"""Untransform LOO CV results from model-internal space to original space.
+
+    Applies the model's outcome transform to map the LOO posterior and observed
+    values back to the original (untransformed) outcome space. This uses
+    ``outcome_transform.untransform_posterior`` for the posterior and
+    ``outcome_transform.untransform`` for the observed values.
+
+    For linear transforms like ``Standardize``, the posterior is analytically
+    rescaled and remains a ``GPyTorchPosterior``. For nonlinear transforms like
+    ``Log``, the posterior is wrapped in a ``TransformedPosterior``.
+
+    Args:
+        model: The GP model with an ``outcome_transform`` attribute.
+        posterior: The LOO posterior in the model's internal (transformed) space.
+            Shape: ``n x 1 x m`` or ``batch_shape x n x 1 x m``.
+        observed_Y: The observed Y values in transformed space with shape
+            ``n x 1 x m`` or ``batch_shape x n x 1 x m``.
+        observed_Yvar: The observed noise variances in transformed space (if
+            applicable) with shape ``n x 1 x m`` or ``batch_shape x n x 1 x m``.
+
+    Returns:
+        A tuple of (posterior, observed_Y, observed_Yvar) in the original
+        (untransformed) outcome space. Note: if the outcome transform has a
+        ``batch_shape`` (e.g., ``Standardize(batch_shape=[num_models])``),
+        broadcasting during untransform may add leading dimensions to
+        ``observed_Y`` that the caller must align with the posterior layout.
+    """
+    outcome_transform = model.outcome_transform
+
+    # Validate observed_Y shape before any transforms.
+    if observed_Y.shape[-2] != 1:
+        raise ValueError(
+            "Expected observed_Y to have size 1 at dim -2 (q dimension), "
+            f"got shape {observed_Y.shape}."
+        )
+
+    posterior = outcome_transform.untransform_posterior(posterior)
+
+    # Untransform observed_Y (and observed_Yvar if present).
+    # observed_Y has shape n x 1 x m; Standardize.untransform expects
+    # batch_shape x n x m. We squeeze the q=1 dim, untransform, and restore it.
+    observed_Y_squeezed = observed_Y.squeeze(-2)
+    observed_Yvar_squeezed = (
+        observed_Yvar.squeeze(-2) if observed_Yvar is not None else None
+    )
+    observed_Y_utf, observed_Yvar_utf = outcome_transform.untransform(
+        observed_Y_squeezed, observed_Yvar_squeezed
+    )
+    observed_Y = observed_Y_utf.unsqueeze(-2)
+    observed_Yvar = (
+        observed_Yvar_utf.unsqueeze(-2) if observed_Yvar_utf is not None else None
+    )
+
+    return posterior, observed_Y, observed_Yvar
+
+
+def _likelihood_requires_X(likelihood: object) -> bool:
+    r"""Check if a likelihood requires training inputs for noise computation.
+
+    Returns True for likelihoods like SparseOutlierGaussianLikelihood that
+    need training inputs to determine per-point noise (e.g., outlier variances).
+    Standard GaussianLikelihood does not need training inputs.
+    """
+    return isinstance(likelihood, SparseOutlierGaussianLikelihood)
 
 
 def _subtract_observation_noise(model: GPyTorchModel, loo_variance: Tensor) -> Tensor:
@@ -426,16 +539,18 @@ def _subtract_observation_noise(model: GPyTorchModel, loo_variance: Tensor) -> T
         noise_shape, dtype=loo_variance.dtype, device=loo_variance.device
     )
 
-    # Some likelihoods (e.g., SparseOutlierGaussianLikelihood) require training
-    # inputs to be passed to correctly compute the noise. We pass the model's
-    # train_inputs if available.
-    train_inputs = getattr(model, "train_inputs", None)
-
-    # Call forward to get the observation noise distribution.
-    # We pass train_inputs as a positional argument so it flows through *params
-    # to the noise model, which is compatible with both standard Noise classes
-    # (that use *params) and SparseOutlierNoise (that uses X as the first arg).
-    noise_dist = likelihood.forward(zeros, train_inputs)
+    # Only pass training inputs when the likelihood needs them (e.g.,
+    # SparseOutlierGaussianLikelihood for per-point outlier noise).
+    # Standard GaussianLikelihood doesn't need inputs, and passing
+    # pre-transform inputs can cause shape mismatches with models that
+    # use dimension-changing input transforms (e.g., AppendFeatures).
+    if _likelihood_requires_X(likelihood):
+        train_inputs = getattr(model, "train_inputs", None)
+        noise_dist = likelihood.forward(
+            zeros, train_inputs[0] if train_inputs else None
+        )
+    else:
+        noise_dist = likelihood.forward(zeros)
 
     # Extract noise variance and reshape to match loo_variance
     noise = noise_dist.variance.unsqueeze(-1)  # ... x n x 1
@@ -522,12 +637,15 @@ def _compute_loo_predictions(
 
     # Add observation noise to the diagonal via the likelihood
     # The likelihood adds noise: K_noisy = K + sigma^2 * I
-    # Some likelihoods (e.g., SparseOutlierGaussianLikelihood) require training
-    # inputs to be passed to correctly apply the noise model. We pass them as
-    # a positional argument for compatibility with both standard likelihoods
-    # and SparseOutlierGaussianLikelihood.
-    train_inputs = model.train_inputs
-    noisy_mvn = model.likelihood(prior_dist, train_inputs)
+    # Only pass training inputs when the likelihood needs them (e.g.,
+    # SparseOutlierGaussianLikelihood for per-point outlier noise).
+    # Standard GaussianLikelihood doesn't need inputs, and passing
+    # pre-transform inputs can cause shape mismatches with models that
+    # use dimension-changing input transforms (e.g., AppendFeatures).
+    if _likelihood_requires_X(model.likelihood):
+        noisy_mvn = model.likelihood(prior_dist, model.train_inputs[0])
+    else:
+        noisy_mvn = model.likelihood(prior_dist)
 
     # Get the covariance matrix - use lazy representation for potential caching
     K_noisy = noisy_mvn.lazy_covariance_matrix.to_dense()
@@ -554,7 +672,7 @@ def _compute_loo_predictions(
     # K_inv_diag has shape ... x n, so after unsqueeze(-1) we get ... x n x 1
     # (the last dim is 1 because each GP is single-output).
     loo_variance = (1.0 / K_inv_diag).unsqueeze(-1)  # ... x n x 1
-    loo_mean = train_Y.unsqueeze(-1) - K_inv_residuals * loo_variance  # ... x n x 1
+    loo_mean = train_Y.unsqueeze(-1) - K_inv_residuals * loo_variance
 
     # If we want the posterior (noiseless) variance, subtract the noise
     if not observation_noise:
@@ -636,6 +754,7 @@ def _reshape_to_loo_cv_format(tensor: Tensor, num_outputs: int) -> Tensor:
 def ensemble_loo_cv(
     model: GPyTorchModel,
     observation_noise: bool = True,
+    untransform: bool = True,
 ) -> CVResults:
     r"""Compute efficient LOO cross-validation for ensemble models.
 
@@ -673,17 +792,27 @@ def ensemble_loo_cv(
             predictive variance (including observation noise). If False,
             return the posterior variance of the latent function (excluding
             observation noise).
+        untransform: If True (default), untransform the LOO predictions and
+            observed values back to the original outcome space when the model
+            has an outcome transform (e.g., ``Standardize``). This makes the
+            results consistent with ``model.posterior()`` and
+            ``batch_cross_validation``. If False, return results in the
+            model's internal (transformed) space.
 
     Returns:
         CVResults: A named tuple containing:
             - model: The fitted ensemble GP model.
             - posterior: A ``GaussianMixturePosterior`` with per-member shape
-              ``n x num_models x 1 x 1``. Access per-member statistics via
+              ``n x num_models x 1 x m``. Access per-member statistics via
               ``posterior.mean`` and ``posterior.variance``, and mixture
               statistics via ``posterior.mixture_mean`` and
               ``posterior.mixture_variance``.
-            - observed_Y: The observed Y values with shape ``n x 1 x 1``.
-            - observed_Yvar: The observed noise variances (if provided).
+            - observed_Y: The observed Y values with shape
+              ``n x num_models x 1 x m``, matching the posterior layout so
+              that element-wise operations (e.g., ``posterior.mean -
+              observed_Y``) work correctly.
+            - observed_Yvar: The observed noise variances (if provided) with
+              the same shape as ``observed_Y``.
 
     Example:
         >>> import torch
@@ -723,7 +852,7 @@ def ensemble_loo_cv(
         )
 
     # Get the number of outputs
-    num_outputs = getattr(model, "_num_outputs", 1)
+    num_outputs = model.num_outputs
 
     # Build the GaussianMixturePosterior
     posterior = _build_ensemble_loo_posterior(
@@ -734,6 +863,44 @@ def ensemble_loo_cv(
     observed_Y, observed_Yvar = _get_ensemble_observed_data(
         model=model, train_Y=train_Y, num_outputs=num_outputs
     )
+
+    # Untransform predictions and observed values back to original space
+    if untransform and hasattr(model, "outcome_transform"):
+        observed_Y_ndim = observed_Y.dim()
+        posterior, observed_Y, observed_Yvar = _untransform_loo_results(
+            model=model,
+            posterior=posterior,
+            observed_Y=observed_Y,
+            observed_Yvar=observed_Yvar,
+        )
+        # After untransform with a batch-shaped outcome transform (e.g.,
+        # Standardize(batch_shape=[num_models])), observed_Y gains leading
+        # batch dimensions from the transform. For example, with
+        # batch_shape=[num_models], observed_Y goes from [n, 1, m] to
+        # [num_models, n, 1, m]. The posterior has num_models at MCMC_DIM=-3,
+        # giving shape [n, num_models, 1, m]. Align observed_Y by moving all
+        # added leading dims to just before the q=1 dim (MCMC_DIM position).
+        n_added = observed_Y.dim() - observed_Y_ndim
+        if n_added > 1:
+            raise UnsupportedError(
+                "ensemble_loo_cv does not support outcome transforms that add "
+                f"more than 1 batch dimension. Got {n_added} added dimensions "
+                f"(shape went from {observed_Y_ndim}D to {observed_Y.dim()}D)."
+            )
+        if n_added == 1:
+            observed_Y = observed_Y.movedim(0, -3)
+            if observed_Yvar is not None:
+                observed_Yvar = observed_Yvar.movedim(0, -3)
+
+    # Ensure observed_Y has the num_models dimension at MCMC_DIM=-3 to match
+    # the posterior shape [n, num_models, 1, m]. Without this, element-wise
+    # operations like `posterior.mean - observed_Y` would fail due to
+    # incompatible broadcasting (3D [n, 1, m] vs 4D [n, num_models, 1, m]).
+    posterior_mean = posterior.mean
+    if observed_Y.dim() < posterior_mean.dim():
+        observed_Y = observed_Y.unsqueeze(-3).expand_as(posterior_mean)
+        if observed_Yvar is not None:
+            observed_Yvar = observed_Yvar.unsqueeze(-3).expand_as(posterior_mean)
 
     return CVResults(
         model=model,
@@ -867,7 +1034,7 @@ def _verify_ensemble_data_consistency(
     first_member = tensor.select(num_models_dim, 0)
     first_expanded = first_member.unsqueeze(num_models_dim).expand_as(tensor)
 
-    if not torch.allclose(tensor, first_expanded):
+    if not torch.equal(tensor, first_expanded):
         raise UnsupportedError(
             f"Ensemble members have different {tensor_name}. "
             "ensemble_loo_cv only supports ensembles where all members share the "

--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -35,6 +35,7 @@ from botorch.models.transforms.utils import (
 )
 from botorch.models.utils.assorted import get_task_value_remapping
 from botorch.posteriors import GPyTorchPosterior, Posterior, TransformedPosterior
+from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.utils.transforms import normalize_indices
 from linear_operator.operators import (
     CholLinearOperator,
@@ -440,8 +441,9 @@ class Standardize(OutcomeTransform):
 
         Returns:
             The un-standardized posterior. If the input posterior is a
-            ``GPyTorchPosterior``, return a ``GPyTorchPosterior``. Otherwise, return a
-            ``TransformedPosterior``.
+            ``GPyTorchPosterior`` or ``GaussianMixturePosterior``, return
+            the same type with analytically rescaled distribution. Otherwise,
+            return a ``TransformedPosterior``.
         """
         if self._outputs is not None:
             raise NotImplementedError(
@@ -455,7 +457,7 @@ class Standardize(OutcomeTransform):
                 "means and standard deviations need to be computed."
             )
         is_mtgp_posterior = False
-        if type(posterior) is GPyTorchPosterior:
+        if type(posterior) in (GPyTorchPosterior, GaussianMixturePosterior):
             is_mtgp_posterior = posterior._is_mt
         if not self._m == posterior._extended_shape()[-1] and not is_mtgp_posterior:
             raise RuntimeError(
@@ -464,7 +466,7 @@ class Standardize(OutcomeTransform):
                 f"{posterior._extended_shape()[-1]}."
             )
 
-        if type(posterior) is not GPyTorchPosterior:
+        if type(posterior) not in (GPyTorchPosterior, GaussianMixturePosterior):
             # fall back to TransformedPosterior
             # this applies to subclasses of GPyTorchPosterior like MultitaskGPPosterior
             return TransformedPosterior(
@@ -506,7 +508,7 @@ class Standardize(OutcomeTransform):
 
         kwargs = {"interleaved": mvn._interleaved} if posterior._is_mt else {}
         mvn_tf = mvn.__class__(mean=mean_tf, covariance_matrix=covar_tf, **kwargs)
-        return GPyTorchPosterior(mvn_tf)
+        return type(posterior)(mvn_tf)
 
 
 class StratifiedStandardize(Standardize):
@@ -721,8 +723,9 @@ class StratifiedStandardize(Standardize):
 
         Returns:
             The un-standardized posterior. If the input posterior is a
-            ``GPyTorchPosterior``, return a ``GPyTorchPosterior``. Otherwise, return a
-            ``TransformedPosterior``.
+            ``GPyTorchPosterior`` or ``GaussianMixturePosterior``, return
+            the same type with analytically rescaled distribution. Otherwise,
+            return a ``TransformedPosterior``.
         """
         if X is None:
             raise ValueError("X is required for StratifiedStandardize.")

--- a/test/models/transforms/test_outcome.py
+++ b/test/models/transforms/test_outcome.py
@@ -24,6 +24,7 @@ from botorch.models.transforms.utils import (
     norm_to_lognorm_variance,
 )
 from botorch.posteriors import GPyTorchPosterior, TransformedPosterior
+from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
 from gpytorch.settings import min_variance
@@ -354,6 +355,55 @@ class TestOutcomeTransforms(BotorchTestCase):
             # error on untransform_posterior
             with self.assertRaises(NotImplementedError):
                 tf.untransform_posterior(None)
+
+    def test_standardize_untransform_gaussian_mixture_posterior(self) -> None:
+        """Test Standardize.untransform_posterior with GaussianMixturePosterior.
+
+        Verifies that when a GaussianMixturePosterior (from ensemble/fully Bayesian
+        models) is passed to Standardize.untransform_posterior, the return type is
+        GaussianMixturePosterior (not TransformedPosterior), and mixture_mean/
+        mixture_variance are accessible and correctly rescaled.
+        """
+
+        # Create a batched MVN simulating MCMC samples: num_mcmc x n x 1
+        num_mcmc, n = 5, 10
+        mean = torch.randn(num_mcmc, n, 1)
+        var = torch.rand(num_mcmc, n, 1).clamp(min=0.01)
+        mvn = MultivariateNormal(
+            mean=mean.squeeze(-1),
+            covariance_matrix=DiagLinearOperator(var.squeeze(-1)),
+        )
+        gmp = GaussianMixturePosterior(distribution=mvn)
+
+        # Verify mixture stats are available before untransform
+        self.assertEqual(gmp.mixture_mean.shape, torch.Size([n, 1]))
+
+        # Fit a Standardize transform
+        Y = torch.randn(n, 1)
+        tf = Standardize(m=1)
+        tf.train()
+        tf(Y)
+        tf.eval()
+
+        # Untransform should preserve the GaussianMixturePosterior type
+        result = tf.untransform_posterior(gmp)
+        self.assertIsInstance(result, GaussianMixturePosterior)
+        self.assertNotIsInstance(result, TransformedPosterior)
+
+        # Per-member statistics should be accessible
+        self.assertEqual(result.mean.shape, torch.Size([num_mcmc, n, 1]))
+        self.assertEqual(result.variance.shape, torch.Size([num_mcmc, n, 1]))
+
+        # Mixture statistics should be accessible
+        self.assertEqual(result.mixture_mean.shape, torch.Size([n, 1]))
+        self.assertEqual(result.mixture_variance.shape, torch.Size([n, 1]))
+        self.assertTrue((result.mixture_variance > 0).all())
+
+        # Verify mean is correctly rescaled: result.mean ≈ stdvs * input.mean + means
+        expected_mean = tf.means.squeeze(-1) + tf.stdvs.squeeze(-1) * mean.squeeze(-1)
+        self.assertAllClose(
+            result.mean.squeeze(-1), expected_mean, rtol=1e-5, atol=1e-5
+        )
 
     def test_standardize_state_dict(self):
         for m in (1, 2):

--- a/test/test_cross_validation.py
+++ b/test/test_cross_validation.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import torch
 from botorch.cross_validation import (
+    _untransform_loo_results,
+    _verify_ensemble_data_consistency,
     batch_cross_validation,
     CVResults,
     efficient_loo_cv,
@@ -19,14 +21,23 @@ from botorch.cross_validation import (
 )
 from botorch.exceptions.errors import UnsupportedError
 from botorch.exceptions.warnings import OptimizationWarning
+from botorch.fit import fit_gpytorch_mll
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.multitask import MultiTaskGP
-from botorch.models.transforms.input import Normalize
-from botorch.models.transforms.outcome import Standardize
+from botorch.models.transforms.input import (
+    ChainedInputTransform,
+    InputTransform,
+    Normalize,
+)
+from botorch.models.transforms.outcome import Log, Standardize
 from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.posteriors.transformed import TransformedPosterior
 from botorch.utils.testing import BotorchTestCase, get_random_data
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from linear_operator.operators import DiagLinearOperator
 
 
 class TestFitBatchCrossValidation(BotorchTestCase):
@@ -155,7 +166,7 @@ class TestEfficientLOOCV(BotorchTestCase):
                 model = SingleTaskGP(train_X, train_Y)
                 model.eval()
 
-                loo_results = efficient_loo_cv(model)
+                loo_results = efficient_loo_cv(model, untransform=False)
 
                 # Output shape: batch_shape x n x 1 x m
                 expected_shape = batch_shape + torch.Size([n, 1, m])
@@ -217,7 +228,9 @@ class TestEfficientLOOCV(BotorchTestCase):
                 model.eval()
 
                 # Compare efficient vs naive
-                loo_results = efficient_loo_cv(model, observation_noise=obs_noise)
+                loo_results = efficient_loo_cv(
+                    model, observation_noise=obs_noise, untransform=False
+                )
                 naive_mean, naive_var = naive_loo_cv(
                     model, observation_noise=obs_noise, batch_shape=batch_shape
                 )
@@ -236,8 +249,6 @@ class TestEfficientLOOCV(BotorchTestCase):
                     self.assertEqual(
                         loo_results.observed_Yvar.shape,
                         expected_shape,
-                        f"observed_Yvar shape mismatch: got "
-                        f"{loo_results.observed_Yvar.shape}, expected {expected_shape}",
                     )
                 else:
                     self.assertIsNone(loo_results.observed_Yvar)
@@ -315,6 +326,214 @@ class TestEfficientLOOCV(BotorchTestCase):
         ):
             efficient_loo_cv(model)
 
+    def test_untransform(self) -> None:
+        """Test that untransform correctly maps results to original space.
+
+        Verifies that:
+        - untransform=True (default) returns results in the original outcome space
+        - untransform=False returns results in the model's internal (transformed) space
+        - The untransformed observed_Y matches the original training data
+        - The untransformed posterior mean is in the same space as the original data
+        - Without outcome_transform, untransform=True has no effect
+        """
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        n, d = 10, 2
+
+        for m in (1, 3):
+            with self.subTest(m=m):
+                train_X, train_Y = get_random_data(
+                    batch_shape=torch.Size(), m=m, n=n, d=d, **tkwargs
+                )
+
+                model = SingleTaskGP(
+                    train_X,
+                    train_Y,
+                    input_transform=Normalize(d=d),
+                    outcome_transform=Standardize(m=m),
+                )
+                model.eval()
+
+                # Get results in both spaces
+                results_original = efficient_loo_cv(model, untransform=True)
+                results_transformed = efficient_loo_cv(model, untransform=False)
+
+                # Shapes should be the same
+                expected_shape = torch.Size([n, 1, m])
+                self.assertEqual(results_original.posterior.mean.shape, expected_shape)
+                self.assertEqual(
+                    results_transformed.posterior.mean.shape, expected_shape
+                )
+
+                # The observed_Y with untransform=True should match original train_Y
+                self.assertAllClose(
+                    results_original.observed_Y.squeeze(-2),
+                    train_Y,
+                    rtol=1e-5,
+                    atol=1e-5,
+                )
+
+                # The observed_Y with untransform=False should be standardized
+                # (mean ~0, std ~1), so it should differ from the original data
+                # unless the data happens to already be standardized
+                transformed_Y = results_transformed.observed_Y.squeeze(-2)
+                # Verify it's standardized (approximately zero mean, unit variance)
+                self.assertAllClose(
+                    transformed_Y.mean(dim=-2),
+                    torch.zeros(m, **tkwargs),
+                    atol=0.5,  # loose check, small n
+                )
+
+                # The means should differ between transformed and untransformed space
+                # (unless Standardize is a no-op, which is unlikely for random data)
+                self.assertFalse(
+                    torch.allclose(
+                        results_original.posterior.mean,
+                        results_transformed.posterior.mean,
+                    )
+                )
+
+                # Variances should also differ (scaled by std^2)
+                self.assertFalse(
+                    torch.allclose(
+                        results_original.posterior.variance,
+                        results_transformed.posterior.variance,
+                    )
+                )
+
+        # Test with nonlinear Log transform → TransformedPosterior
+
+        train_X_log, train_Y_log = get_random_data(
+            batch_shape=torch.Size(), m=1, n=10, d=2, **tkwargs
+        )
+        # Log transform requires positive Y
+        train_Y_log = train_Y_log.abs() + 0.1
+
+        model_log = SingleTaskGP(
+            train_X_log,
+            train_Y_log,
+            outcome_transform=Log(),
+        )
+        model_log.eval()
+
+        results_log = efficient_loo_cv(model_log, untransform=True)
+        self.assertIsInstance(results_log.posterior, TransformedPosterior)
+        self.assertEqual(results_log.posterior.mean.shape, torch.Size([10, 1, 1]))
+
+        # Verify log-normal transform values against the exact formulas:
+        # E[Y] = exp(mu + sigma^2/2), Var[Y] = expm1(sigma^2) * exp(2*mu + sigma^2)
+        results_tf = efficient_loo_cv(model_log, untransform=False)
+        mu = results_tf.posterior.mean  # in log-space
+        var = results_tf.posterior.variance  # in log-space
+        expected_mean = torch.exp(mu + 0.5 * var)
+        expected_var = torch.special.expm1(var) * torch.exp(2 * mu + var)
+        self.assertAllClose(results_log.posterior.mean, expected_mean, rtol=1e-5)
+        self.assertAllClose(results_log.posterior.variance, expected_var, rtol=1e-5)
+
+        # observed_Y should be exp(log_Y) = original Y
+        self.assertAllClose(
+            results_log.observed_Y.squeeze(-2),
+            train_Y_log,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+    def test_untransform_no_transform(self) -> None:
+        """Test that untransform=True is a no-op when no outcome_transform exists."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        n, d, m = 10, 2, 1
+
+        train_X, train_Y = get_random_data(
+            batch_shape=torch.Size(), m=m, n=n, d=d, **tkwargs
+        )
+        model = SingleTaskGP(train_X, train_Y, outcome_transform=None)
+        model.eval()
+
+        results_true = efficient_loo_cv(model, untransform=True)
+        results_false = efficient_loo_cv(model, untransform=False)
+
+        self.assertAllClose(results_true.posterior.mean, results_false.posterior.mean)
+        self.assertAllClose(
+            results_true.posterior.variance, results_false.posterior.variance
+        )
+        self.assertAllClose(results_true.observed_Y, results_false.observed_Y)
+
+    def test_untransform_with_fixed_noise(self) -> None:
+        """Test that observed_Yvar is correctly untransformed."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        n, d, m = 10, 2, 1
+
+        train_X, train_Y = get_random_data(
+            batch_shape=torch.Size(), m=m, n=n, d=d, **tkwargs
+        )
+        train_Yvar = torch.full_like(train_Y, 5e-3)
+
+        model = SingleTaskGP(
+            train_X,
+            train_Y,
+            train_Yvar,
+            outcome_transform=Standardize(m=m),
+        )
+        model.eval()
+
+        results = efficient_loo_cv(model, untransform=True)
+        self.assertIsNotNone(results.observed_Yvar)
+
+        results_tf = efficient_loo_cv(model, untransform=False)
+        self.assertIsNotNone(results_tf.observed_Yvar)
+
+        # Untransformed Yvar should differ from transformed (scaled by std^2)
+        self.assertFalse(
+            torch.allclose(results.observed_Yvar, results_tf.observed_Yvar)
+        )
+
+    def test_chained_input_transform(self) -> None:
+        """Test efficient_loo_cv with dimension-changing ChainedInputTransform.
+
+        Verifies the fix for the bug where passing model.train_inputs (pre-transform)
+        to the likelihood caused shape mismatches when an input transform changes
+        the feature dimensionality (e.g., appending derived features d -> d+1).
+        """
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        n, d = 10, 3
+
+        train_X, train_Y = get_random_data(
+            batch_shape=torch.Size(), m=1, n=n, d=d, **tkwargs
+        )
+
+        # Custom transform that appends a derived feature (d -> d+1)
+        class AppendDerived(InputTransform, torch.nn.Module):
+            is_one_to_many = False
+
+            def __init__(self):
+                super().__init__()
+                self.transform_on_train = True
+                self.transform_on_eval = True
+                self.transform_on_fantasize = True
+
+            def transform(self, X):
+                return torch.cat([X, X[..., 0:1] * X[..., 1:2]], dim=-1)
+
+        input_tf = ChainedInputTransform(
+            append=AppendDerived(),
+            normalize=Normalize(d=d + 1),
+        )
+
+        model = SingleTaskGP(
+            train_X,
+            train_Y,
+            input_transform=input_tf,
+            outcome_transform=Standardize(m=1),
+        )
+        model.eval()
+
+        # This should not raise a shape mismatch error
+        loo_results = efficient_loo_cv(model, untransform=False)
+
+        expected_shape = torch.Size([n, 1, 1])
+        self.assertEqual(loo_results.posterior.mean.shape, expected_shape)
+        self.assertEqual(loo_results.posterior.variance.shape, expected_shape)
+        self.assertTrue((loo_results.posterior.variance > 0).all())
+
 
 class TestLOOCV(BotorchTestCase):
     """Test the high-level loo_cv dispatch function."""
@@ -350,7 +569,7 @@ class TestLOOCV(BotorchTestCase):
 
                     # Verify correct function was called with the model
                     mock_func.assert_called_once_with(
-                        mock_model, observation_noise=True
+                        mock_model, observation_noise=True, untransform=True
                     )
                     self.assertIs(result, mock_results)
 
@@ -396,8 +615,11 @@ class TestEnsembleLOOCV(BotorchTestCase):
                 self.assertEqual(mixture_mean.shape, torch.Size([n, 1, m]))
                 self.assertEqual(mixture_var.shape, torch.Size([n, 1, m]))
 
-                # Check observed_Y shape (ensemble dim removed)
-                self.assertEqual(loo_results.observed_Y.shape, torch.Size([n, 1, m]))
+                # Check observed_Y shape (has num_models at MCMC_DIM=-3)
+                self.assertEqual(
+                    loo_results.observed_Y.shape,
+                    torch.Size([n, num_models, 1, m]),
+                )
 
                 # Check that variances are positive
                 self.assertTrue((mixture_var > 0).all())
@@ -441,9 +663,122 @@ class TestEnsembleLOOCV(BotorchTestCase):
                 )
                 self.assertTrue((loo_results_no_noise.posterior.variance >= 0).all())
 
+    def test_untransform(self) -> None:
+        """Test that untransform works for ensemble models with outcome transforms.
+
+        Exercises the untransform branch in ensemble_loo_cv. When the model
+        has an outcome_transform and untransform=True, the posterior and
+        observed_Y should be mapped back to the original outcome space.
+
+        Standardize.untransform_posterior now preserves the GaussianMixturePosterior
+        type, so mixture_mean and mixture_variance remain accessible.
+        """
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        n, d, num_models = 8, 2, 3
+
+        for m in (1, 2):
+            with self.subTest(m=m):
+                train_X = torch.rand(n, d, **tkwargs)
+                train_Y = torch.rand(n, m, **tkwargs)
+
+                # Create ensemble model WITH Standardize outcome_transform
+                train_X_batched = (
+                    train_X.unsqueeze(0).expand(num_models, -1, -1).contiguous()
+                )
+                train_Y_batched = (
+                    train_Y.unsqueeze(0).expand(num_models, -1, -1).contiguous()
+                )
+                ensemble_model = SingleTaskGP(
+                    train_X_batched,
+                    train_Y_batched,
+                    outcome_transform=Standardize(
+                        m=m, batch_shape=torch.Size([num_models])
+                    ),
+                )
+                ensemble_model._is_ensemble = True
+
+                per_member_shape = torch.Size([n, num_models, 1, m])
+                mixture_shape = torch.Size([n, 1, m])
+
+                # untransform=True: exercises _untransform_loo_results + movedim
+                results_utf = ensemble_loo_cv(ensemble_model, untransform=True)
+                self.assertIsInstance(results_utf.posterior, GaussianMixturePosterior)
+                self.assertEqual(results_utf.posterior.mean.shape, per_member_shape)
+                self.assertEqual(results_utf.posterior.variance.shape, per_member_shape)
+                self.assertEqual(
+                    results_utf.posterior.mixture_mean.shape, mixture_shape
+                )
+                self.assertEqual(
+                    results_utf.posterior.mixture_variance.shape, mixture_shape
+                )
+                self.assertTrue((results_utf.posterior.mixture_variance > 0).all())
+
+                # untransform=False: exercises expand_as fallback
+                results_tf = ensemble_loo_cv(ensemble_model, untransform=False)
+                self.assertIsInstance(results_tf.posterior, GaussianMixturePosterior)
+
+                # observed_Y shape should match posterior for both cases
+                self.assertEqual(results_utf.observed_Y.shape, per_member_shape)
+                self.assertEqual(results_tf.observed_Y.shape, per_member_shape)
+
+                # Element-wise posterior.mean - observed_Y must work
+                residuals_utf = results_utf.posterior.mean - results_utf.observed_Y
+                self.assertEqual(residuals_utf.shape, per_member_shape)
+                residuals_tf = results_tf.posterior.mean - results_tf.observed_Y
+                self.assertEqual(residuals_tf.shape, per_member_shape)
+
+                # observed_Y should differ between transformed and untransformed
+                self.assertFalse(
+                    torch.allclose(results_utf.observed_Y, results_tf.observed_Y)
+                )
+
+                # Untransformed observed_Y should recover the original training
+                # data. All ensemble members share the same data.
+                self.assertAllClose(
+                    results_utf.observed_Y.select(-3, 0).squeeze(-2),
+                    train_Y,
+                    rtol=1e-5,
+                    atol=1e-5,
+                )
+
+                # Test observation_noise=False + untransform=True + active transform
+                results_no_noise = ensemble_loo_cv(
+                    ensemble_model, observation_noise=False, untransform=True
+                )
+                self.assertIsInstance(
+                    results_no_noise.posterior, GaussianMixturePosterior
+                )
+                self.assertEqual(
+                    results_no_noise.posterior.mean.shape, per_member_shape
+                )
+                self.assertEqual(results_no_noise.observed_Y.shape, per_member_shape)
+                self.assertTrue(
+                    (
+                        results_no_noise.posterior.variance
+                        <= results_utf.posterior.variance + 1e-6
+                    ).all()
+                )
+
+                # Test FixedNoiseGaussianLikelihood + outcome_transform + untransform
+                train_Yvar = torch.full_like(train_Y, 5e-3)
+                train_Yvar_batched = (
+                    train_Yvar.unsqueeze(0).expand(num_models, -1, -1).contiguous()
+                )
+                ensemble_fixed = SingleTaskGP(
+                    train_X_batched,
+                    train_Y_batched,
+                    train_Yvar_batched,
+                    outcome_transform=Standardize(
+                        m=m, batch_shape=torch.Size([num_models])
+                    ),
+                )
+                ensemble_fixed._is_ensemble = True
+                results_fixed = ensemble_loo_cv(ensemble_fixed, untransform=True)
+                self.assertIsNotNone(results_fixed.observed_Yvar)
+                self.assertEqual(results_fixed.observed_Yvar.shape, per_member_shape)
+
     def test_matches_naive(self) -> None:
         """Test that ensemble_loo_cv matches naive per-model LOO CV."""
-        from botorch.fit import fit_gpytorch_mll
 
         tkwargs = {"device": self.device, "dtype": torch.double}
         n, d, num_models = 6, 2, 3
@@ -487,7 +822,7 @@ class TestEnsembleLOOCV(BotorchTestCase):
 
                 # Get ensemble LOO CV results
                 loo_results = ensemble_loo_cv(
-                    ensemble_model, observation_noise=obs_noise
+                    ensemble_model, observation_noise=obs_noise, untransform=False
                 )
                 ensemble_mean = loo_results.posterior.mean
                 ensemble_var = loo_results.posterior.variance
@@ -573,16 +908,18 @@ class TestEnsembleLOOCV(BotorchTestCase):
                 )
 
                 # Verify observed_Y and observed_Yvar shapes
-                expected_shape = batch_shape + torch.Size([n, 1, m])
-                self.assertEqual(loo_results.observed_Y.shape, expected_shape)
+                # observed_Y has num_models at MCMC_DIM=-3
+                expected_obs_shape = batch_shape + torch.Size([n, num_models, 1, m])
+                self.assertEqual(loo_results.observed_Y.shape, expected_obs_shape)
 
                 if use_fixed_noise:
                     self.assertIsNotNone(loo_results.observed_Yvar)
                     self.assertEqual(
                         loo_results.observed_Yvar.shape,
-                        expected_shape,
-                        f"observed_Yvar shape mismatch: got "
-                        f"{loo_results.observed_Yvar.shape}, expected {expected_shape}",
+                        expected_obs_shape,
+                        "observed_Yvar shape mismatch: got "
+                        f"{loo_results.observed_Yvar.shape}, "
+                        f"expected {expected_obs_shape}",
                     )
                 else:
                     self.assertIsNone(loo_results.observed_Yvar)
@@ -594,7 +931,6 @@ class TestEnsembleLOOCV(BotorchTestCase):
         Multi-output models always have 2D+ noise, so this only applies to m=1.
         The normal 2D noise case is covered by test_matches_naive.
         """
-        from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
 
         tkwargs = {"device": self.device, "dtype": torch.double}
         n, d, num_models = 10, 2, 5
@@ -616,14 +952,17 @@ class TestEnsembleLOOCV(BotorchTestCase):
 
         loo_results = ensemble_loo_cv(ensemble_model)
 
-        # observed_Yvar should have shape n x 1 x 1
+        # observed_Yvar should have shape n x num_models x 1 x 1
         self.assertIsNotNone(loo_results.observed_Yvar)
-        self.assertEqual(loo_results.observed_Yvar.shape, torch.Size([n, 1, 1]))
+        self.assertEqual(
+            loo_results.observed_Yvar.shape,
+            torch.Size([n, num_models, 1, 1]),
+        )
         # All values should be 0.01
         self.assertTrue(
             torch.allclose(
                 loo_results.observed_Yvar,
-                torch.full((n, 1, 1), 0.01, **tkwargs),
+                torch.full((n, num_models, 1, 1), 0.01, **tkwargs),
             )
         )
 
@@ -649,8 +988,6 @@ class TestEnsembleLOOCV(BotorchTestCase):
         model._is_ensemble = True
 
         # Create a mock posterior with 2D results (not 4D as expected for ensembles)
-        from gpytorch.distributions import MultivariateNormal
-        from linear_operator.operators import DiagLinearOperator
 
         mock_mean = torch.rand(n, 1, **tkwargs)
         mock_var = torch.rand(n, 1, **tkwargs)
@@ -674,8 +1011,6 @@ class TestEnsembleLOOCV(BotorchTestCase):
                 ensemble_loo_cv(model)
 
         # Test 3: Inconsistent ensemble data should raise error
-        from botorch.cross_validation import _verify_ensemble_data_consistency
-
         num_models, n, m = 3, 5, 2
         # Test different configurations: (shape, num_models_dim, tensor_name)
         test_configs = [
@@ -708,6 +1043,60 @@ class TestEnsembleLOOCV(BotorchTestCase):
         single_model_data = torch.randn(1, n, **tkwargs)
         _verify_ensemble_data_consistency(single_model_data, -2, "train_Y")
 
+        # Test _untransform_loo_results raises ValueError when shape[-2] != 1
+        bad_Y = torch.randn(n, 2, 1, **tkwargs)  # shape[-2] = 2, not 1
+        mock_post = GPyTorchPosterior(
+            MultivariateNormal(torch.zeros(n), DiagLinearOperator(torch.ones(n)))
+        )
+        model_for_err = SingleTaskGP(
+            train_X, train_Y, outcome_transform=Standardize(m=1)
+        )
+        model_for_err.eval()
+        with self.assertRaisesRegex(
+            ValueError, "Expected observed_Y to have size 1 at dim -2"
+        ):
+            _untransform_loo_results(
+                model=model_for_err,
+                posterior=mock_post,
+                observed_Y=bad_Y,
+                observed_Yvar=None,
+            )
+
+        # Test UnsupportedError for n_added > 1 in ensemble untransform.
+        # We simulate this by mocking _untransform_loo_results to return a
+        # tensor with 2 extra leading dims (as if a 2D batch_shape transform).
+        n_ens, num_models_ens = 8, 3
+        train_X_ens = torch.rand(n_ens, d, **tkwargs)
+        train_Y_ens = torch.rand(n_ens, 1, **tkwargs)
+        tx = train_X_ens.unsqueeze(0).expand(num_models_ens, -1, -1).contiguous()
+        ty = train_Y_ens.unsqueeze(0).expand(num_models_ens, -1, -1).contiguous()
+        ens_model = SingleTaskGP(
+            tx,
+            ty,
+            outcome_transform=Standardize(
+                m=1, batch_shape=torch.Size([num_models_ens])
+            ),
+        )
+        ens_model._is_ensemble = True
+
+        def mock_untransform(**kwargs):
+            # Simulate 2 extra dims added by a hypothetical 2D batch_shape
+            return (
+                kwargs["posterior"],
+                kwargs["observed_Y"].unsqueeze(0).unsqueeze(0),  # adds 2 leading dims
+                None,
+            )
+
+        with patch(
+            "botorch.cross_validation._untransform_loo_results",
+            side_effect=mock_untransform,
+        ):
+            with self.assertRaisesRegex(
+                UnsupportedError,
+                "does not support outcome transforms that add more than 1",
+            ):
+                ensemble_loo_cv(ens_model, untransform=True)
+
 
 _EMPTY_BATCH_SHAPE: torch.Size = torch.Size()
 
@@ -732,8 +1121,6 @@ def naive_loo_cv(
     Returns:
         A tuple of (loo_means, loo_variances) with shape ``batch_shape x n x m``.
     """
-    from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
-
     fitted_model.eval()
     train_X = fitted_model.train_inputs[0]
     train_Y = fitted_model.train_targets


### PR DESCRIPTION
Summary:

Previously, efficient_loo_cv, loo_cv, and ensemble_loo_cv always returned
results in the model's internal (transformed) space. This was inconsistent
with model.posterior() and batch_cross_validation, which automatically
untransform predictions via outcome_transform.untransform_posterior().

This adds an untransform parameter (default True) to all three LOO CV
functions, so results are returned in the original outcome space by default.
When the model has an outcome transform (e.g. Standardize), the LOO
posterior and observed values are mapped back to the original space. The
untransform=False escape hatch preserves access to the internal space for
users who need it.

Safety analysis:
- For Standardize (most common case), the untransform is an exact analytical
  rescaling of the mean and covariance — no approximation involved.
- For Log transforms, the untransform uses the exact log-normal mean
  (exp(mu + sigma^2/2)) and variance formulas, not naive exp(mu).
- The only production consumer is Ax (ax/adapter/cross_validation.py), which
  performs its own Ax-level untransform chain on top. Because Ax's Standardize
  and botorch's Standardize on already-standardized data were approximately a
  no-op, the old behavior was approximately correct. With this change, botorch
  now correctly maps from internal space to Ax model space before Ax applies
  its own transforms, making the pipeline more correct with negligible numerical
  differences. No double-untransform risk exists because botorch and Ax
  untransforms operate at different abstraction levels (tensors vs Observation
  objects).

Reviewed By: esantorella

Differential Revision: D102340841


