### PR TITLE
Fix device mismatch issue in `test_learned_feature_imputation` (#3289)

### DIFF
--- a/test/models/transforms/test_input.py
+++ b/test/models/transforms/test_input.py
@@ -1891,7 +1891,7 @@ class TestInputTransforms(BotorchTestCase):
                 self.assertTrue(
                     torch.equal(
                         tf._task_values,
-                        torch.tensor([5, 12], dtype=torch.long),
+                        torch.tensor([5, 12], dtype=torch.long, device=self.device),
                     )
                 )
                 tf.raw_imputation_values.data = torch.tensor(


### PR DESCRIPTION
Summary:

This is failling due to tensors on different devices

Reviewed By: hvarfner

Differential Revision: D102351043


