### PR TITLE
Make JAX/numpyro imports lazy in fully Bayesian models (#3292)

### DIFF
--- a/botorch/__init__.py
+++ b/botorch/__init__.py
@@ -16,7 +16,7 @@ from botorch import (
     test_functions,
 )
 from botorch.cross_validation import batch_cross_validation
-from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_mll
+from botorch.fit import fit_gpytorch_mll
 from botorch.generation.gen import (
     gen_candidates_scipy,
     gen_candidates_torch,
@@ -53,7 +53,6 @@ __all__ = [
     "acquisition",
     "batch_cross_validation",
     "exceptions",
-    "fit_fully_bayesian_model_nuts",
     "fit_gpytorch_mll",
     "gen_candidates_scipy",
     "gen_candidates_torch",

--- a/botorch/fit.py
+++ b/botorch/fit.py
@@ -12,16 +12,17 @@ from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
 from itertools import filterfalse
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from warnings import catch_warnings, simplefilter, warn_explicit, WarningMessage
 
-import jax
+if TYPE_CHECKING:
+    from botorch.models.fully_bayesian import AbstractFullyBayesianSingleTaskGP
+    from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
+
 from botorch.exceptions.errors import ModelFittingError, UnsupportedError
 from botorch.exceptions.warnings import OptimizationWarning
 from botorch.logging import logger
 from botorch.models import SingleTaskGP
-from botorch.models.fully_bayesian import AbstractFullyBayesianSingleTaskGP
-from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.map_saas import get_map_saas_model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.transforms.input import InputTransform
@@ -44,7 +45,6 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 from linear_operator.utils.errors import NotPSDError
-from numpyro.infer import MCMC, NUTS
 from torch import device, Tensor
 from torch.nn import Parameter
 from torch.utils.data import DataLoader
@@ -367,6 +367,11 @@ def fit_fully_bayesian_model_nuts(
         >>> gp = SaasFullyBayesianSingleTaskGP(train_X, train_Y)
         >>> fit_fully_bayesian_model_nuts(gp)
     """
+    # Local import to avoid pulling in JAX/numpyro at module level,
+    # which would break environments without NumPy >= 2.0.
+    import jax
+    from numpyro.infer import MCMC, NUTS
+
     model.train()
 
     # Do inference with NUTS

--- a/botorch/models/__init__.py
+++ b/botorch/models/__init__.py
@@ -14,8 +14,6 @@ from botorch.models.deterministic import (
     GenericDeterministicModel,
     PosteriorMeanModel,
 )
-from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
-from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
@@ -47,8 +45,6 @@ __all__ = [
     "PairwiseGP",
     "PairwiseLaplaceMarginalLogLikelihood",
     "PosteriorMeanModel",
-    "SaasFullyBayesianMultiTaskGP",
-    "SaasFullyBayesianSingleTaskGP",
     "SingleTaskGP",
     "SingleTaskMultiFidelityGP",
     "SingleTaskVariationalGP",

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -38,20 +38,17 @@ from collections.abc import Mapping
 from math import log, sqrt
 from typing import Any, TypeVar
 
-import jax.numpy as jnp
 import numpy as np
 
-if np.lib.NumpyVersion(np.__version__) < "2.0.0":
-    raise ImportError(
-        "BoTorch's fully Bayesian models require NumPy >= 2.0 "
-        "(python-scientific-stack version 3). "
-        "Please update your PACKAGE file to set "
-        '"python-scientific-stack": "3".'
-    )
+try:
+    import jax
+    import jax.numpy as jnp
+    import numpyro
+    import numpyro.distributions as numpyro_dist
 
-import jax
-import numpyro
-import numpyro.distributions as numpyro_dist
+    _HAS_JAX = True
+except ImportError:  # pragma: no cover
+    _HAS_JAX = False
 import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel
@@ -88,6 +85,16 @@ TFullyBayesianSingleTaskGP = TypeVar(
 )
 
 _sqrt5 = math.sqrt(5)
+
+
+def _check_jax_available() -> None:
+    if not _HAS_JAX:
+        raise ImportError(
+            "BoTorch's fully Bayesian models require JAX, numpyro, and "
+            "NumPy >= 2.0 (python-scientific-stack version 3). "
+            "Please update your PACKAGE file to set "
+            '"python-scientific-stack": "3".'
+        )
 
 
 def matern52_kernel(X: jax.Array, lengthscale: jax.Array) -> jax.Array:
@@ -872,6 +879,7 @@ class AbstractFullyBayesianSingleTaskGP(ExactGP, BatchedMultiOutputGPyTorchModel
             indices_to_warp: An optional list of indices to warp. The default
                 is to warp all inputs.
         """
+        _check_jax_available()
         if not (
             train_X.ndim == train_Y.ndim == 2
             and len(train_X) == len(train_Y)

--- a/botorch/models/fully_bayesian_multitask.py
+++ b/botorch/models/fully_bayesian_multitask.py
@@ -11,18 +11,22 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, NoReturn, TypeVar
 
-import jax.numpy as jnp
-import numpyro
-import numpyro.distributions as numpyro_dist
 import torch
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.fully_bayesian import (
+    _check_jax_available,
+    _HAS_JAX,
     matern52_kernel,
     MCMC_DIM,
     MIN_INFERRED_NOISE_LEVEL,
     reshape_and_detach,
     SaasPyroModel,
 )
+
+if _HAS_JAX:
+    import jax.numpy as jnp
+    import numpyro
+    import numpyro.distributions as numpyro_dist
 from botorch.models.gpytorch import (
     BatchedMultiOutputGPyTorchModel,
     MultiTaskGPyTorchModel,
@@ -353,6 +357,7 @@ class SaasFullyBayesianMultiTaskGP(MultiTaskGP):
                 input are expected tasks values. If false, unexpected task values
                 will be mapped to the first output_task if supplied.
         """
+        _check_jax_available()
         if not (
             train_X.ndim == train_Y.ndim == 2
             and len(train_X) == len(train_Y)

--- a/botorch/posteriors/__init__.py
+++ b/botorch/posteriors/__init__.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.higher_order import HigherOrderGPPosterior
 from botorch.posteriors.multitask import MultitaskGPPosterior
@@ -14,7 +13,6 @@ from botorch.posteriors.torch import TorchPosterior
 from botorch.posteriors.transformed import TransformedPosterior
 
 __all__ = [
-    "GaussianMixturePosterior",
     "GPyTorchPosterior",
     "HigherOrderGPPosterior",
     "MultitaskGPPosterior",

--- a/test/acquisition/test_input_constructors.py
+++ b/test/acquisition/test_input_constructors.py
@@ -111,8 +111,9 @@ from botorch.acquisition.utils import (
     project_to_target_fidelity,
 )
 from botorch.exceptions.errors import BotorchError, UnsupportedError
-from botorch.models import MultiTaskGP, SaasFullyBayesianSingleTaskGP, SingleTaskGP
+from botorch.models import MultiTaskGP, SingleTaskGP
 from botorch.models.deterministic import FixedSingleSampleModel
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.optim.optimize import optimize_acqf
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -1284,20 +1284,16 @@ class TestFullyBayesianLinearWarpingSingleTaskGP(TestFullyBayesianLinearSingleTa
 
 
 class TestNumpyVersionCheck(BotorchTestCase):
-    def test_old_numpy_raises_import_error(self) -> None:
-        """Test that importing fully_bayesian with NumPy < 2.0 raises ImportError."""
-        import importlib
-        import sys
+    def test_missing_jax_raises_on_instantiation(self) -> None:
+        """Test that missing JAX raises ImportError at model instantiation."""
+        from botorch.models import fully_bayesian
+        from botorch.models.fully_bayesian import _check_jax_available
 
-        from numpy.lib import NumpyVersion
-
-        with patch.object(NumpyVersion, "__lt__", return_value=True):
-            # Remove cached module so the version check re-runs on import.
-            mod_name = "botorch.models.fully_bayesian"
-            saved = sys.modules.pop(mod_name)
-            try:
-                with self.assertRaises(ImportError):
-                    importlib.import_module(mod_name)
-            finally:
-                # Restore the module so other tests are not affected.
-                sys.modules[mod_name] = saved
+        with patch.object(fully_bayesian, "_HAS_JAX", False):
+            with self.assertRaises(ImportError):
+                _check_jax_available()
+            with self.assertRaises(ImportError):
+                SaasFullyBayesianSingleTaskGP(
+                    train_X=torch.rand(10, 2),
+                    train_Y=torch.rand(10, 1),
+                )

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import jax.numpy as jnp
 import numpyro
 import torch
-from botorch import fit_fully_bayesian_model_nuts, utils
+from botorch import utils
 from botorch.acquisition.analytic import (
     ExpectedImprovement,
     PosteriorMean,
@@ -41,6 +41,7 @@ from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
 )
 from botorch.acquisition.utils import prune_inferior_points
+from botorch.fit import fit_fully_bayesian_model_nuts
 from botorch.models import ModelList, ModelListGP
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.fully_bayesian import (

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -10,7 +10,6 @@ import itertools
 import jax.numpy as jnp
 import numpyro.handlers
 import torch
-from botorch import fit_fully_bayesian_model_nuts
 from botorch.acquisition.analytic import (
     LogExpectedImprovement,
     PosteriorMean,
@@ -30,6 +29,7 @@ from botorch.acquisition.multi_objective.logei import (
     qLogExpectedHypervolumeImprovement,
     qLogNoisyExpectedHypervolumeImprovement,
 )
+from botorch.fit import fit_fully_bayesian_model_nuts
 from botorch.models import ModelList, ModelListGP
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.fully_bayesian import (
@@ -48,7 +48,7 @@ from botorch.models.fully_bayesian_multitask import (
 )
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
-from botorch.posteriors import GaussianMixturePosterior
+from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.sampling.get_sampler import get_sampler
 from botorch.sampling.normal import IIDNormalSampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (

--- a/test/models/test_fully_bayesian_multitask.py
+++ b/test/models/test_fully_bayesian_multitask.py
@@ -6,6 +6,7 @@
 
 
 import itertools
+from unittest.mock import patch
 
 import jax.numpy as jnp
 import numpyro.handlers
@@ -181,6 +182,21 @@ class TestFullyBayesianMultiTaskGP(BotorchTestCase):
             ),
         }
         return mcmc_samples
+
+    def test_missing_jax_raises_on_instantiation(self) -> None:
+        """Test that missing JAX raises ImportError at model instantiation."""
+        from botorch.models import fully_bayesian
+
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        train_X, train_Y, train_Yvar = self._get_base_data(**tkwargs)
+        with patch.object(fully_bayesian, "_HAS_JAX", False):
+            with self.assertRaises(ImportError):
+                SaasFullyBayesianMultiTaskGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    task_feature=4,
+                )
 
     def test_raises(self):
         tkwargs = {"device": self.device, "dtype": torch.double}

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -14,9 +14,9 @@ from botorch.models import (
     HigherOrderGP,
     ModelList,
     PairwiseGP,
-    SaasFullyBayesianSingleTaskGP,
     SingleTaskGP,
 )
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP

--- a/tutorials/saasbo/saasbo.ipynb
+++ b/tutorials/saasbo/saasbo.ipynb
@@ -1,1248 +1,1248 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "26affedc",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "501041cc-0473-4971-bff9-fd6e92e1eae4",
-        "papermill": {
-          "duration": 0.004313,
-          "end_time": "2026-01-08T16:43:17.656542",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:17.652229",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "## High-Dimensional sample-efficient Bayesian Optimization with SAASBO\n",
-        "\n",
-        "This tutorial shows how to use the Sparse Axis-Aligned Subspace Bayesian Optimization (SAASBO) \n",
-        "method for high-dimensional Bayesian optimization [1]. SAASBO places strong priors on the \n",
-        "inverse lengthscales to avoid overfitting in high-dimensional spaces. Specifically, SAASBO \n",
-        "uses a hierarchical sparsity prior consisting of a global shrinkage parameter \n",
-        "$\\tau \\sim \\mathcal{HC}(\\beta)$ and inverse lengthscales $\\rho_d \\sim \\mathcal{HC}(\\tau)$ \n",
-        "for $d=1, \\ldots, D$, where $\\mathcal{HC}$ is the half-Cauchy distribution. \n",
-        "While half-Cauchy priors favor values near zero they also have heavy tails, which allows the \n",
-        "inverse lengthscales of the most important parameters to escape zero. To perform inference in the \n",
-        "SAAS model we use Hamiltonian Monte Carlo (HMC) as we found that to outperform MAP inference.\n",
-        "\n",
-        "We find that SAASBO performs well on problems with hundreds of dimensions. As we rely on HMC \n",
-        "and in particular the No-U-Turn-Sampler (NUTS) for inference, the overhead of SAASBO scales \n",
-        "cubically with the number of datapoints. Depending on the problem, using more than a few hundred\n",
-        "evaluations may not be feasible as SAASBO is designed for problems with a limited evaluation budget.\n",
-        "\n",
-        "In general, we recommend using [Ax](https://ax.dev) for a simple BO setup like this one. See [here](https://ax.dev/docs/tutorials/saasbo.html) for a SAASBO tutorial in Ax, which uses the Log Noisy Expected Improvement acquisition function. Therefore, this tutorial shows a minimal illustrative example of how to use SAASBO with only BoTorch. To customize the acquisition function used with SAASBO in Ax, see the [custom acquisition tutorial](/docs/tutorials/custom_acquisition), where adding `\\\"surrogate\\\": Surrogate(SaasFullyBayesianSingleTaskGP),` to the `model_kwargs` of `BOTORCH_MODULAR` step is sufficient to enable the SAAS model.\n",
-        "\n",
-        "[1]: [D. Eriksson, M. Jankowiak. High-Dimensional Bayesian Optimization with Sparse Axis-Aligned Subspaces. Proceedings of the Thirty-Seventh Conference on Uncertainty in Artificial Intelligence, 2021.](https://proceedings.mlr.press/v161/eriksson21a.html)"
-      ]
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "26affedc",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "501041cc-0473-4971-bff9-fd6e92e1eae4",
+    "papermill": {
+     "duration": 0.004313,
+     "end_time": "2026-01-08T16:43:17.656542",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:17.652229",
+     "status": "completed"
     },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "b53528f6",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:17.676669Z",
-          "iopub.status.busy": "2026-01-08T16:43:17.676305Z",
-          "iopub.status.idle": "2026-01-08T16:43:17.684172Z",
-          "shell.execute_reply": "2026-01-08T16:43:17.683740Z"
-        },
-        "papermill": {
-          "duration": 0.019369,
-          "end_time": "2026-01-08T16:43:17.685182",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:17.665813",
-          "status": "completed"
-        },
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "# Install dependencies if we are running in colab\n",
-        "import sys\n",
-        "if 'google.colab' in sys.modules:\n",
-        "    %pip install botorch"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "47a9cce7",
-      "metadata": {
-        "code_folding": [],
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:17.701332Z",
-          "iopub.status.busy": "2026-01-08T16:43:17.701182Z",
-          "iopub.status.idle": "2026-01-08T16:43:19.247188Z",
-          "shell.execute_reply": "2026-01-08T16:43:19.246797Z"
-        },
-        "executionStartTime": 1668653404823,
-        "executionStopTime": 1668653404909,
-        "hidden_ranges": [],
-        "originalKey": "26933c08-82d6-439d-9fcb-6e358b080ab6",
-        "papermill": {
-          "duration": 1.555946,
-          "end_time": "2026-01-08T16:43:19.248116",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:17.692170",
-          "status": "completed"
-        },
-        "requestMsgId": "1806f0c7-d668-4248-a390-14add9bcb451",
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "[KeOps] Warning : There were warnings or errors :\n",
-            "/bin/sh: brew: command not found\n",
-            "\n",
-            "[KeOps] Warning : CUDA libraries not found or could not be loaded; Switching to CPU only.\n",
-            "\n",
-            "[KeOps] Warning : There were warnings or errors :\n",
-            "/bin/sh: brew: command not found\n",
-            "\n",
-            "[KeOps] Warning : OpenMP library not found, it must be downloaded through Homebrew for apple Silicon chips\n",
-            "[KeOps] Warning : OpenMP support is not available. Disabling OpenMP.\n"
-          ]
-        }
-      ],
-      "source": [
-        "import os\n",
-        "\n",
-        "import torch\n",
-        "from torch.quasirandom import SobolEngine\n",
-        "\n",
-        "from botorch import fit_fully_bayesian_model_nuts\n",
-        "from botorch.acquisition.logei import qLogExpectedImprovement\n",
-        "from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP\n",
-        "from botorch.models.transforms import Standardize\n",
-        "from botorch.optim import optimize_acqf\n",
-        "from botorch.test_functions import Branin\n",
-        "\n",
-        "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "e0e850ae",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:19.293052Z",
-          "iopub.status.busy": "2026-01-08T16:43:19.292759Z",
-          "iopub.status.idle": "2026-01-08T16:43:19.294909Z",
-          "shell.execute_reply": "2026-01-08T16:43:19.294637Z"
-        },
-        "executionStartTime": 1668653405125,
-        "executionStopTime": 1668653405130,
-        "hidden_ranges": [],
-        "originalKey": "f1e3c7f0-1afc-42e2-af59-5f5fae755ce5",
-        "papermill": {
-          "duration": 0.017579,
-          "end_time": "2026-01-08T16:43:19.295618",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.278039",
-          "status": "completed"
-        },
-        "requestMsgId": "068ddee5-939e-4f5b-8210-2f6a490f6c4e",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "tkwargs = {\n",
-        "    \"device\": torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\"),\n",
-        "    \"dtype\": torch.double,\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "5d1c2e99",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "08a3d790-52a5-4821-af21-1040f1a037f0",
-        "papermill": {
-          "duration": 0.019641,
-          "end_time": "2026-01-08T16:43:19.325175",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.305534",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "The time to fit the SAAS model can be decreased by lowering\n",
-        "`WARMUP_STEPS` and `NUM_SAMPLES`. \n",
-        "\n",
-        "We recommend using 512 warmup steps and 256 samples when\n",
-        "possible and to not use fewer than 256 warmup steps and 128 samples. By default, we only\n",
-        "keep each 16th sample which with 256 samples results in 32 hyperparameter samples.\n",
-        "\n",
-        "To make this tutorial run faster we use 256 warmup steps and 128 samples. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "e833c35e",
-      "metadata": {
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:19.341365Z",
-          "iopub.status.busy": "2026-01-08T16:43:19.341223Z",
-          "iopub.status.idle": "2026-01-08T16:43:19.343141Z",
-          "shell.execute_reply": "2026-01-08T16:43:19.342877Z"
-        },
-        "executionStartTime": 1668653405353,
-        "executionStopTime": 1668653405445,
-        "originalKey": "363224de-347c-46a7-9c84-970cbb8e825d",
-        "papermill": {
-          "duration": 0.010996,
-          "end_time": "2026-01-08T16:43:19.343986",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.332990",
-          "status": "completed"
-        },
-        "requestMsgId": "09e1ff1f-9c11-4053-8123-08aa3397dfc1",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "WARMUP_STEPS = 256 if not SMOKE_TEST else 32\n",
-        "NUM_SAMPLES = 128 if not SMOKE_TEST else 16\n",
-        "THINNING = 16"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "53e25989",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "af8beafd-352c-421d-8797-7660ddfa39f3",
-        "papermill": {
-          "duration": 0.007009,
-          "end_time": "2026-01-08T16:43:19.364083",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.357074",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "## Simple model fitting\n",
-        "We generate a simple function that only depends on the first parameter and show that the SAAS\n",
-        "model sets all other lengthscales to large values."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "caaadea4",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:19.383405Z",
-          "iopub.status.busy": "2026-01-08T16:43:19.383147Z",
-          "iopub.status.idle": "2026-01-08T16:43:19.385763Z",
-          "shell.execute_reply": "2026-01-08T16:43:19.385412Z"
-        },
-        "executionStartTime": 1668653405681,
-        "executionStopTime": 1668653405771,
-        "hidden_ranges": [],
-        "originalKey": "f506aa6b-904c-4a7e-8a38-0443e983df06",
-        "papermill": {
-          "duration": 0.011204,
-          "end_time": "2026-01-08T16:43:19.386592",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.375388",
-          "status": "completed"
-        },
-        "requestMsgId": "a6b6bfcd-c30c-4339-a342-02dd398a8274",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "train_X = torch.rand(10, 4, **tkwargs)\n",
-        "test_X = torch.rand(5, 4, **tkwargs)\n",
-        "train_Y = torch.sin(train_X[:, :1])\n",
-        "test_Y = torch.sin(test_X[:, :1])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "330044d3",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "cc9314b1-f255-4f7d-9f6d-eb349b34805e",
-        "papermill": {
-          "duration": 0.007496,
-          "end_time": "2026-01-08T16:43:19.401389",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.393893",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "By default, we infer the unknown noise variance in the data. You can also pass in a known \n",
-        "noise variance (`train_Yvar`) for each observation, which may be useful in cases where you for example\n",
-        "know that the problem is noise-free and can then set the noise variance to a small value such as `1e-6`.\n",
-        "\n",
-        "In this case you can construct a model as follows:\n",
-        "```\n",
-        "gp = SaasFullyBayesianSingleTaskGP(train_X=train_X, train_Y=train_Y, train_Yvar=torch.full_like(train_Y, 1e-6))\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "db012225",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:19.416322Z",
-          "iopub.status.busy": "2026-01-08T16:43:19.416072Z",
-          "iopub.status.idle": "2026-01-08T16:43:25.616161Z",
-          "shell.execute_reply": "2026-01-08T16:43:25.615854Z"
-        },
-        "executionStartTime": 1668653406085,
-        "executionStopTime": 1668653471282,
-        "hidden_ranges": [],
-        "originalKey": "148855fb-cf0c-4fc5-8431-06a5e61c5da5",
-        "papermill": {
-          "duration": 6.2083,
-          "end_time": "2026-01-08T16:43:25.617083",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:19.408783",
-          "status": "completed"
-        },
-        "requestMsgId": "0c13f0b6-28b9-43ea-8d1b-00871e5e4f02",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "gp = SaasFullyBayesianSingleTaskGP(\n",
-        "    train_X=train_X,\n",
-        "    train_Y=train_Y,\n",
-        "    outcome_transform=Standardize(m=1)\n",
-        ")\n",
-        "fit_fully_bayesian_model_nuts(\n",
-        "    gp,\n",
-        "    warmup_steps=WARMUP_STEPS,\n",
-        "    num_samples=NUM_SAMPLES,\n",
-        "    thinning=THINNING,\n",
-        "    disable_progbar=True,\n",
-        ")\n",
-        "with torch.no_grad():\n",
-        "    posterior = gp.posterior(test_X)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "58028f75",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "5f4fa168-2662-499b-ac82-3ab122dfe2ad",
-        "papermill": {
-          "duration": 0.016223,
-          "end_time": "2026-01-08T16:43:25.652051",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.635828",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "Computing the median lengthscales over the MCMC dimensions makes it clear that the first feature has the smallest lengthscale\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "b8e7237c",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:25.678544Z",
-          "iopub.status.busy": "2026-01-08T16:43:25.678235Z",
-          "iopub.status.idle": "2026-01-08T16:43:25.681636Z",
-          "shell.execute_reply": "2026-01-08T16:43:25.681375Z"
-        },
-        "executionStartTime": 1668653471605,
-        "executionStopTime": 1668653471693,
-        "hidden_ranges": [],
-        "originalKey": "44a1f7c0-9649-4d89-8226-0405fdf88518",
-        "papermill": {
-          "duration": 0.015169,
-          "end_time": "2026-01-08T16:43:25.682451",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.667282",
-          "status": "completed"
-        },
-        "requestMsgId": "e815926b-5a2d-4b78-8b89-3c0720e45592",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "tensor([ 3.1031, 20.1120, 29.0710, 19.8204], dtype=torch.float64)\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(gp.median_lengthscale.detach())"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "id": "372b0c45",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "cf15a6ca-3377-40d1-9821-fad8f6600657",
-        "papermill": {
-          "duration": 0.010072,
-          "end_time": "2026-01-08T16:43:25.702269",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.692197",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "### Make predictions with the model\n",
-        "\n",
-        "In the next cell we show how to make predictions with the SAAS model. You compute the mean\n",
-        "and variance for test points just like for any other BoTorch posteriors. Note that the mean \n",
-        "and posterior will have an extra batch dimension at -3 that corresponds to the number of MCMC\n",
-        "samples (which is 8 in this tutorial)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "id": "a43c31c2",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:25.744423Z",
-          "iopub.status.busy": "2026-01-08T16:43:25.744262Z",
-          "iopub.status.idle": "2026-01-08T16:43:25.746777Z",
-          "shell.execute_reply": "2026-01-08T16:43:25.746483Z"
-        },
-        "executionStartTime": 1668653471916,
-        "executionStopTime": 1668653472023,
-        "hidden_ranges": [],
-        "originalKey": "898039a4-6ec8-46bd-a583-5a1614a3ccf6",
-        "papermill": {
-          "duration": 0.036982,
-          "end_time": "2026-01-08T16:43:25.747574",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.710592",
-          "status": "completed"
-        },
-        "requestMsgId": "4328636f-fb02-44ee-8c48-842c3845297f",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "torch.Size([8, 5, 1])\n",
-            "torch.Size([8, 5, 1])\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(posterior.mean.shape)\n",
-        "print(posterior.variance.shape)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f02bb5df",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "02b33f7f-4f31-432a-bac7-8cad1831e9a1",
-        "papermill": {
-          "duration": 0.007008,
-          "end_time": "2026-01-08T16:43:25.761952",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.754944",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "We also provide several convenience methods for computing different statistics over the MCMC samples:\n",
-        "```\n",
-        "mixture_mean = posterior.mixture_mean\n",
-        "mixture_variance = posterior.mixture_variance\n",
-        "mixture_quantile = posterior.quantile(q=0.95)\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "cb484111",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:25.778844Z",
-          "iopub.status.busy": "2026-01-08T16:43:25.778674Z",
-          "iopub.status.idle": "2026-01-08T16:43:25.781693Z",
-          "shell.execute_reply": "2026-01-08T16:43:25.781341Z"
-        },
-        "executionStartTime": 1668653472240,
-        "executionStopTime": 1668653472326,
-        "hidden_ranges": [],
-        "originalKey": "b387d057-a497-401b-bfc2-ab427669c451",
-        "papermill": {
-          "duration": 0.013012,
-          "end_time": "2026-01-08T16:43:25.782426",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.769414",
-          "status": "completed"
-        },
-        "requestMsgId": "64e0ee73-6ffd-4ad5-b9b2-bd9ea4e637ee",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Ground truth:     tensor([0.7361, 0.1658, 0.2783, 0.4090, 0.7812], dtype=torch.float64)\n",
-            "Mixture mean:     tensor([0.7358, 0.1632, 0.2735, 0.4077, 0.7820], dtype=torch.float64)\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(f\"Ground truth:     {test_Y.squeeze(-1)}\")\n",
-        "print(f\"Mixture mean:     {posterior.mixture_mean.squeeze(-1)}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "733aa578",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "executionStartTime": 1644277314184,
-        "executionStopTime": 1644277314189,
-        "hidden_ranges": [],
-        "originalKey": "d9bec8be-2acd-40b8-aebb-612b62bbdfc3",
-        "papermill": {
-          "duration": 0.007506,
-          "end_time": "2026-01-08T16:43:25.798670",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.791164",
-          "status": "completed"
-        },
-        "requestMsgId": "d9bec8be-2acd-40b8-aebb-612b62bbdfc3",
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "## Optimize Branin embedded in a 30D space\n",
-        "We take the standard 2D Branin problem and embed it in a 30D space. In particular,\n",
-        "we let dimensions 0 and 1 correspond to the true dimensions. We will show that\n",
-        "SAASBO is able to identify the important dimensions and efficiently optimize this function.\n",
-        "We work with the domain $[0, 1]^d$ and unnormalize the inputs to the true domain of Branin \n",
-        "before evaluating the function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "id": "e4697bdc",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:25.815096Z",
-          "iopub.status.busy": "2026-01-08T16:43:25.814920Z",
-          "iopub.status.idle": "2026-01-08T16:43:25.817451Z",
-          "shell.execute_reply": "2026-01-08T16:43:25.817083Z"
-        },
-        "executionStartTime": 1668653472540,
-        "executionStopTime": 1668653472545,
-        "hidden_ranges": [],
-        "originalKey": "15baa08e-ca35-4da7-a495-c63fe5d5779d",
-        "papermill": {
-          "duration": 0.011102,
-          "end_time": "2026-01-08T16:43:25.818236",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.807134",
-          "status": "completed"
-        },
-        "requestMsgId": "6c3f8d91-9139-4c07-986f-77629b1887e5",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "branin = Branin().to(**tkwargs)\n",
-        "\n",
-        "\n",
-        "def branin_emb(x):\n",
-        "    \"\"\"x is assumed to be in [0, 1]^d\"\"\"\n",
-        "    lb, ub = branin.bounds\n",
-        "    return branin(lb + (ub - lb) * x[..., :2])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "id": "4ae7ff47",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:25.834019Z",
-          "iopub.status.busy": "2026-01-08T16:43:25.833873Z",
-          "iopub.status.idle": "2026-01-08T16:43:25.836125Z",
-          "shell.execute_reply": "2026-01-08T16:43:25.835809Z"
-        },
-        "executionStartTime": 1668653472768,
-        "executionStopTime": 1668653472776,
-        "hidden_ranges": [],
-        "originalKey": "98b6936b-2f06-4d1f-82c0-2f1bd660d0b2",
-        "papermill": {
-          "duration": 0.01027,
-          "end_time": "2026-01-08T16:43:25.836830",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.826560",
-          "status": "completed"
-        },
-        "requestMsgId": "1b5baaf2-e690-4b4d-9011-b6124e083410",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using a total of 50 function evaluations\n"
-          ]
-        }
-      ],
-      "source": [
-        "DIM = 30 if not SMOKE_TEST else 2\n",
-        "\n",
-        "# Evaluation budget\n",
-        "N_INIT = 10\n",
-        "N_ITERATIONS = 8 if not SMOKE_TEST else 1\n",
-        "BATCH_SIZE = 5 if not SMOKE_TEST else 1\n",
-        "print(f\"Using a total of {N_INIT + BATCH_SIZE * N_ITERATIONS} function evaluations\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7ac5211a",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "27fd793f-18ee-49cb-9aa5-c8cd78b0b807",
-        "papermill": {
-          "duration": 0.007282,
-          "end_time": "2026-01-08T16:43:25.851396",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.844114",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "### Run the optimization\n",
-        "We use 10 initial Sobol points followed by 8 iterations of BO using a batch size of 5, \n",
-        "which results in a total of 50 function evaluations. As our goal is to minimize Branin, we flip\n",
-        "the sign of the function values before fitting the SAAS model as the BoTorch acquisition\n",
-        "functions assume maximization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "id": "eefbc014",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:43:25.866031Z",
-          "iopub.status.busy": "2026-01-08T16:43:25.865875Z",
-          "iopub.status.idle": "2026-01-08T16:46:54.574548Z",
-          "shell.execute_reply": "2026-01-08T16:46:54.574269Z"
-        },
-        "executionStartTime": 1668653473096,
-        "executionStopTime": 1668655621405,
-        "hidden_ranges": [],
-        "originalKey": "269287e0-500f-474d-891a-5439487e9a77",
-        "papermill": {
-          "duration": 208.7194,
-          "end_time": "2026-01-08T16:46:54.577665",
-          "exception": false,
-          "start_time": "2026-01-08T16:43:25.858265",
-          "status": "completed"
-        },
-        "requestMsgId": "5117b535-1fe7-40be-9f68-361db9d9b51b",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Best initial point: 5.322\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "3) New best: 3.360 @ [1.000, 0.121]\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "4) New best: 1.432 @ [0.517, 0.211]\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "5) New best: 0.620 @ [0.556, 0.153]\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "6) New best: 0.492 @ [0.539, 0.173]\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "7) New best: 0.427 @ [0.542, 0.163]\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "8) New best: 0.398 @ [0.543, 0.151]\n"
-          ]
-        }
-      ],
-      "source": [
-        "X = SobolEngine(dimension=DIM, scramble=True, seed=0).draw(N_INIT).to(**tkwargs)\n",
-        "Y = branin_emb(X).unsqueeze(-1)\n",
-        "print(f\"Best initial point: {Y.min().item():.3f}\")\n",
-        "\n",
-        "for i in range(N_ITERATIONS):\n",
-        "    train_Y = -1 * Y  # Flip the sign since we want to minimize f(x)\n",
-        "    gp = SaasFullyBayesianSingleTaskGP(\n",
-        "        train_X=X,\n",
-        "        train_Y=train_Y,\n",
-        "        train_Yvar=torch.full_like(train_Y, 1e-6),\n",
-        "        outcome_transform=Standardize(m=1),\n",
-        "    )\n",
-        "    fit_fully_bayesian_model_nuts(\n",
-        "        gp,\n",
-        "        warmup_steps=WARMUP_STEPS,\n",
-        "        num_samples=NUM_SAMPLES,\n",
-        "        thinning=THINNING,\n",
-        "        disable_progbar=True,\n",
-        "    )\n",
-        "\n",
-        "    EI = qLogExpectedImprovement(model=gp, best_f=train_Y.max())\n",
-        "    candidates, acq_values = optimize_acqf(\n",
-        "        EI,\n",
-        "        bounds=torch.cat((torch.zeros(1, DIM), torch.ones(1, DIM))).to(**tkwargs),\n",
-        "        q=BATCH_SIZE,\n",
-        "        num_restarts=10,\n",
-        "        raw_samples=1024,\n",
-        "    )\n",
-        "\n",
-        "    Y_next = torch.cat([branin_emb(x).unsqueeze(-1) for x in candidates]).unsqueeze(-1)\n",
-        "    if Y_next.min() < Y.min():\n",
-        "        ind_best = Y_next.argmin()\n",
-        "        x0, x1 = candidates[ind_best, :2].tolist()\n",
-        "        print(\n",
-        "            f\"{i + 1}) New best: {Y_next[ind_best].item():.3f} @ \"\n",
-        "            f\"[{x0:.3f}, {x1:.3f}]\"\n",
-        "        )\n",
-        "    X = torch.cat((X, candidates))\n",
-        "    Y = torch.cat((Y, Y_next))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "93db4c3b",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "a9704a99-0712-40bb-a263-6798e0925291",
-        "papermill": {
-          "duration": 0.015334,
-          "end_time": "2026-01-08T16:46:54.615678",
-          "exception": false,
-          "start_time": "2026-01-08T16:46:54.600344",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "## Plot the results\n",
-        "\n",
-        "We can see that we were able to get close to the global optimium of $\\approx 0.398$ after 50 function evaluations.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "0f045f2f",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:46:54.640940Z",
-          "iopub.status.busy": "2026-01-08T16:46:54.640666Z",
-          "iopub.status.idle": "2026-01-08T16:46:54.972304Z",
-          "shell.execute_reply": "2026-01-08T16:46:54.971992Z"
-        },
-        "executionStartTime": 1668655621761,
-        "executionStopTime": 1668655621936,
-        "hidden_ranges": [],
-        "originalKey": "fd0d7aa7-8d55-4942-adc2-de356666ac84",
-        "papermill": {
-          "duration": 0.345164,
-          "end_time": "2026-01-08T16:46:54.973795",
-          "exception": false,
-          "start_time": "2026-01-08T16:46:54.628631",
-          "status": "completed"
-        },
-        "requestMsgId": "4024717d-fc5c-4939-90ce-fb24b3e06ea3",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAI5CAYAAABDx+koAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe5RJREFUeJzt3QeUU9XWwPE9HYbeOwgiVQUUUVGaCAiIgqgoqKBYECyI/akUn9337AVFBRWRpiCKKIgUUUBAUBRFRJr0OnRmmMm39pl382Vm0mZSb/L/rXVJSG5uTnKSzM7JPvskOBwOhwAAAAAxKjHSDQAAAABCiYAXAAAAMY2AFwAAADGNgBcAAAAxjYAXAAAAMY2AFwAAADGNgBcAAAAxjYAXAAAAMY2AFwAAADGNgBcAimjjxo2SkJBgtnHjxkW6OQAADwh4ARTJ/PnzncGeu61kyZLSoEEDuf766+Xbb7+NdHMhIqeccorHvqpRo4Y0a9ZMbrjhBnn11Vdl69atEit27dol77//vtxxxx3SunVrqVu3rpQqVUrS0tKkWrVq0qVLF3nzzTflyJEjfh9z1qxZ0qtXL6lZs6Y5jp7q//VyANEnweFwOCLdCAD2DHg7dOjg9/4aSL333nuSlJQksTTCq8GTGjt2rAwYMECiPeDdtGmTX/tqP1122WXywgsvmNvZ2TvvvCO33HKLz/3q1Kkjn3zyiZx99tke98nJyZFbb71V3n33XY/73HzzzfLWW29JYiJjSkC0SI50AwDY3+233y6DBw92/l+/R+/bt08WL14sL774ohlh++CDD6RWrVryxBNPSKzQQNCOYwbVq1eXr7/+2vn/rKws2b9/vwmGf/jhB5kyZYpkZGTItGnTZO7cuTJ+/Hjp0aOH2JWOYp922mnSvn17adGihRnN1pHd48ePm8esj0+fDz3fqVMn+fXXX81z5M4jjzziDHb1WA888ICceuqpsn79ennuuedk5cqVJsCuVKmSPPXUU2F+pAA80hFeACisefPmaaRnthEjRnjc77fffnMUK1bM7FeqVCnHiRMnwtpO/L86deqYftBTbw4dOuQYNmyYs3+LFy/uWLZsmcOusrKyfO7z4osvOh/vPffc43aftWvXOpKTk80+LVu2dBw9ejTP9UeOHDGX6/W637p164L2GAAEht9bAIRUkyZNpHv37ub8oUOH5I8//oh0k+CD5vT+97//lWeeecb8/9ixY+ZnertKTvb9Y6bm9+rjVt99953bfV566SU5efKkOa95zsWLF89zfXp6urlc6X766waA6EDACyDkrDxXdeLEiQLXa4UDawKV5sXqPhpcnHfeeVKxYkVz+ciRI537Z2Zmyueff26ClHPOOUfKlSsnKSkpUqFCBTn33HPNvnv27PFrApeVd7t27VqT56mX6ySkKlWqmElIS5YsKXKVBm2Hdb3Sn9Cff/55Oeuss8ykKd1atWolr732mjOQiib6c70+n+rnn3+WL7/8UmKVBsXFihVz9lN+mrry2WefmfONGjUyr0139PKGDRua87q/HVNegFhEDi+AkHOdKFW7dm2v+2qgqoHmqlWrPO6jk4Z01n1+mjf8448/mk2DSA04LrjgAp/t01zV6667To4ePeq8TPOOp0+fbgLrjz76SPr06SOB2Llzp1xyySUFHteyZcvMNnv2bHN/0TTRSQP1u+++W/r27Wv+r+3r1q2bxCLNVba+JGlAm9+GDRtk27Zt5ny7du28Hkuv1y9QWunCdWIjgMiJnk9WADFJUxi++OIL5+iXjpx6M3DgQDOaqFUdZs6cKStWrDABqTXSqHQ0tF69enLvvffKpEmTzOQ4DRqnTp0qgwYNktTUVNm7d68JnDVw9Wb16tUmoNN2aZCsI7p6PB2d1RG/7OxsE2Dv3r07oOfhiiuukDVr1shdd90lc+bMMY9rwoQJ0rhxY3O9BtZjxoyRaHPxxRc7z3v6qd+uNMVG+0T7Wl8rFg3y89P9LO4CYleu1//+++9Bay+AAASYAwwgTrlOWrv99tsdq1evdm6//PKLY+HChY5nn33WUbVqVbNPmTJlHIsXL3Z7rLFjxzqPpds777zj9b7/+usvR05Ojsfr9f5LlixpjvXoo496ncCl29lnn+3IyMgosM/48eOd+7zwwgsFrt+wYYPzen0M+elkPuv6lJQU85zlt3fvXkeVKlXMPmeeeaYjGiat5VezZk3nRKyiyN+/Rd2CwbVP8m9JSUmO1157ze3t3nzzTed+U6ZM8Xofer217+jRo4PSbgCBYYQXQMC0aP8ZZ5zh3M4880xp27atPPjgg2aEVUddNc3AU96jq4suusiM8nqjZaCsvFh3tA3WJCv9Gd4XrQ9cunTpApfryK9VnirQ0c0777zTlMXKr3z58nLjjTc6R5u1HFi00dxoa2T94MGDEos6duxoypENGTLE42iwxZrc5kmJEiWc5w8fPhzEVgIoKnJ4AYSUFuqfOHGiSQ/QWf86Icybfv36Ffo+tIas5u/qZCNrklDZsmWdP0VrnVmd1OaOFaC7o0G11lrV3M2///5bAuHtcVkLHWjbNVe0efPmEk1cAzwN/Nx9OfCmZ8+e0rJlS4kGWi/6yiuvNOd1ZTVNOdAa0ZrDq3nab7/9dp70GYvrRDZNmfHG9TWuFS4ARB4BL4CAjRgxIk8VBesP/V9//SUffvihKc+kVReWL19uCvxr+SZPPAWf+eloqB5Xl3LdsWOH14BbA+LKlSu7vd5XPqaOwOYf4SsKb/dj3Ucw7icUXNtU2GDX+vJhfQGJNH0duL4WNLjVSh1PPvmkPProo2YUXic7du7cOc/trAoOVpUQb1wrkeQvXQYgMkhpABAS+odeR0919ak33njDXLZo0SKfq09piTFfdKUrLe2ly/l6C3b9GWXzFnwrq2qCTl4LhLf7ca3MEOj9hIJVvUBLd2kptVikK6hpiTgdydXydPnLxLk+bl9pCjpy7G/6A4DwYIQXQMhpTu5DDz1k0g40X9bb8sJJSUk+qz5oTrAGJDpSd//995u8X62fq0GJlbqg92PlAlMLteg0B9sqx2XVly2sAwcOyD///BNwW04//XQJpcsvv9zkmm/evNmctm7d2nldzZo1ned9PZYtW7Y4z+ty2gAij4AXQMjpCOZpp50mS5cule3bt5uSYdZEqMLSBR402NXAeMGCBR5TBTS4RuC0hJrlwgsvLNIxdOKgNTEvEKH+4lKpUqU8taNdA15dMdDia7VA1+utsnMAIouUBgBh4foTcSCriv3222/mtFmzZl7zYjVfGIEHmK+88orz/661amORLhThKRVBF4+wKnboFy1vFi5caE5r1KhhfnkAEHkEvABCTlcwswr3a26vLhdcVFaw7JonmZ+OIs+YMaPI94Fczz77rPlpX2nOdJcuXYp0HJ0UpsFzoFso6eTGTz75xPl/zT/PX7FDUx6sEVxPS07r5dYIr+7vrXwegPAh4AUQclrBwZo4pkGTrzxdbzQ1Qq1bt05++OEHt8G11s+NpXJQujytBk66uavlG2w6Keu+++6Thx9+2Dnh7p133hG70hXsvE0G1GBXV+3TOryqTZs2bkdmhw4d6nztal3l/K8x/b9ebk3w0/0BRAdyeAEEZWKTFSxYdLa7BqVa4/Srr75ylnZ6/PHHA7qv66+/Xl599VUTpHTv3t1MWtPcUj22Lterpcr0fi+44AL5/vvvA7qvWKV1iV37S/+vE8s0sNYvEbpEs/5flSlTRj766CNTj9iudGnoUaNGmfq7uvhJnTp1TBCv5epWrlxp8sJ/+eUXZ9m1119/3e1xGjRoYF5vWk9aU2b0NaaLq+hCKOvXrzcj4no8pftZX84ARB4BL4CgrLSmm68JQePHjy/wU3FhnXPOOSZ40dq/GpRpOan8dLROZ/THSsDrOpJY1Ml+rrTqgq9+0BHKyy67TF544QUTIMZCfu7LL79sNk90gpmv16jW69UveFoFRIPba665psA+Wh3EWyUSAOFHwAsgJHQ1Kl1QoWnTptKtWzczS9+fGrv+GD58uFm5S4OXZcuWmXxeLVGmdVS1ZFmnTp3MqF2sWLx4sfP8PffcE/Tj62injuRqbrVOBtTnsXfv3s5JWnanI/+6QInm1+pKdjt37jRflvRx62PU/GSdkKc5t55W5HOtOKJ1oPX50VXZ9PWndYr1udMvY7fddpt07do1bI8NgH8SHBSoBICoppO+3n//fenQoYN8++23kW4OANgOk9YAIMpZZbB0ZBsAUHiM8AJAFNNVvXS1Lq0cYNV3BQAUDgEvAAAAYpotUxq0nuJjjz1mVr7RIvZaEubf//53yAuTAwAAwH5sWaVBax1qCSSdxKEzwLUeos4A11nGd911V6SbBwAAgChiy5SGSy+9VKpUqWJKw1i0RIyO9moNRQAAAMDWI7ytW7c29Q///PNPs/LNzz//LIsWLTIF0t05ceKE2Sy6QtO+fftMAXfWOQcAAIg+OiZ76NAhUy9ba2DHXcD70EMPycGDB6VRo0ZmXXPN6dXVb/r16+d2/6efftqszAQAAAB72bJli9SsWTP+UhomTpxo1il//vnnTQ7vqlWrZOjQoWaEt3///j5HeDMyMqR27dpmhFhXgvLmiScS5aWXkuTWW7PlqadyQvJ4EFpZWVkyb948U7Tf1ypKsD/6O77Q3/GF/o4v+/btM7/k68qIOk8r7kZ4NdjVUV5rDXNd93zTpk1mJNddwJuWlma2/DTY9bUufcmSuaepqbqGfbAeAcL9AalLiGpf8wEZ++jv+EJ/xxf6Oz4lBCH91JZlyY4ePVogl0NTGzQ3N9is5zgEhwYAAEAY2HKEt0ePHiZnV9MSNKVh5cqVJp3hpptuCvp9WXG1/RI/AAAAYNuA99VXXzULTwwePFh27dplZu/ddtttIVln3gp4GeEFAACwJ1sGvKVKlZKXXnrJbKFGwAsAAGBvtszhDSdyeAEAAOyNgNcHcngBAADsjYDXB1IaAAAA7I2A1wdSGgAAAOzNlpPWwomUBgAoGl3IUxcKCEWNdIsePzk5WY4fP26WmUdso7/tJzEx0SwSEozFIwJBwOsDKQ0AUDgaiOzZs0cOHTpkApRQB9VVq1aVLVu2RPwPKkKP/ranlJQUU2GrYsWKZqGwSCDg9YGAFwAKF+xqMHLixAkpU6aMlCxZ0vyBC1VwoqPHhw8fNveTfwVOxB76235fULKzs02fHThwQI4dOya1atWKSNBLwOsDObwA4D8d2dVgV1fCLF68eFgCoMzMTClWrBgBUBygv+2pZMmS5gvw5s2bzWdElSpVwt4GXi0+kMMLAP6P5mgag/5hC0ewC8A+ihcvLqVLlzafEfpZEW4EvD6Q0gAA/tF8Xd10NAcA8tM8XutzItwIeH0g4AUA/1jVGCI1KQVAdEv632dDKCu3eELA62cOLykNAOAfZs8DiLbPBgJeHxjhBQAAsDcCXh8IeAEAAOyNgNcHypIBAADYGwGvD5QlAwAAsDcCXh9IaQAAALA3Al4fCHgBAJGgxfmnTJkivXr1kjp16pjC/Vrj+NRTT5ULL7xQhg0bJtOmTZODBw/6PFafPn3MDHndHnnkkSK36dxzz3UeZ8yYMX7fbs2aNXLXXXdJs2bNzMIkqampUr16dWnRooX069dPRo8eLX/++WeB282fP995f7ppWaty5cqZ07S0NKlZs6ZceumlMnHiRL8WMzh+/Li89dZb5jbWaoDansaNG8utt94q8+bNK/RzAptwxKGMjAx9Vzj27Nnjc98PP9R3kMPRqVNYmoYQyMzMdEyfPt2cIvbR35Fz7Ngxx5o1a8xpuGRnZzv2799vTmOJPqZ27dqZv1XWlpyc7Chfvrw5db187NixXo+lf+tSU1Od+9eoUcNx8uTJQrdp9erVee73vPPO8+t2zz33XIE2ly1b1lG8ePE8l+njzW/evHnO68uVK+eoUqWKo3LlyubU9THp1qVLF8fx48c9tmP27NmOmjVr5rlN6dKlHWlpaXku69q1q1/xAUL/GaH9oH2icVugGOH1gRFeAEC43XDDDbJgwQIzknnvvfea0c8TJ07I3r175dixY/Lzzz/Ls88+a0ZMfRk/frxkZmZKt27dzOjw1q1b5euvvy50m959911zOmDAALNi1pIlS8zIrTeffvqpPPDAA3Ly5Elp27atzJ4927R///79cvToUfnnn3/k448/liuvvNKM+vo61rZt22Tt2rXmVEdr161bJ3379jXX62N64YUX3N520qRJ5vHr/dWoUUPeeecd2bdvn2RkZJjj/P777zJ06FBJTk6WWbNmyXnnnSe7du0q9HOEKOaIQ4UZ4f3449wR3g4dwtI0hAAjfvGF/o4cRniD488//3SONj799NM+9z969KjX68844wxzrIkTJzpGjhxpzl9xxRWFatOJEyccFStWNLddsmSJY8CAAeb8sGHDvN6udevWZr/TTz/dkZWVVejH4TrCq+fd9beOVjdo0MDs06pVqwLH0Ndkenq6uV6fi127dnlsw8yZM50jxx07dvTaXhQeI7xRjLJkAIBwWrVqlfP85Zdf7nN/zUP1ZNmyZbJ69WqTp6rH0pFjzYX9/PPPZffu3X636bPPPpM9e/ZIw4YNTR5v//79naPHWVlZPh+Ljq7q6GlRH4c3Ogp+xhlnmPOHDx8ucP2jjz5qRpM151dzoitVquTxWNpO3V/NnTtXZs6cWaQ2IfoQ8PpAWTIAQKToT/CBsNIQrr76ailWrJjUrVtX2rRpY4LUDz/8sNDH0YBZtWvXzkyk05/9NXgO9ePwJicnR3799VdzXgNyV9u3b5fp06eb89dee22B69255557TMqGev3110PSZoQfAa8P5PACQPDo4MGRI7G1BXtA5JxzzjGjsMrK3y0KHdXU/FjXQFVZo7PvvfeeX8fZsmWLzJkzx7TpuuuuM5fpeeuYVjDsTqtWrczp5MmTZcKECSY4Daa///7b5BRrXq+O9Gqwmr/Kg3WfvXv39uuYWgmjc+fO5vx3331n8o9hfwS8PhDwAkDwHD2qAUXwttKlE6VmzbLmNJjHLcymjymYTjnlFLn55pvNeU1HaNSokZx11lkyZMgQE6TqaKY/JbimTp1qSpZZZcwsV111lUkf+O2332Tp0qU+jzN27FgTNHbo0MGU8rJYAa9OFtNJZO6MHDnSpDJo0Kjlx3TCmJZIe/75500JsCP6jcFPV1xxhSllpqO0eqoj1vrYNJDWAPWbb74xo9eu9DFatASav5o3b+5Mkdi0aZPft0P0IuD1M4eXlAYAQLi88cYb8thjj0mJEiVMcLty5Upz2cCBA02+atWqVU0d3p07d3o8hjXyev311+e5XH+u19q+rvt4ovetAW/+UWJVv359ad26tWRnZ8u4cePc3l5TH7766itnKsGOHTvMaK9WbrjoootMTd3u3bvLwoULfT4nWtlBH6+mUeipVq1Qev9acUGrT+SnVS0sFSpUEH9VrFjR7TFgXwS8PjDCCwDBk56uo2bB2w4ezJF//jlgToN53MJs+piCTUdFH3/8cRPEaa6tjvhqCTKrdJcGfS+++KKcfvrp8uOPPxa4/V9//WV+jtfUg/wBr2tagy7YoKkPnnz77beyceNGE3i7SwmwjmMFxe507NjRlC/T9IKHH37YBLrly5c312ku8ZdffmkC4+HDh3t9TnREWINbDXz1VG+rKQ3PPPOMGfXWdIuHHnrI6zEQvwh4fSDgBYDg/mpWokRsbdYvgaGg1RU0kNNVzbTigdaN1XzaHj16mOu1coIGolpL1pWmPujo7AUXXCD16tUrcNyLL77YpBccOnTIVC7wxBoB1hFhzW3Nz5oMpwG21g32JDEx0QS1Tz31lKl+oKOmWvtWg1wNptW///1v+eKLLwr1pUAn4T344IPy3HPPmcu0NrFrO1xHdQszUqvPq7tjwL4IeH0g4AUARAsNLjVYnTFjhnN0VSsgaNqARUc/33//fXN+0aJFeZbmdV2i10oB8JTWoCOpunSxVX7M3XE0JcEKtn2lR+SnucmjRo0yj8WapKcLQhSFpnpYx7Am6qkmTZo4z//0009+H09TSJQG+VqNAvZHwOsDObwAgGh06623Os9rlQKLrhTmaRKZO5r6oCuW5ffRRx8VGDn2Z5JcYWmKg+YD538chZGenu7Mu92wYYPzcp1op6PL6pNPPvHrWDpRTUfRlU6C81U/GPZAwOsDI7wAgGjkmmKgiyq4S0PQlAVvm1Z/8FSizDrO3Xff7fUYmmahiznoksGuo6tFeSyuj6MwNDC3UhasFAlVrVo15+Idmq/sT0CtudH6uNTgwYOL1B5EHwJeHwh4AQDhpCOU/tTetdIWlBW4avUCKw9Wy39pIOlt0xJl1rE0FcL1539rlTRdsMHbMUqXLm1KhrlLa5g9e7bPEmo///yz2VwfR2FpMGvV223ZsmWe6zQ3WMuwaVUHfbyu+bn56ej4E0884Rwd1goSiA0EvD6Q0gAACCetHdu4cWMTbH3wwQemSoJFKxNofumNN94oL7zwgnNxB6vOru6vNW81wLv00kt93pdOOrNWJNNqCRYrcNX8VV1K2N/j6FLG1qpnqm/fviZXV4NOvS4zM9N5nZYo09FUzUnWYFVTB3Q0uTC0jq8G69btNPjWfF5XTZs2NbnBmresdY21Hq+OaB84cMC5j37B0DJvl112mWmjTvTT+r5WXjBigCMOZWRkaPjq2LNnj899587VUNfhaNo0LE1DCGRmZjqmT59uThH76O/IOXbsmGPNmjXmNFyys7Md+/fvN6ex4quvvjJ/o1y31NRUR/ny5R0JCQl5Lj/rrLMcW7dudd62UaNG5vLevXv7fX96DL1Nz549zf+1/8qWLWsuu/fee/06xsmTJx2VK1c2txk6dKjz8qpVq+Zpb2JioqNcuXKOtLS0PJeXKlXKMWXKlALHnTdvnnMfvV2VKlXM/ehphQoVzPGs6/X50f09mTVrlqN69ep57rdMmTKOYsWK5bmsc+fOjl27dvn9/CF0nxEap2mfaNwWKDKxfSClAQAQTl26dDGTyHTEVass6IipVmLQEUmdnKWrjOkopaYR6E/01qSs77//Xv744488I67+0H01hUFTITQlQlcss0Y//T2Ojp5qe0aPHm0qOmh5MK0ZrCOnuhKb1tDV+1i/fr2p/qBtrlKlihnJ7tSpkxmV1f97o7fLf59atk1HkLt27SqDBg0yucSeXHLJJaZ8mi6SoY9V0yg0vUHbqSvI6QQ1Td/QusGIPQka9Uqc0Vmk+ibRF7qv+nq6+Eu7diK6SMz/PkdgM1Zh827duklKSkqkm4MQo78jRycOaf6p1kbV8lnhoD+F62e6/pRtBX6IXfR3fH1G7N2711Tf0ImR2ueB4NXiAzm8AAAA9kbA6wMpDQAAAPZGwOsDAS8AAIC9EfD6QEoDAACAvRHw+sAILwAAgL0R8PpAwAsAAGBvBLw+EPACAADYGwGvD+TwAgAA2BsBrw+M8AIAANgbAa8PBLwAAAD2RsDrZ8BLSgMAAIA92TLgPeWUUyQhIaHANmTIkJDl8DLCCwAAYE/JYkPLli2T7Oxs5/9//fVX6dSpk1x11VVBvy9SGgAAAOzNlgFvpUqV8vz/mWeekVNPPVXatWvndv8TJ06YzXLw4EFzmpWVZTZvcuPqFMnJcUhW1slgNB9hZvWxr75GbKC/I0efc4fDITk5OWYLB70/6zRc94nIob/tLScnx/SdflYkJSX53D+Yn+O2DHhdZWZmyvjx42XYsGEmrcGdp59+WkaNGlXg8nnz5kl6errX42/bVkJELjbB7pdffhm0diP85syZE+kmIIzo7/BLTk6WqlWryuHDh81nczgdOnQorPeHyKK/7SkzM1OOHTsmCxculJMnfQ8iHj16NGj3neCwvi7Z1OTJk6Vv376yefNmqV69ut8jvLVq1ZLt27dLhQoVvB5//XqRxo1TpGRJh+zbxwivHek3RA1+NO0lJSUl0s1BiNHfkXP8+HHZsmWLmWdRrFixsNyn/gnT4KdUqVIeBz0QO+hv+39GbNy40cRg/nxG7N27V6pVqyYZGRlSunTp+B7hfffdd6Vr164eg12VlpZmtvz0j6GvP4jWzXJyEvjjaXP+9DdiB/0dfjq3QoOQxMREs4WD9bO2db+InHHjxsmNN94oderUMUGNnfq7ffv2smDBAhkxYoSMHDlS7MCObU5MTDR95+/nczA/w20d8G7atEm++eYb+fTTT0N2H5QlAwBEelTs/fffl88//1x++eUX2b17t6SmppqBnjZt2si1114rHTp0CNn9a/CqwayyS2AFxFTAO3bsWKlcubJ07949ZPdBWTIAQKRoes5NN90k//zzj/My/WlX0/T++OMPs40ZM8b80vnhhx/6TNMrasBrzYPxFvCWKVNGGjZsKDVq1Ah6G4BA2fb3H/1ZQwPe/v37m4kSoUJZMgBAJEyaNEm6detmgl0NIt955x3Zt2+fyWfUUd/ff/9dhg4dav4Gzpo1S8477zzZtWtXxNrbq1cvE4DPnTs3Ym0AYi7g1VQGnaim33xDiYAXABBuGszq3zedyX7GGWfIypUrZeDAgVKuXDnnPo0aNZIXX3xRPvvsM5Pi8Ndff5lJ3ABiKODt3Lmzma3ZoEGDkN6PldJADi8AIFweffRRU5JJJ1xPmTKlQP15VzoKrPsrHV2dOXNmgZQEa0VSPb9u3ToZMGCA1KxZ0xy/du3aMmjQINm2bVuBY2vFDdf84PwrnOpxLJrnq5fpbfLTVAi9TidaqRkzZkjHjh1NCoamaLRu3VqmT5+e5zaaonHBBReYIL9kyZLStm1br6PHugiV3s9FF11kavMXL17cHLtFixbm+dmzZ48Ek34JsZ4Hza325oYbbjD76WMOR5utds2fP9/jPu3btzf7eEtT+f777+W6664zExG1qoKmrbRq1UqeffZZU37QVhxxKCMjQ8NXx549e3zuu2OHhrq5G+wpMzPTMX36dHOK2Ed/R86xY8cca9asMafhkp2d7di/f785jRXbtm1zJCYmmr9TAwYM8Os2hw4dcpQqVcrcpmvXrnmu27Bhg7lct4kTJzr3K1mypKN48eLO68qXL+9YsWJFntu2bNnSUa5cOec+VapUybPdddddzn3Hjh1r9qlTp06B9o0YMcJc165dO8fw4cPNeX2MZcqUcR5bt9GjRztycnIc/fv3N/9PTk52tle3pKQk8xjc9bfer7VfsWLFzONJSEhwXlajRg3HH3/84fb503bpPtrOwmjatKm53X333edxn8OHDztKlChh9hs3blxY2mzdft68eR7b1c7L7fX51b517Rt9vejzb/2/YcOGjo0bNzpC+RmhcZrel8ZtgbLtCG+4uFY9YZQXAIJj95HdRd6OZR3zeNw9R/cU+bhHMo94PO6+Y/vc3iYUdFTOKr/Vu3dvv26jI6D6y6f67rvvPBb1v+2226Ru3bqydOlSU8/2yJEj8vXXX5tRXs0P1jxc10Udli1blqcS0o4dO/JsL7/8cqEe26pVq+TJJ580m97fgQMHTI5yly5dzPX333+/GXHUGvujR482+cpaO//PP/+Uli1bmtJ39913n9tV1nS1VR1l1gpOuriB1nDVXGdNgdRRya1btwY95UNHbtWECRM8rvw2bdo08zyXKFGiQH9Gos3+0FJnr7zyiikM8Prrr5t26etC26iLdukI9Nq1a+WKK66wzYp3tq7SEImAlzrXABC4yv+pXOTbvtb1NRnSaojb6xq/3tgEvUUxot0IGdne/c+7bca2kTW71xS43GEGLoPrt99+c57XwMJfzZs3l08++cT81KwBlP5Enp9OcNPKDxrIKP1JWwPlr776ytxe58ZooKmBZyhoAPvEE0/Iv/71L+dlOiFPA1wts6ZB1eOPP25WUO3Xr59zn9NOO00mTpwo9evXNwHyDz/8YFIcXGnptvw0t1nTCDQVQm/7008/yaJFi+TCCy8MyuPRNj788MMmHUSDVOtLR/7UDKVfJvSLSaTb7IumvegKtZpeMXv2bGnWrFmeurhW/d8mTZqYtml6Ss+ePSXaMcLrg2uAa5MvMQAAG9PRNEthyoxVrFjR7TFcaa6uFey6aty4sVx55ZXmvAaWoaJ5oFpZIj/NWz3//PPNeR1tdjeqqQG8BoBq9erVhbpfDTR1NFVp8BgsGqxr/q1rYOtKV3S18o6vv/76qGizLzrirCPpl1xySZ5g15WudGcFufoLgR0wwluIEV4CXgCAnVnBmafr9Kd5nYClS3SHYqVCHRXUn/bdqVKlijnV1AVPywbrPlqNYv/+/W6v/+KLL0zgqakYO3fuNBP/8nOtaRystAYd3XVNXbDo86nBo45eX3zxxVHTZm90oprS0d2qVat63M+atKa/JtgBAa8PBLwAgHByHdXVkVp/F3JwndHvaWTY27Gs6zT/V/NrrQA0mHRk0BOrpr4/+2hA7krzSLWawMcff5xnX63woCkCyqpfrEFpMGke6+DBg00AqPnOriO51qivpj7kXwo5km32xqrWoffpz/26C9CjEQGvD0xaA4Dg23Vf0RdIKJmaNw/S1e9DfjclK4siPSXd43Xf3fidZOdkSzjoKKhFcyT9DXi1TJb1U7iWkYon7777rgkck5KS5JFHHjFBZ7169fIEmXqZ5gYX9fXhiY7oatD7wQcfmM0KeDXt4ueff3bedzS12RsdkVYPPvigPPPMMxIrCHh9IIcXAIKvUgnPdWUDUTH9//NYg6l88fISLlr3VoMeHQHUSWg9evTweRsdXdTJaKpNmzYeVyDVWf+6/K+n65Tetnz58D3eYLDyjm+++WbnMsj5aVWJUNHAVIPdb7/91jyP+iXFGt3VyYC6eEg426xBtAauOjrsSUZGhtvLNY1BKzDYJVXBX0xa84GUBgBAOFWrVk0uv/xyZ1CkwYcvuuKaVU5Mf173REtK+bruzDPPzJO/6zriGM6RxsLYsmWL16oW+oVAS7GFiuY/60Ie+iXFKlGmp66ly8LZZmtFPus+8tPXiq7m544u9qE0L9lbwGw3BLw+kNIAAAi3f//736Ys1IkTJ+Sqq67yuuLWrFmzTKkva3S4e/fuHvfVkmPujqVB9dSpU835Pn36FKigYNG6udFIVwBTVgqBu+fTtb5wsOmXAquMmo7sWiO9OtLqqY5uKNtsVVfQXwjc+c9//mNeW+7oktY6yq+vE63H601mZqZtVlwj4PWBlAYAQLg1bdpU3nnnHRMwaS6ojgK+9957eQJOXYxh2LBhctlll5nAQ/M/dVTRU4UDa7JXp06dTEUAa8RWR/J04QcNgGrVqmVKl7lq0KCBcxKVtikaR3m1hJYaM2aMvP322+b5sFIC7rnnHnnuuecKVeKtKFxzd7U2r9K6vJ4m/4Wyzddee62zZJgGrQcPHjT/1yBWayDrF6SyZcu6va2Wf3vsscfMeW2DjlDrEsgWndSoC4hovWQtE6fn7YCA1wdSGgAAkaAjg1qySktaaVmqgQMHmp+qNVDR0V/NxdVUBg1ANLBasmSJ1zJS6q233pL169ebVby0GoJOcNMAWPM19bhaZcB1RFelp6c7g7kHHnjAOSnulFNOMaueRYN7771XGjVqZJ4LXU1Onx99rvS5e+mll8xll156aci/pJx11lnm/PLly72mM4S6zQMGDDCj/UoD07Jly5q8bK3BrBPRnn32WY81dpUGvLrplycdsdYcZH0daK1nraWsX8A0kNaUCW9fsKIJAa8PBLwAgEjRUUCtO/vGG29It27dzGQozavUHFsdedUgWEdodSSvUiXfEwHPPfdcE4xpIKY/qWuwpce85ZZbzMik1sB1R5eX1SV/rclXuiKbBsneUi3CSQM6XX1NF7XQQFxHxvVneV0VTCshaCpHOLgGuPrFwcrFDneb9VgzZ840k+E0qE5NTXWuqqeTG319UdF9NVDWmsyaE64Lk+gxdaKbBuWtW7c2q/Fp+62c32iX4IjG3yZCTIf29Y2ub1RfPxfos2MFvbt2ifjxeYIooz/hffnll+aPRSgKqSO60N+Ro4HYhg0bpG7dumYUKBx0cpB+pmtwkb/OKf5/qVjtE6X9o8GVXdHf8fUZsXfvXjOqrIF2/l8eCotXiw/k8AIAANgbAa8frC+RBLwAAAD2Q8BbiIA3/pI/AAAA7I+AtxBpDYzwAgAA2A9LC/uBlAYAgF3pJLU4nJ8O5MEIrx8IeAEAAOyLgNcP5PACAADYFwGvH8jhBQAAsC8CXj+Q0gAAAGBfBLx+IKUBAPzHBCkA0fbZQMDrB0Z4AcA3a6nX7OzsSDcFQBTK/t9nQySWhSbg9QM5vADgW0pKitkOHz4c6aYAiEKHDh1yfk6EGwGvHxjhBQDfEhISpFSpUpKRkSHHjh2LdHMARJFjx47JwYMHzWeEflaEGwtP+IEcXgDwT8WKFc0fts2bN0vp0qXNH7ekpKSQ/YHLycmRzMxMOX78eER+JkV40d/2y9nNzs42I7sa7KalpZnPiEgg4PUDKQ0A4B8NbmvVqiV79uwxf+QOHDgQ8j+oGmAXL148IqNGCC/6255SUlKkbNmyJtjVz4hIIOD1AykNAOA//YNWpUoVqVy5smRlZZlRuVDR4y9cuFDatm0bkbxAhBf9bT+JiYmmryL9BYWA1w+kNABA4ekfuNTU1JAH1ydPnpRixYoRAMUB+htFRQKMHxjhBQAAsC8CXj+QwwsAAGBfBLx+YIQXAADAvgh4/UAOLwAAgH0R8PqBlAYAAAD7IuD1AykNAAAA9kXA6wdSGgAAAOyLgNcPjPACAADYFwGvH8jhBQAAsC8CXj8wwgsAAGBfBLx+IIcXAADAvgh4/cAILwAAgH0R8PqBHF4AAAD7IuD1AykNAAAA9kXA6wdSGgAAAOzLtgHv1q1b5brrrpMKFSpI8eLF5YwzzpDly5eH5L5IaQAAALCvZLGh/fv3ywUXXCAdOnSQWbNmSaVKlWTdunVSrly5kNwfI7wAAAD2ZcuA99lnn5VatWrJ2LFjnZfVrVs3ZPdHDi8AAIB92TLgnTFjhnTp0kWuuuoqWbBggdSoUUMGDx4st9xyi9v9T5w4YTbLwYMHzWlWVpbZfElISDLZH5mZJyUri6jXbqw+9qevYX/0d3yhv+ML/R1fsoLYzwkOh/3GLYsVK2ZOhw0bZoLeZcuWyd133y2jR4+W/v37F9h/5MiRMmrUqAKXT5gwQdLT033e3yOPXCC//VZR7r9/mVxwwbYgPQoAAAB4cvToUenbt69kZGRI6dKlJe4C3tTUVGnZsqX88MMPzsvuuusuE/guXrzYrxFeTYnYvn27mfTmS6dOSbJgQaJ89NFJueoq2z1dcU+/Ic6ZM0c6deokKSkpkW4OQoz+ji/0d3yhv+PL3r17pVq1akEJeG2Z0qAPvkmTJnkua9y4sXzyySdu909LSzNbfvpm8ecNk5Rk5fImC+8v+/K3vxEb6O/4Qn/HF/o7PqQEsY/9CniTrIgviBISEuTkyZNFuq1WaFi7dm2ey/7880+pU6eOhAJVGgAAAOzLr4A32rIe7rnnHmndurU89dRTcvXVV8uPP/4ob7/9ttlCgTq8AAAAMR7wjhgxwuv1M2fOdC760LRpU2nVqpVUqVLF/H/nzp0mt/bXX381o7qae9utW7eAGn3OOefItGnT5OGHH5bHH3/clCR76aWXpF+/fhIKlCUDAACI44BXA04Ndps1a2ZGWDUYdUeD3ttuu83s2717dxk+fHjRWy0il156qdnCgZQGAACAOF1aeO7cuabkV4MGDWTRokUeg12l13333XdSv359UyLsm2++EbsgpQEAACBOA95XXnnFpCk89NBDUqJECZ/76z66r+YEv/rqq2IXpDQAAADEacBr5e2eeeaZft9GUx+sFAe7IKUBAAAgTgPeffv2mVMtCOwva1nf/fv3i10Q8AIAAMRpwFu9enVz6mnBB3emTp3qXDzCLsjhBQAAiNOA95JLLjH5uG+99ZZMnjzZr2BX99W830BLk4UTObwAAABxGvD+61//Mmsb5+TkyLXXXis9e/aU6dOny9atW81617qSmp7Xy3r16iV9+vSR7OxsKVWqlKmhaxekNAAAAMR4HV5PatSoIZ9//rn06NHD5Obqed080dFgDXY/++wzc1u7IKUBAAAgTkd4VZs2bWT16tXSu3dvSUxMNEGtu02vu+KKK+SXX36Rdu3aiZ2Q0gAAABCnI7yWWrVqyZQpU8wywvPmzTMBsFXBoVy5cnLGGWdIhw4dpGrVqmJHpDQAAADEecBrqVKlilxzzTVmiyUEvAAAAHGc0hAPyOEFAACwLwJeP5DDCwAAYF9BS2nYu3evLF68WP7++285dOiQKT/my/Dhw8UOSGkAAACI44B3165dcs8995hFJbTubmEQ8AIAACCqA979+/fLhRdeKOvXrzelx2I9hzeGHyIAAEDMCiiH95lnnpG//vrLBLudO3eWr776Snbv3m3SGXT1NV+bXTDCCwAAEKcjvLpiWkJCgnTv3l1mzJghsYqAFwAAIE5HeDdv3mxOhwwZIrGMsmQAAABxGvCWLFnSueBELKMsGQAAQJwGvLpksNq0aZPEMlIaAAAA4jTgve2228yEtQ8//FBiGQEvAABAnAa8V199tfTr10+mTZtmKjbEKsqSAQAAxGmVhoULF8rAgQNlw4YN8sgjj8inn34qffv2lUaNGkl6errP27dt21bsgBFeAACAOA1427dvb8qSWVasWGE2f+jtCrsyW6QQ8AIAAMTx0sKxvMKahbJkAAAAcRrwzps3T+IBZckAAADiNOBt166dxANSGgAAAOK0SkO8IOAFAACwLwJeP1CWDAAAwL4IeP3ACC8AAECc5vBedNFFRb6tliWbO3eu2CngnT1b5LrrIt0aFFZOTpJs23aWTJqU5OxLxK5w9XeXLiLXXx+64wMAoiTgnT9/vglcvZUmc63Tq6x9818ezSpWzD1dty53g91o1FMr0o1AjPX35MkiffqIpKaG/K4AAJEMeHWlNF+B65EjR+Svv/6SAwcOmH0bNGgg1apVEzu58UYRXTjuwIFItwRFkZ2dLb//vkYaN24iSUlJkW4OYqC/H3xQJCtLZPt2kTp1QnIXAIBoGuH115dffil33XWX7Nu3T95991254IILxC402NWgF/aUlZUjX375t3Tr1khSUgh4Y104+vvVV0U2bBD55x8CXgCwg7BlNHbr1k0WLVokycnJ0qtXL9m6dWu47hoAgqpmzdxTDXgBANEvrFN4qlatKvfcc4/s2bNHnnvuuXDeNQAEDQEvANhL2OesX3jhheZ05syZ4b5rAAgKAl4AsJewB7yp/5vSvG3btnDfNQAEBQEvANhL2ANezeNV6ToTDABsiIAXAOwlrAHv4sWL5fHHHzflyVq1ahXOuwaAoCHgBYA4KkumwasvOTk5sn//flm+fLksXbrU/F8DXp28BgB2Dni1Du/JkyLJAX2SAgBCLaCP6ZEjRxZqxTRdZU3LkmmFhk6dOgVy1wAQMVWqiOiaFtnZIjt3itSoEekWAQC8CXhcwtuywkoD4lKlSkndunWlXbt2cuutt0qTJk0CvVsAiBgNdqtXF9myJTetgYAXAGI44NX0BACI17QGK+A999xItwYAEFVVGgAgFjBxDQDsg4AXAIqAgBcA4jzgPXnypOzevdtsej7YrMlyrlujRo2Cfj8A4AkBLwDYR9CK6fz+++/yxhtvyDfffCPr1q1zTmbTYPS0004zVRkGDRoUtAlrTZs2Nfdl0eoPABAuBLwAYB9BiRIffvhh+c9//mMmseWv2qD/X7t2rfz555/y5ptvyv333y9PPfVUwPepAW7VqlUDPg4AFAUBLwDEUcB75513mpFdK9Bt3LixnHvuuc5gdMeOHfLjjz/KmjVrJDs7W5599lk5cuSIvPzyywHdr44iV69eXYoVKybnn3++PP3001K7dm23+544ccJsloMHD5rTrKwssyG2WX1MX8eHcPW31uIVSZGtWx1y4sRJSWRGRETw/o4v9Hd8yQpiPyc4fBXS9eL777+XNm3amLQFDXTffvttad26tcdlhTWlYfXq1Wb/7777zuO+vsyaNUsOHz4sDRs2lO3bt8uoUaNk69at8uuvv5qav+5yfnWf/CZMmCDp6elFagOA+HbyZIJcdVUPcTgSZNy4r6Rs2f//Ug0ACNzRo0elb9++kpGRIaVLl45cwHvDDTfI+PHjpV69erJixQopU6aM1/21wWeffbZs2LBB+vXrJx988IEEw4EDB6ROnTrywgsvyMCBA/0a4a1Vq5YJlitUqBCUNiC6vyHOmTPH5JGnpKREujmIof6uUydZtm9PkCVLsuSss0J6V/CA93d8ob/jy969e6VatWpBCXgDSmnQUVodrX3ooYd8BrtK93nwwQfltttuM7cNlrJly0qDBg3kr7/+cnt9Wlqa2fLTNwtvmPhBf8eXcPS35vFu366pW3pfIb0r+MD7O77Q3/EhJYh9HFDWmebnqhYtWvh9m7P+NwyyUxegDxJNb1i/fr35FgAA4cLENQCwh4ACXp0wpnQSmr+sfd2NuPrrvvvukwULFsjGjRvlhx9+kF69eklSUpJce+21RT4mABQWAS8AxEHAW7duXXP6+eef+30ba1/N+y2qf/75xwS3Omnt6quvNnm4S5YskUqVKhX5mABQWAS8AGAPAeXwduvWTVatWiWvvvqqXHLJJdKxY0ev+8+bN8/sq3m/etuimjhxYpFvCwDBQsALAHEwwjt06FAza05nTXbt2lXuuOMO+emnn8wCFBY9r5fpdRoUZ2ZmmtvobQHAzgh4ASAORngrVqwokydPlssuu8wEsrqSmm6pqalSvnx5M5KrJSX0OqUV0PS6KVOmUA4MQEwFvFrgMSEh0i0CALgT8NpAnTt3NvmzLVu2NAGtblrzVmvcbtu2zZy3Ltd9li5dKhdffHGgdwsAEVejRu7p8eMi+/ZFujUAgJAtLayaN29ulg9etmyZfPPNN2bFs33/+/TXkd7TTz/dBLnnnHNOMO4OAKKCFpupXFlk167cUV5+uAIAGwe8M2bMMKc6Ka1EiRIe99OAlqAWQLylNVgBb7NmkW4NAKDIKQ09e/aUK664QjZt2pTn8ptuusks5avpCwAQj5i4BgAxlMOrObj5jRs3zmz79+8PdrsAwBYIeAEgRgJea1U0XcIXAPD/CHgBIEYC3hr/m4r83Xffhbo9AGArBLwAECOT1nSy2pgxY+Rf//qXqcbQoEEDSUlJcV7/xhtvSGWdqlxIw4cPL/RtACCaEPACQIwEvI8++qh8+umnZhGJqVOnFsjt1cUmioKAF0CsBLxbtrD4BADYOqWhVq1aZnngm2++WU455RQzuquBrq6kpqyFJQq7AUCsLD5x5IjIwYORbg0AIKCFJzToffvtt/NclpiYaILe1atXS5MmTfw9FADEjPR0XWAnd6U1TWsoUybSLQIABH1pYQCId+TxAkAMLy08duxYc1rT+rQHgDikH4G//ELACwAxGfD2798/eC0BAJtihBcAohspDQAQIAJeAIhuBLwAECACXgCIbgS8ABAgAl4AiG4EvAAQIAJeAIhuBLwAEKSA98ABkcOHI90aAEB+BLwAEKBSpURKl849v3VrpFsDAMiPgBcAgoC0BgCIXgS8ABAEBLwAEL0IeAEgCAh4ASBGV1pzlZOTI/PmzZPFixfLjh075OjRo/Lkk09KtWrVnPtkZmbKyZMnJSkpSdLS0oJ11wAQcQS8ABDjAe8XX3whd911l2zatCnP5ffdd1+egPedd96RO++8U0qWLCnbtm2TEiVKBOPuASDiCHgBIIZTGsaMGSOXX365bNy4URwOh1SoUMGcunPzzTdLmTJl5PDhwzJt2rRA7xoAogYBLwDEaMC7bt06GTJkiDl/0UUXyZo1a2TXrl0e909NTZXevXubgHj27NmB3DUARBUCXgCI0YD3xRdfNDm5TZs2lS+//FIaNWrk8zZt2rQxpytXrgzkrgEgKgPePXtEjh+PdGsAAEELeL/99ltJSEiQoUOHmtFbf9SvX9+cbtmyJZC7BoCoUrasSHp67nkWnwCAGAp4//nfb3fNmjXz+zbWRDWt4gAAsSIhgbQGAIjJgFdHdwsbvO7du9ec6uQ1AIglBLwAEIMBb40aNczp33//7fdtFi1aZE7r1asXyF0DQNQh4AWAGAx427dvbyouvP/++37tn5GRIaNHjzYjw1rVAQBiCQEvAMRgwHvbbbeZ4HXBggUybtw4n6kMPXv2NKuwJScny6BBgwK5awCIOgS8ABCDAW+LFi3k7rvvNqO8AwcOlD59+sjkyZOd1//www8yYcIEU6tXqzMsXLjQBMiPPfaY1KlTJxjtB4CoQcALADG6tPB///tfOXHihLz55psydepUs1mT2XQE2GKtvqYlzB599NFA7xYAog4BLwDE6NLCGty+/vrr8vXXX5ucXv2/Breumzr//PNl5syZ8sILLwSj3QAQtQHvzp0imZmRbg0AIGgjvJZOnTqZ7dChQ2YVNV1iODs7WypUqCDNmzeXihUrBuuuACAq6cecrsGjwe727SJkbgFAjAW8llKlSknbtm2DfVgAsM3iE1qpUdMaCHgBIEZSGgAA/488XgCIPgS8ABBEBLwAEGMpDTfddFORb6uT2959991A7h4Aog4BLwDEWMCri01YJcgKQys3EPACiEUEvAAQYwFv7dq1fQa8R44cMausWUGuVmtIT08P5G4BIGoR8AJAjAW8Gzdu9Gu//fv3y8cffyzDhw+XsmXLyowZM6Rhw4aB3DUARCUCXgCI00lr5cqVk8GDB8v3339v6vN27drVBMHB8Mwzz5iRY13BDQCiJeDVOrwnT0a6NQCAsFdp0FHdu+66y4wM65LEgVq2bJm89dZbcuaZZwalfQAQqMqVRZKTRbKzc1dcAwBEXtjLkl188cXm9NNPPw3oOIcPH5Z+/frJmDFjzAgyAESDpCSR6tVzz5PWAAAxutKaLyVLljSnmzdvDug4Q4YMke7du5sA+oknnvC674kTJ8xmOXjwoDnNysoyG2Kb1cf0dXyIhv6uUSNJNm9OlI0bT8pZZzki1o54EA39jfChv+NLVhD7OewB78qVK81pSkpKkY8xceJE+emnn0xKgz+efvppGTVqVIHL582bR8WIODJnzpxINwFx0t+JiS017JU5c36XYsX+jlg74gnv7/hCf8eHo0eP2jPg3bBhg4wcOdJMMmvevHmRjrFlyxa5++67zYu9WLFift3m4YcflmHDhuUZ4a1Vq5Z06NBBKlSoUKR2wF7fEPX10qlTp4C+aMEeoqG/589PlO+/FylTpol069YoIm2IF9HQ3wgf+ju+7N27NzoC3g8++MDnPjk5OaYiw/Lly+Wzzz4z0boGvIMGDSrSfa5YscJUejjrrLOcl2VnZ8vChQvltddeM6kLSZpE5yItLc1s+embhTdM/KC/40sk+7t27dzTrVuTJCUl7+cRQoP3d3yhv+NDShD7OKCAd8CAAYVaaU0Xn1BaqaFPnz5Fus+OHTvK6tWr81x24403SqNGjeTBBx8sEOwCQLhRixcAokvAKQ1WEOuLLjjRtm1bU4+3c+fORb6/UqVKyemnn57nshIlSpjUhPyXA0AkEPACQAwFvJqT60tiYqIJUjXgBYB4Cni3btW0Lv0cjHSLACC+BRTw1qlTR6LB/PnzI90EAHCqWjU3yNWV1nbtyv0/ACByGHcAgCDTeRZWkEtaAwBEHgEvAIQAebwAED0IeAEgBAh4AcBmObz16tUL+h1rObP169cH/bgAEA0IeAHAZgHvxo0bg37HhanfCwB2Q8ALADYLePv37x/6lgBADCHgBQCbBbxjx44NfUsAIIYQ8AJA9GDSGgCEOOD1c0FKAECIEPACQAhUr557euKEyN69kW4NAMQ3Al4ACIG0NJHKlXPPk9YAADZeWthTRYc9e/bIsWPHxOHjd7y2bdsG++4BIKrSGnRpYQ14mzePdGsAIH4FJeBdu3atPPXUUzJjxgw5ePCg32XJTupC8wAQwwHvTz8xwgsAtg94p0+fLv369ZPjx4/7HNEFgHhCpQYAiIGAd8uWLXLdddeZ9IUaNWrI/fffL+np6XLrrbeaEdxvvvlG9u3bJ8uXL5cPP/xQtm3bJhdeeKGMHDlSkpKSgvcoACAKEfACQAwEvK+88oocPXpUSpUqJUuXLpXq1avLb7/95ry+Q4cO5rR3794yfPhwGThwoEyaNEneffdd+eijjwJvPQBEMQJeAIiBKg06gqsjuYMHDzbBrjfFixeX8ePHS4sWLWTixInyySefBHLXABD1CHgBIAYCXq3IoFq3bu28TANgS/5JaYmJiXLXXXeZXN/33nsvkLsGgKjH4hMAEAMB75EjR8xprVq1nJdpDq8lIyOjwG2aNm1qTn/++edA7hoAol6NGrmn+lHp5uMQAGCHgLdMmTLmVCs0WCpUqOA8v379+gK3sYJgrdULALFMv/+XL597nrQGALBpwNuwYUNz+vfffzsv0wlsderUMednz55d4DZz5swxp2XLlg3krgHAFsjjBQCbB7znn3++OV2yZEmeyy+99FKTp/v888/LvHnznJdPnjxZXn75ZZPne8EFFwRy1wBgC1bGFwEvANg04O3WrZsJbD/99FPJzs52Xm7V4z18+LBcfPHFUqlSJTPye+2115r0B528pvsAQKxjhBcAbB7wtm/fXkaMGCE33nijbN261Xl57dq1ZcqUKSbHVwPivXv3mgluej4tLU3GjBkj5513XjDaDwBRjYAXAGy+8ISmJmjA607Xrl1l3bp1MnXqVLMYhZYoO+200+Tqq682q7IBQDwg4AUAmwe8vmjFhttuuy2UdwEAUY2AFwBsntIAAPCOgBcAbB7wah7ua6+9Jrt37w5eiwAghlgZXFqC/NChSLcGAOJTQAHvjz/+KHfffbfJydWc3fHjxztXXwMAaG1yXaQn97zL3F4AgF1yeHUSmk5M0wlpusiEboMGDZLLLrtM+vXrJ5dccokkJSUFr7UAYNO0Bh3h/fhjXV5dbK1lS5F69SLdCgAIY8C7du1aWbFihUyYMEEmTZok27Ztk6NHj5rzuumkNa3K0LdvX2ndunUgdwUAtl584rffRB5/XGyvcmWRbdtEGMsAEFdVGs4++2yz/ec//zGrqmnwqwtRHDhwQPbs2SNvvvmm2XS5YR311eC3cePGwWk9ANjAgw+K5OSIZGaKrS1aJLJrl8jGjSKnnhrp1gBABMqSaU3eiy66yGxvvPGGzJw50wS/eqqrq23cuFGeeuopszVr1kyuu+46GTZsWLDuHgCiVvv2uZvdNW8u8vPPImvWEPACsJeQlCVLTU2VXr16mdXWdu7cKe+++6507NjRLCmsq62tWrWKpYUBwGaaNMk91YAXAOwk5HV4S5UqZZYe1glt48aNk7Jly4b6LgEAIQx4f/890i0BgChaaU399NNPJrVh4sSJsn379lDfHQAgRBjhBWBXIQl4//77b/noo49MoPvnn3+ayzSVQZUoUUJ69uxpJrABAOzDmm+sAa9+pCckRLpFABDmgFdXW9NRXA1ydUEK1yA3OTlZOnfubILcyy+/XNLT04N1twCAMKlfXz/PRXR9oS1bRGrXjnSLACAMAa+uqqYlyHQ099tvv5Xs7Ow8ge75559vglytxVuxYsVA7goAEGEpKSINGuSO8OpGwAsgLgLeypUrm5JjrkFuo0aNnPV269atG5xWAgCiJo/XCngvuSTSrQGAMAS8x44dM6fVq1eXa665xgS6LVq0COSQAIAoxsQ1AHEX8Gq5MQ1yO3ToYBaeAADENkqTAYi7gFcXlAAAxA8qNQCwo5AvPAEAiB06aS0xUeTAAZEdOyLdGgDwDwEvAMBvxYqJnHpq7nnyeAHYBQEvAKBQmLgGwG4IeAEAhULAC8BuCHgBAIVCwAvAbmwZ8L755pty5plnSunSpc2mK7rNmjUr0s0CgLhAaTIAdmPLgLdmzZryzDPPyIoVK2T58uVy0UUXyeWXXy6//fZbpJsGADGvYcPc0927czcAiOk6vJHSo0ePPP9/8sknzajvkiVLpGnTpgX2P3HihNksBw8eNKdZWVlmQ2yz+pi+jg/0d+ilpoqcckqybNyYIKtXn5Q2bXKXlo8E+ju+0N/xJSuI/WzLgNdVdna2TJkyRY4cOWJSG9x5+umnZdSoUQUunzdvnqSnp4ehlYgGc+bMiXQTEEb0d2hVqHCubNxYVaZM+U0OHdoY6ebQ33GG/o4PR48eDdqxEhwOXSunaOrWrSuJiYny9ddfS/369f26zebNm6V9+/ZmKeL169cX9a5l9erVJsA9fvy4lCxZUiZMmCDdunVzu6+7Ed5atWrJ9u3bpUKFCkVuA+zzDVE/HDt16iQpKSmRbg5CjP4Oj4ceSpQXXkiSIUOy5cUXcyLWDvo7vtDf8WXv3r1SrVo1ycjIMHO2IjbCu2nTJhO4ZmZmFurFunHjRnO7QDRs2FBWrVplnoSpU6dK//79ZcGCBdLEmk3hIi0tzWz56ZuFN0z8oL/jC/0dWqefnnv6xx9JkpKSFOnm0N9xhv6ODylB7GPbpjSkpqY6R5XPPvtsWbZsmbz88svy1ltvRbppABDzqNQAwE7CXqVBR2RVsHNnc3Jy8qQtAABCp1Gj3NNt20QOHIh0awAgykZ4x48fb07r1KlT5GM8/PDD0rVrV6ldu7YcOnTI5O/Onz/f5BIDAEKvTBmRGjVEtm7NHeX1MGcYAOwX8Gq9W3duvPFGKVGihNfb6ujr33//Lbt27TL5u507d5ai0mPccMMNZtJZmTJlzCIUGuxqEjsAIHxpDRrw6oprBLwAYibg1VFUDVZdCzvoec2fLYx69eqZUdqievfdd4t8WwBA8AJerQ7FEsMAYirgbdu2bZ7qCloVQf+vk8a8jfDqPsWKFTOlJVq3bi3XXHONzxFhAIA9Jq4R8AKIuRFeV1qDV40bN85tOTAAQOwi4AUQF5PWNI9WR2/LlSsXvBYBAGyhcePc082bRQ4fFilZMtItAoAQBLw6sgsAiE+6UGXlyjqRWBegEGnZMtItAoAI1uHVJYSXLl0qO3fuDMfdAQDChLQGADEf8Gp5sDfeeMNs1oISrv766y8zoa1BgwZmslqNGjWkd+/esn///kDuFgAQJQh4AcR8wPvpp5/KHXfcYZb01Xq4+evu6uIQq1atMqXLdNPV0KZPny6XX355oO0GAEQBAl4AMR/wzp4920xa69Wrl9v8Xk1lUJdddpkJinv06GEC3++//14mTZoUyF0DAKIAAS+AmA94165da07PO++8Atfpcr/W6mw6qnvnnXfKZ599JhdffLEJeidOnBjIXQMAoijg3bBB5NixSLcGAEIQ8O7evduc1qxZM8/lx44dkyVLlpjR31tvvTXPdTfddJM5/emnnwK5awBAFNAqDVqZMidH5M8/I90aAAhBwHvgwIE8C1BYNNjNysoyAa+O6LqqW7euc8IbAMDedPFN0hoAxHTAW/J/VcZ37NjhdkU2XX0t/6IUKSkp5jQ5OaASwACAKEHACyCmA95GjRqZ06+++irP5Z988okZ3W3Xrl2B21jBcZUqVQK5awBAlCDgBRDtAhpm7d69u0lfePvtt6Vx48bSpk0bU51hzZo1JuC94oorCtzGyt3VmrwAAPsj4AUQ0wGv1uDVRSe2b99uzrs6//zzpUOHDgVu8/nnn5tg+JxzzgnkrgEAURbwrlsnkpkpkpoa6RYBQBBTGnSxiW+++UbOOuss5+ISuulI7+TJkwvs//PPP8uyZcvM+U6dOgVy1wCAKKE/2JUqJZKdrStsRro1AFBQwDPHNJVh+fLlsmHDBpOfW61aNTnllFM87j927FhnfV4AQGxUamjcWOTHH3PTGqwRXwCIFkErlaDlxqySY540a9bMbACA2KJBrhXwAkBMpTQAAKCYuAYgLkZ4c3JyZN68ebJ48WKT2nD06FF58sknTYqDJTMzU06ePClJSUmSlpYWrLsGAEQYAS+AmA94v/jiC7nrrrtk06ZNeS6/77778gS877zzjtx5551mwYpt27ZJiRIlgnH3AIAoCXjXrhU5eVIXF4p0iwAgiCkNY8aMkcsvv1w2btxoKjRUqFDBnLpz8803m8oOhw8flmnTpgV61wCAKFGnjkjx4rllyf7+O9KtAYAgBrzr1q2TIUOGOKsu6IITu3bt8rh/amqq9O7d2wTEs2fPDuSuAQBRJDFRV9/MPf/775FuDQAEMeB98cUXTU5u06ZN5csvv3QuNeyN1uhVK1euDOSuAQBRhjxeADEZ8H777bdm1bShQ4ea0Vt/1K9f35xu2bIlkLsGAEQZAl4AMRnw/vPPP+a0MLV1rYlqWsUBABA7CHgBxGTAq6O7hQ1e9+7da0518hoAIHZYAa/m8ObkRLo1ABCkgLeGLqAuOiPX/ym5ixYtMqf16tUL5K4BAFFGP9Y1u+3YMZF8VSoBwL4Bb/v27U3Fhffff9+v/TMyMmT06NFmZFirOgAAYofW3m3YMPc8lRoAxEzAe9ttt5ngdcGCBTJu3DifqQw9e/Y0q7AlJyfLoEGDArlrAEAUatw495Q8XgAxE/C2aNFC7r77bjPKO3DgQOnTp49MnjzZef0PP/wgEyZMMLV6tTrDwoULTYD82GOPSR2tUg4AiClMXAMQjQJe/PG///2vnDhxQt58802ZOnWq2azJbDoCbLFWX9MSZo8++migdwsAiEIEvABicmlhDW5ff/11+frrr01Or/5fg1vXTZ1//vkyc+ZMeeGFF4LRbgBAlAe8HlaZBwD7jfBaOnXqZLZDhw6ZVdR0ieHs7GypUKGCNG/eXCpWrBisuwIARKnTThNJShI5dEhk61aRmjUj3SIACGLAaylVqpS0bds22IcFANiAliXToPePP3JHeQl4AcRESgMAAO4qNVCaDEDcBLz79++X3bt3O3N5AQCxjYlrAGIi4D158qT8+uuvsmLFChPM5nf8+HEZPny41KxZ0+TuVq1a1aQ6XHnllfLbb78Fo90AgChFwAvA1gGvjtJqIKtBbLNmzaRVq1YmmL3wwgtl2bJlZp/MzEzp0qWLPPnkk7J9+3ZnpYajR4/KtGnTzG3mzp0bqscDAIiSgFfHN/hxD4DtJq3deOON8uGHH5rzrikKusDEJZdcIkuXLpU33nhDvvvuO3N5+fLl5bTTTjMjwmvWrJFjx46ZrV+/frJ27VopU6ZMsB8PACDCdHlhLce+f7/Irl0iVapEukUA4p3fI7zz5s2TDz74wJxPS0uT3r17y3333SdXXXWVFC9eXA4cOCAvvviiWWI4JSVF3n77bZPusHjxYjP6u2fPHrO/0st9LUUMALCn4sVF6tXLPU9aAwBbBbxjx441p5UrVza5u1OmTJHnnntOJk2aZP5fpUoVE+RmZGTIPffcIzfffLNzxTWlQbHur+kOOjqsi1AAAGI7rYFKDQBsFfBquoIGsBrMNrZqzvxPo0aNzOW60IS6/vrrPR6nf//+5pTJawAQu6w/E4zwArBVwLtt2zbnEsHuuF5ev359j8fRnF61b9++wrQTAGAjVGoAYMuA98iRI86JaO6ULVvWeV5zfD0pVqyYs5oDACA2EfACsHUdXte8XH8uBwDEn0aNck937hTZuzfSrQEQ72y5tPDTTz8t55xzjlnMQifR9ezZ05Q5AwBEh1KlRGrXzj3PxDUAkWbLgHfBggUyZMgQWbJkicyZM0eysrKkc+fOzrQLAEDkNW2ae/rjj5FuCYB4V6iFJ5QuLKGjqvnt0uri//P44497vL3rfkX11Vdf5fm/1vS1yqW1bds24OMDAALXtavIrFkikyeLDBsW6dYAiGeFDnjffPNNj9dZebyjRo2ScNLav94m1J04ccJsloMHD5pTHRnWDbHN6mP6Oj7Q39GjVy+RoUOTZenSBPnjjyw59dTg3wf9HV/o7/gSzH5OcLiuEexFYmJwsx80OLbq9gYiJydHLrvsMrPS26JFi9zuM3LkSLdB+IQJEyQ9PT3gNgAA3Bsx4nz5+efK0rfv73L11X9GujkAbOTo0aPSt29fM7BZunTp8AS8mjcbbO3atQv4GLfffrvMmjXLBLs1a9b0e4S3Vq1asn37dqlQoULAbUD0f0PUXO9OnTqZZa8R2+jv6PLBBwly883J0qiRQ37++aQEu6AP/R1f6O/4snfvXqlWrVpQAt7kcAanwXbHHXfIF198IQsXLvQY7Fp1gd3VBtY3C2+Y+EF/xxf6OzpceaXIkCEif/yRIL//niLNmoXmfujv+EJ/x4eUIPaxLas06KC0BrvTpk2Tb7/9VurWrRvpJgEA3ChTRqR799zzH38c6dYAiFe2DHi1JNn48eNNDq7W4t2xY4fZjh07FummAQDyufba/w94c3Ii3RoA8ciWAa9WitB8jvbt25vcDmubNGlSpJsGAMhHR3h1IYrNm0UWL450awDEI9umNLjbBgwYEOmmAQDyKV5c5Iorcs9PmBDp1gCIR7YMeAEA9kxr0EUoKKEKINwIeAEAIdexo0ilSiJ79ojMnRvp1gCINwS8AICQS04Wufrq3POkNQAINwJeAEBY9O2bezptmghFdQCEEwEvACAszj9fpE4dkcOHRb74ItKtARBPCHgBAGGhywq71uQFgHAh4AUAhI0V8M6cKXLgQKRbAyBeEPACAMLmjDNEmjYVyczMzeUFgHAg4AUAhDWtwZq8RrUGAOFCwAsACKtrrsk9/fZbkR07It0aAPGAgBcAEFb16omcd55ITk7uymsAEGoEvACAiE1eI60BQDgQ8AIAwk5XXUtMFFm6VOTvvyPdGgCxjoAXABB2VauKXHRR7nlq8gIINQJeAEBEuFZrcDgi3RoAsYyAFwAQEb16iaSmiqxZI7J6daRbAyCWEfACACKibFmR7t1zzzN5DUAoEfACACKe1jBxYm6ZMgAIBQJeAEDE6AhvqVIimzaJLF4c6dYAiFUEvACAiClePDeXV1GtAUCoEPACAKJiEQpdde3kyUi3BkAsIuAFAERUx44ilSqJ7N4tMndupFsDIBYR8AIAIiolReSqq3LPU60BQCgQ8AIAoqZaw6efihw7FunWAIg1yZFuAAAA558vUru2yObNItOni/Ts6d/tsrJETpxINEGyv/m/SUm5C14AiB8EvACAiEtMzJ289uyz/z/a658UEelRqPvSgPftt0VuuqmwrQRgV6Q0AACiws03566+FmrZ2SLPPSficIT+vgBEB0Z4AQBRoX59kV27RI4f9/82WVlZMnv2bOncubOk6Ow3H44cETn1VJG1a0V+/FHk3HMDazMAeyDgBQBEDY1Z/Yhb8+TwFi9+0qzW5s/tdL8rrhAZP15k3DgCXiBekNIAAIgr/fvnnk6cWLjRZAD2RcALAIgrHTqI1KwpcuCAyOefR7o1AMKBgBcAEFe0SsP11+eef//9SLcGQDgQ8AIA4jat4auvRHbujHRrAIQaAS8AIO40bChy3nm5Jco++ijSrQEQagS8AIC4HuXVag3U5AViGwEvACAu9ekjkpYmsnq1yKpVkW4NgFAi4AUAxKVy5UQuuyz3PJPXgNhGwAsAkHhPa5gwIXcRCwCxiYAXABC3unQRqVJFZPdukVmzIt0aAKFCwAsAiFvJySL9+uWeJ60BiF0EvACAuGalNeiqa3v3Rro1AEKBgBcAENfOPFOkRYvcHN6PP450awCEAgEvACDuWaO8pDUAsYmAFwAQ9/r2zc3nXb5cZM2aSLcGQLAR8AIA4l6lSiLduuWeZ5QXiD0EvAAAuKQ1jB8vkp0d6dYACCYCXgAARKR7d5Hy5UW2bRP55ptItwaAxHvAu3DhQunRo4dUr15dEhISZPr06ZFuEgDA5tLSRK69Nvc8aQ1AbLFlwHvkyBFp1qyZvP7665FuCgAghgwYkHs6bZpIRkakWwMgWJLFhrp27Wo2AACC6eyzRZo0ya3UMHmyyC23RLpFAOI24C2sEydOmM1y8OBBc5qVlWU2xDarj+nr+EB/x5dQ9Pd11yXKv/6VJOPG5ciAAcxeiya8v+NLVhD7OS4C3qefflpGjRpV4PJ58+ZJenp6RNqE8JszZ06km4Awor/jSzD7u2rVYpKY2Fl++CFR3n33W6lW7UjQjo3g4P0dH44ePRq0Y8VFwPvwww/LsGHD8ozw1qpVSzp06CAVKlSIaNsQnm+I+uHYqVMnSUlJiXRzEGL0d3wJVX9PnOiQ2bMTZMuWDjJwYE7QjovA8P6OL3v37g3aseIi4E1LSzNbfvpm4Q0TP+jv+EJ/x5dg97dOXps9W+Sjj5Lk3/9OkkRbTvGOXby/40NKEPuYtzAAAPn07ClSurTIpk1aCjPSrQEQlwHv4cOHZdWqVWZTGzZsMOc3b94c6aYBAGJA8eIiV1+de37cuEi3BkBcBrzLly+XFi1amE1pfq6eHz58eKSbBgCIsZq8U6fqQEukWwMg7nJ427dvLw6HI9LNAADEsNatRerXF/nrL5FPPxW54YZItwhAXI3wAgAQagkJ/x/kvveeCOMsgH0R8AIA4IEGvFqhYcECreke6dYAKCoCXgAAPKhTR+S//809/8gjImPGRLpFAIqCgBcAAC+GDtUFjHLPDxqUm88LwF4IeAEA8OHJJ0UGDhTJyRG59lpdmj7SLQJQGAS8AAD4MYFt9OjcBSkyM0Uuv1xk5cpItwqAvwh4AQDwQ3KyyMcfi7RrJ3LokMgll+SWLAMQ/Qh4AQDwU7FiIp99JtKsmciuXSKdO4ts3x7pVgHwhYAXAIBCKFNG5KuvROrV06XtRbp2FTlwINKtAuANAS8AAIVUtarI7NkiVaqI/Pxzbk7vsWORbhUATwh4AQAoglNPFfn6a5HSpUUWLsyt3nDyZKRbBcAdAl4AAIpIc3k//1wkLS03t/e221iCGIhGBLwAAASgbVuRSZNylyB+7z2Rf/0r0i0CkF9ygUsAAEChaA6vLjusi1M884xIuXIi119fuDq/mg+spwCCj4AXAIAguOkmkd27RR56SOTBB3O3wmjYUOSRR3JzgbXmL4DgIaUBAIAgeeABkREjRNLTRZKS/N90ZHftWpEbbhBp1Cg3NSIrK9KPBogdBLwAAASJBq4jR4ocOZJbscHfTev4Pv20SMWKIuvX56ZGnHZa7nLGJ05E+lEB9kfACwBAhGlpM02F2LhR5L//zc3n3bRJ5Pbbc8ufvfoqdX6BQBDwAgAQJUqUEBk2LHcFt1deEalRQ2TrVpG77spd2e2FF3JHjwEUDgEvAABRpnhxkTvvzE1vePNNkdq1RXbsELn3XpFTTsmtBHHoUKRbCdgH80ABAIhSuqDFoEG5FSA+/FDkqadE/v5b5OGHcys6VK4sUq2aSPXquafuzmt6REpKpB8JEFkEvAAARLnU1NyJbP37i3z8sciTT+ZWddBRX91WrvQ+kU4nw1WtGp7AV+9PN12Iw92p63mtUHHGGSI9eohceCGBOUKHgBcAAJvQ+ry6oMV11+UGutu3//+2bVvB87qPVoHQ+sC6RaNvvhF58UWRsmVFunYVuewykUsuyf0/ECwEvAAA2IyOjlppC97k5Ijs3ZsbAO/cKZKdHfq2ORy59+t66umy48dF5s8XmTlTZM+e3NFr3TSwb9MmN/jV0V+tVAEEgoAXAIAYpakDlSrlbtFqwIDcQHzJEpHPPxeZMUPk999F5s3L3e65R6RJk9zAt1u3hLAE7Yg9cR3w7jmyR3KK5RT6diVTS0rxlOLuj3l0jzj0a2sRpKekS4nUEm6v23dsn2TnFO1dXiy5mJRKK+X2ugPHD0hWdtGW80lNSpUyxcq4vS7jeIZkZmcW6bgpSSlStpj737IOnTgkx08eL9TxsrKyJONkhnkOq6RUcbvPkcwjcjTraJHam5CQIBXTK7q97ljWMTmceViKqlIJ93+lTpw8IQdPHCzycSukV5DEhIJFWrTPtO+KqlzxcpKcWPBj5WTOSdl/bH+Rj6uvM3295ZfjyJG9R/e67e/dR3ZLio+EwNJppSUtOc3tdXr7ouIzwl6fEZakxCQpX7y82+v4jAjtZ4Qj4aQ0aL5f7m0ucu9jIn9vEJn9tcjXs0UWLxZZs1Fkzasiz74qkpB4viQm6udJwv8f4HgZScgp+BnhkByR9LyfEYVyorQkZLv/jHCkB5AjkllSEk66/4xwFN8jklC0zwjJSpeELPefEY5i+0QSi/ht4WQxScgs+BmhH7E16x+QOvWyTPWQU+rkVhHRrXYdkWLunzq/PyM0TguWuA54G73ZSKRY4W/3WtfXZEirIW6va/x6Y/MHrShGtBshI9uPdHtdm7FtZM3uNUU67uCWg+X17q+7va7nxJ6yYNOCIh33yiZXypSrpri97ubPb5apa6YW6bjt6rST+QPmu73uoW8ekjeWv1Gk4zbe0VjWDHH/HD7/w/MyasGoIh1X/5Dtvt/9B997K9+TO2bdIUXlGOH+Q2/G2hly9dSri3zcXfftcvuH8octP0iH9zsU+bi/3v6rNK3ctMDla/esldPfPL3Ix53Xf560P6V9gcs12K38n8oeGuP7uJOvnCxXNb3K7XUej+sHPiPs+RnRpFIT+W3wb26v4zMiQp8Rrf+3udBHXCBsGzdPZGPBzwgT7A4r+ntZJk8WWeP+MyKg4858TWSZ+88IGdRYpEQRA735I0Tmu/+MkBvaiFQu2meE/DhY5MuCnxGaH77u7J6y7pT/fUbod6xf/rcF4zPip6J9RrgT1wEvAACwvylTRFpXL3j53mMiZ44v+nFHvyXSo57762qMKfpxtcrGgIJxv3HGhyL7ivYjhVm05N6P3F/XYYrInweKdtz+A0SecvN4dfW/K2aI/FL0HxPChoAXAADYmpZd05rD+aUEuCpd+XLujxuoMmU8H1fzrouqVCnPx00OoORbiXTPxy1X7n8ju1GOldYAAAAQ0xIcRZ09YWMHDx6UMmXKyB+b/pDyFdxPUPCGCSn2mpCik5i+mfuNdOnURaqUZtJaPExa0/6+uOPFTFqLg88I7e8vv/xSunXrZvqbSWux/Rnh6f1dmM+IwuAzIrKfETt27ZBGdRpJRkaGlC5dWgIR1ykNFUtUlAolKgT3mB4+1ALl6UM4UJ4Cy0B5egEHSt9wnt503j4gyySX8foc6geEpw+JQOgHmqcPtUDoB3Cl5ODXGdIPH09/QAOhf+BCcVz9g5z/uFZ/6+W+Al5vQtFexWdE9H1G+IPPiOj4jCjs+9vdZ0Sw8BkR+s+IkyVOBu14pDQAAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCm2Trgff311+WUU06RYsWKybnnnis//vhjpJsEAACAKGPbgHfSpEkybNgwGTFihPz000/SrFkz6dKli+zatSvSTQMAAEAUsW3A+8ILL8gtt9wiN954ozRp0kRGjx4t6enp8t5770W6aQAAAIgiyWJDmZmZsmLFCnn44YedlyUmJsrFF18sixcvLrD/iRMnzGbJyMgwp/v27QtTixFJWVlZcvToUdm7d6+kpKREujkIMfo7vtDf8YX+ji/7/henORyO+Ax49+zZI9nZ2VKlSpU8l+v///jjjwL7P/300zJq1KgClzdo0CCk7QQAAEBg9AtOmTJl4i/gLSwdCdZ8X8uBAwekTp06snnz5oCfQES/gwcPSq1atWTLli1SunTpSDcHIUZ/xxf6O77Q3/ElIyNDateuLeXLlw/4WLYMeCtWrChJSUmyc+fOPJfr/6tWrVpg/7S0NLPlp8Eub5j4oX1Nf8cP+ju+0N/xhf6OL4mJifE5aS01NVXOPvtsmTt3rvOynJwc8//zzz8/om0DAABAdLHlCK/SFIX+/ftLy5YtpVWrVvLSSy/JkSNHTNUGAAAAwPYBb58+fWT37t0yfPhw2bFjhzRv3ly++uqrAhPZ3NH0Bq3f6y7NAbGH/o4v9Hd8ob/jC/0dX9KC2N8JjmDUegAAAACilC1zeAEAAAB/EfACAAAgphHwAgAAIKYR8AIAACCmxWXA+/rrr8spp5wixYoVk3PPPVd+/PHHSDcJQbBw4ULp0aOHVK9eXRISEmT69Ol5rtf5mVrVo1q1alK8eHG5+OKLZd26dRFrL4pOlws/55xzpFSpUlK5cmXp2bOnrF27Ns8+x48flyFDhkiFChWkZMmS0rt37wKL1cAe3nzzTTnzzDOdiw1ovfVZs2Y5r6evY9szzzxjPtOHDh3qvIw+jx0jR440/eu6NWrUKOh9HXcB76RJk0wNXy1z8dNPP0mzZs2kS5cusmvXrkg3DQHSOszan/qFxp3nnntOXnnlFRk9erQsXbpUSpQoYfpe30ywlwULFpgPwCVLlsicOXMkKytLOnfubF4DlnvuuUc+//xzmTJlitl/27ZtcsUVV0S03SiamjVrmqBnxYoVsnz5crnooovk8ssvl99++81cT1/HrmXLlslbb71lvvC4os9jS9OmTWX79u3ObdGiRcHva0ecadWqlWPIkCHO/2dnZzuqV6/uePrppyPaLgSXvrSnTZvm/H9OTo6jatWqjueff9552YEDBxxpaWmOjz/+OEKtRLDs2rXL9PmCBQucfZuSkuKYMmWKc5/ff//d7LN48eIIthTBUq5cOcc777xDX8ewQ4cOOU477TTHnDlzHO3atXPcfffd5nL6PLaMGDHC0axZM7fXBbOv42qENzMz04wQ6E/Zrusz6/8XL14c0bYhtDZs2GAWKHHt+zJlypiUFvre/jIyMsxp+fLlzam+z3XU17W/9Sey2rVr0982l52dLRMnTjSj+ZraQF/HLv0Vp3v37nn6VtHnsWfdunUmHbFevXrSr18/2bx5c9D72rYrrRXFnj17zIdl/tXY9P9//PFHxNqF0NNgV7nre+s62FNOTo7J7bvgggvk9NNPN5dpn6ampkrZsmXz7Et/29fq1atNgKspSJrHN23aNGnSpImsWrWKvo5B+qVG0w41pSE/3t+x5dxzz5Vx48ZJw4YNTTrDqFGjpE2bNvLrr78Gta/jKuAFEJujQPrB6Jrzhdijfww1uNXR/KlTp0r//v1NPh9iz5YtW+Tuu+82+fk6uRyxrWvXrs7zmqutAXCdOnVk8uTJZoJ5sMRVSkPFihUlKSmpwOw+/X/VqlUj1i6EntW/9H1sueOOO+SLL76QefPmmYlNFu1TTWE6cOBAnv3pb/vSUZ769evL2Wefbap06ATVl19+mb6OQfoztk4kP+ussyQ5Odls+uVGJx3reR3do89jV9myZaVBgwby119/BfX9nRhvH5j6YTl37tw8P4fq//WnMsSuunXrmjeHa98fPHjQVGug7+1H5yVqsKs/a3/77bemf13p+zwlJSVPf2vZMs0Lo79jg352nzhxgr6OQR07djQpLDqib20tW7Y0uZ3Wefo8dh0+fFjWr19vSogG8/0ddykNWpJMfwrTN0yrVq3kpZdeMpMfbrzxxkg3DUF4k+g3QteJavrhqBOZNMFd8zyfeOIJOe2000yA9Nhjj5kkea3hCvulMUyYMEE+++wzU4vXyuXSiYj6E5ieDhw40Lzftf+1duudd95pPiDPO++8SDcfhfTwww+bnz31fXzo0CHT9/Pnz5evv/6avo5B+p628vEtWkZS67Bal9PnseO+++4zNfQ1jUFLjmnZWP01/tprrw3u+9sRh1599VVH7dq1HampqaZM2ZIlSyLdJATBvHnzTKmS/Fv//v2dpckee+wxR5UqVUw5so4dOzrWrl0b6WajCNz1s25jx4517nPs2DHH4MGDTfmq9PR0R69evRzbt2+PaLtRNDfddJOjTp065jO7UqVK5r07e/Zs5/X0dexzLUum6PPY0adPH0e1atXM+7tGjRrm/3/99VfQ+zpB/wlV1A4AAABEWlzl8AIAACD+EPACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgi5hIQEs40cOTLSTYla2dnZ8vLLL5slz3X5TOs5i9elr2PxNdO+fXvzmPQUQHgR8AIhNH/+fOcfbt369Onj8zYDBgxw7o/4oevGDx06VJYtWyaHDh2KdHMAIKYQ8AJhNGXKFFm9enWkm4Eo88MPP5jXhurevbvMmTNHfvnlF/NaeeWVVyLdPPjxBfWUU06JdFMAeJHs7UoAweVwOGTEiBHy6aefRropiCLffPONOU1KSpIJEyaYlAbE5i8+ACKDEV4gTCpWrGhOp02bJitXrox0cxBFtm7dak6rVKlCsAsAIUDAC4TJXXfdJWlpaeb88OHDI90cRJETJ06Y05SUlEg3BQBiEgEvECa1atWSW2+91Zz/4osv5McffyzScTRXUHMGNXewqLmFGzdudE6MGzdunLlM0yw6d+4slStXlhIlSkizZs3k1VdflaysrDwpGfqTu84y1/3S09PlrLPOktGjR5vrCvMT/mWXXSbVqlWTYsWKSb169eSOO+5wjnT68tNPP8mgQYOkYcOGUrJkSdNePX/77bfLn3/+6fF2+litx63PgQaaL730kpx33nlmBD6QqgCab6v9e9ppp5nnpVSpUtK0aVO55557zH25Y7Xl/fffN//ftGlTnkmOgUxcnDdvnvTv3988t9oeHTk+44wz5P7775dt27YV2P/o0aOmzXqf/fr183n8xYsXO9v4xhtv5Llu//79MnbsWLnuuuukSZMmpo9SU1OlatWq0qVLF3n77bclMzOzyI9N+8if58d10qi7dIKcnBz59ttv5b777pMLLrjAvAb0S0fZsmWlefPm5vLNmzd7bYO3vsvfPn+rNCxatEiuv/56897V94e2p0WLFvLoo4/K7t27C/V4J0+eLB07dpRKlSpJ8eLFzfvkgQcekH379nltg76P7rzzTjn99NPN60L7r3r16uZ5uemmm2TSpEnOL2qALTgAhMy8efM0CjTb2LFjHdu2bXMUL17c/L9z585ub9O/f3/nbdypU6eOuU7388Y6ju6f34YNG/K06/bbb3f+P/92xRVXOE6ePOk4fvy448orr/S43y233OKxLdY+I0aMcIwcOdLjMcqUKeNYuHChx+NkZ2c77rnnHkdCQoLHYyQnJzveeustt7fXx2rtt2zZMkfz5s0L3F7bWFhPPfWUIzEx0WOb0tLSHO+//77H58XbVljHjh1zXHPNNV6PWaJECceMGTMK3Pa6665zXn/48GGv9zNkyBDn87179263r1FvW4sWLRzbt2/3eHxv/aGX+fP8uL7/9Ly343ja0tPTHZ9++mmRbpu/fe3atTOX6amn17f1vHp7j8yePdvn4507d66zP91t9evX9/j8T5482ZGamurzsa1evdrr8w9EEwJeIIwBrxo2bJjzsu+++y7iAe+5555rTrt162b+sK9YscIxffp05+W6jRkzxnHnnXea83379nV88cUXZr+JEyc6GjVq5Nxv1qxZbttiXd+yZUtz2rBhQ8e7775rgs5vvvnGcdtttzkDxtKlSzs2b97s9jiDBw92Hqtt27aO9957zzF//nzHjz/+aNrYtGlT5/WfffaZ14D3zDPPNIHzDTfc4Jg5c6Z5PNOmTXN8+eWXjsJ4/fXXncesVKmS4z//+Y9j8eLFjkWLFpngXoNHvU7vS+/HlQYMul1++eVmn+rVqzsvs7bCyMnJcXTv3t3Znh49ejg+/PBDx/fff2/a9PLLLztq165trtOARp9/V9p/1m0/+ugjj/eTlZXlqFy5stlP7y+/mjVrmtfPv//9b/Na0fvRNowfP95xySWXOO/DU+AXroD3kUcecVSrVs28rqznyXr9P/DAA46SJUua2xYrVsyxZs2aPLfduXOnz77L33++At7777/f2d66des6Ro8ebV7b2nb9opeSkuLsu1WrVnl9vK1btzanPXv2dL6v9bXt+vrQL0b57dixw/ma1T5+/PHHTYD9008/medHv7jddNNNjvLlyxPwwlYIeIEwB7z6h9L6g9KhQ4eIB7y6DR06tMA+R44ccd5XhQoVTMD20ksvFdhPR4lKlSpl9rvsssvctsX1vs466yzHoUOHCuzzwQcfOPe56qqrClyvf3St69955x2Po5sXXXSR83FrYOYp4PV2HH/t2rXLjABaAY+7QF0DBau/a9So4cjMzCxUXxXG22+/bY6jgZGnLx/79u1zfjG44IILChXIuguMJ0yYUOD6P//802s79YuKdXv9whOpgFffB+76w7JlyxbTZ3p7HS11pzB95y3g/eWXX5xf+k4//XTH/v373T7v1j6tWrXy+nh1e+KJJ9x+KdJfl6zReX0Nu9Ivov6M4B49etRsgF2QwwuEmea+ar6qlWepW6Rzi5977rkCl2vep+aAqr1798q5554rd999d4H9NC+zV69e5vx3333n8/40f1NzOvPTnMWuXbs6K1ns2LEjz/XPPPOMOe3du7cMHDjQ7bE13/G1115z5lR6e24vuugij8fxl+apau6reuGFF8xzmZ/mXj788MPmvOYoT58+XUJBY8Rnn33WOUHykksucbtfuXLl5Pnnnzfnv//+e1m3bp3zuuTkZOfiKLNnzzb97s5HH31kTrUfL7/88gLXax6zNzfeeKPJBVWhej78oTmy3iYK1qxZ0+Q8qxkzZhQqT72w3nzzTZNTrN555x2Tt5uf9qnmzyqdA6CLlHhy9tlny7/+9a8Cl2t+77Bhw8z5kydPmlxsV9b7Tl8nmr/rieYD6wbYBQEvEAH6R1QngqjHHnssom254oorPP7R14lrFm+rxFn76WSlAwcOeNxPJ03pH2JPrD/m+ofYdZLRwYMHnf+/8sorvT6exo0bO0vA5f9j7sqfiVn+1s/V4ESfR09uvvnmArcJtjVr1sj69ev9eo7atm3rPJ//ObKeF52sqBOe8jt27JgzSNVlj/WLkTcaJGoQpZOgfv31V+dWo0YNc/3PP/8s0UJfZxs2bJDffvvN2U7r8VnXhYr1utCJjvrl0pNbbrmlwG3c6du3r8dJfa7vwb///jvPdTqR1Hovf/bZZ4V4BEB0I+AFIqBChQpmGVlrlO3rr7+OWFsaNGjg8TrXUSZ/9/O2LO4555zjtS2tWrVynnddkU7rFlujX7oEr7vZ8K7bnj17zL75R4ldnXnmmRIoDYiUVqrwNlKo9XWtahnWbYJt+fLlzvPnn3++1+fHdYQ9/3Okwdapp56aZyTXlY50Hj582OeXhpkzZ8qll14qZcqUMUGUVgfQLzzWptcrq68iRX8J0GoE2j/aVq1qoSObVjutyiqhbKtWO7BG2r0Fu9YvBtZrzdtrqVGjRh6vK1++vMf3q1ZPsd7P+suN/hLy4osvyooVKyQ7O9vPRwREHwJeIEL0Z0XrD4uuvhYp3kboEhMTC72ftz+Kms7hjQaGFteySbt27ZKisNIN3NGfbANltdHX47JSP1xvE2zBfI6sQFaXPM5fUs0KgvUxX3zxxW5HdHVEW4NdDWq9fQGyRowjZdasWaZsmqbBaODrS6jaqqOpFl+vJQ129Quzr9dSUd+vemz9UqMj8NqXmhakn1UtW7Y0gbL+kqFlFQG7YWlhIEI02NU/JLoIxdKlS80fEQ0SYllR68q6/lF+6623pHXr1n7dzltQq8v4Bksg9XKDxfU5+vzzz93WX3bHXYClAe/jjz9uAp6PP/7YmYOsAZb1a4SmuGjOb37vvfeevPvuu+a85unqLxk6aqkBlAZh1vN+ww03yIcffhjSvFhvdLRWf/bXgF9HvLXmrtYI1tFtHenVurNK6/RqHVsVjrZGw2upTZs28tdff8knn3wiX375pSxcuFD++ecfk9ah+fW66XOltbt9pbQA0YKAF4ggDQZefvllMzlIR3n9CXit0RnrJ35Pjhw5ItFm586dfl/v+rOrNaKl9A+st8k04aRt3L59u8/H5Zo64Pq4gsn1OdIvU4E8R5q+oiN6miahC41YAe/UqVOdC0Z4SmcYM2aMOa1fv74ZIfY0sSmQkW7XEUp9H7j+39/3gD4WK99cAzh3o9WBttNfrl/MfL2WNL/dmkwYqteSNQFU+9jqZ81f1hF7XYxG87H1i88jjzxi0h0AOyClAYggnbhmzQLX1cP0D68/t8n/M6g73lYcixRvs8rzX+8asOlIoTXypTnP0cJqo/adBiLe0g2sn8xDFaxrbqclGM+RFehonugvv/ySJ51BR0E95ZrqhC8rF9RTsKsjpfqcFZX1HvD1PvD2HrDaqUGjp2A3f250qEZkdclxq7KF/trjjeazW6sfhvOLX926dU11GX2PavUK5W5SIxCtCHiBCNM/ItbPyjrK6+tnU/3DozRg8LSv/jG3gpRoohPR9A+2J/pzuNKfvV2XX9VlUXX5X6Ujjt6WVw0nK1DSkUL9edcT/Ynf6itvwVUgdOKcFYho6bfjx48HdLxrrrnGmX6gga7+pG2VnfM2Wc0K/L2Nrursfx0ZLyrrPeArIJ04caLPdurz5OnXEk130LQLXyOhKtBldq3Xhb53vS07riXL8t8mnHSJamvyaaQnHAKFQcALRFiJEiXkwQcfdAaEmjPnTbt27czptm3bTH5lfjpJKND6sqGks97dBUMayFqPXctdWeWRLI8++qg51TxCLbvlrfyZBh+vv/56wEGfL1pP1sphvPfee02d3fy07NZTTz1lzmseqz62UNCf9a26q1pqSnNkvQVh+jxaNYs9TbLTGfpKX2faP1bQ7i3gtUYqNY/YXTqAlk4bMmSIBEJzuK38Yf1J3d0XP6017C1wtNqpQa27kUrNidbJd/o+88Z6neoovq8Jet7cfvvtztQMfY9o/+SntZGt/GitaOKr6klRaKqCty8jGRkZzufV9YsHEPUivfIFEG8rrbmjKxbpEqf516p3R1dG0uV3rSVPR40a5ViyZIlj6dKljjfeeMNRv359c3mLFi38WmnNW7t8rVTlbgUzPbavpYV1OWK9zfLlyx1z58513H777c4VpHTVNnfHUHfffbfzWFWrVjVL9+pKXStXrjRL+Y4bN84xcOBAR7ly5cw++Vd089XOonBdWrhKlSqOF1980fSFLsOqfWMtT+tuaeFgr7Smq2j16tXL2Z5TTz3V8dxzz5nll/U5WrBggeOtt95yXHvttWb1N11Bzxt9Pq1jlS1b1tmH3jz//PPO2zRo0MCs3KXPh963rpBWpkwZ8/rUFfe8PWZvK60pfQzWPpdeeqlZhUxXtdNlgXv37p1neV13r19dRS0tLc35PnrwwQfNa0mXQdbHffbZZztXo/P2HpgzZ47zel12W5dwXrdunXMr6tLC2ne6cp62R/vv3nvvzbO0sPZnUd+v3p5ffS3q/ehS47qyoj4n+rxq/+lrvXHjxs7b6msdsAsCXiAKAl716quv+hXwqsmTJzuSkpIK7K9b8eLFHVOmTPF7aeFwBrz6x9V1Wdj8mwby+sfdW0CnQaQuierpGNamAV3+pU9DEfCqJ5980hmwu9s0sHr//fc93j5YAa/SpXL1C4QG2L6eo7p163o91sGDB83ryfU2voIcvX9r6VpPr099/fp6zL4C3h07djhOO+00j/dzzTXXmGDN2+tXlzj21m99+vTxeYzs7GzHeeed5/EYhQl49ViDBw/22mf6heHrr792e/tgBby+Xje6DRo0yLQXsAtSGoAooSsouVua1p2rrrrKzIDXwvCa36ollPS2uhSwTirxtdJWJI0cOVK++uor6d69u6m7q23XElqDBw82+YtWyoanCUJaxk0nIz3wwAPO2qCaa6oTmbSmqv7c/v7775ufZcO19KmmEmhusvahTujS+9VUFV31TZdj/uOPP0yKQThondY33njDpFLoggq6eIKW2dLnSE91AqCmvGiVgt9//93rsfQ57dGjh/P/egzN7fV1/zqb/5VXXjH9oykf+nxo1YZBgwaZ3HN9/QZKXzs6wUvTgTQ9QSd+6WtBV5EbP368ScPwVXpOU1I0L1nTTPR9pG3XFAVdwnfSpEkmB9jXMTQNQVMNNOVGVxzUEmdFncimx9JUHC0Dpq/j2rVrm8elebPab/o60wUqOnfuLKGiKSL6/Omqh9p/moaj71HtQ63eoZ8x+pzpUsieqmMA0ShBo95INwIAAAAIFb6eAQAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAAEBi2f8BrJ0GirgU1KkAAAAASUVORK5CYII=",
-            "text/plain": [
-              "<Figure size 800x600 with 1 Axes>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "\n",
-        "%matplotlib inline\n",
-        "\n",
-        "Y_np = Y.cpu().numpy()\n",
-        "fig, ax = plt.subplots(figsize=(8, 6))\n",
-        "ax.plot(np.minimum.accumulate(Y_np), color=\"b\", label=\"SAASBO\")\n",
-        "ax.plot([0, len(Y_np)], [0.398, 0.398], \"--\", c=\"g\", lw=3, label=\"Optimal value\")\n",
-        "ax.grid(True)\n",
-        "ax.set_title(f\"Branin, D = {DIM}\", fontsize=20)\n",
-        "ax.set_xlabel(\"Number of evaluations\", fontsize=20)\n",
-        "ax.set_xlim([0, len(Y_np)])\n",
-        "ax.set_ylabel(\"Best value found\", fontsize=20)\n",
-        "ax.set_ylim([0, 8])\n",
-        "ax.legend(fontsize=18)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8883d412",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "d81134ff-cec6-45cb-92bf-4170f428af40",
-        "papermill": {
-          "duration": 0.017598,
-          "end_time": "2026-01-08T16:46:55.013068",
-          "exception": false,
-          "start_time": "2026-01-08T16:46:54.995470",
-          "status": "completed"
-        },
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "## Predict on some test points\n",
-        "We fit a model using the 50 datapoints collected by SAASBO and predict on 50 test \n",
-        "points in order to see how well the SAAS model predicts out-of-sample.\n",
-        "The plot shows the mean and a 95% confidence interval for each test point."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "c00275a9",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:46:55.036424Z",
-          "iopub.status.busy": "2026-01-08T16:46:55.036246Z",
-          "iopub.status.idle": "2026-01-08T16:47:17.790284Z",
-          "shell.execute_reply": "2026-01-08T16:47:17.789927Z"
-        },
-        "executionStartTime": 1668655622271,
-        "executionStopTime": 1668655822584,
-        "hidden_ranges": [],
-        "originalKey": "970977ea-ee5e-46eb-b500-683673ce723e",
-        "papermill": {
-          "duration": 22.769638,
-          "end_time": "2026-01-08T16:47:17.791324",
-          "exception": false,
-          "start_time": "2026-01-08T16:46:55.021686",
-          "status": "completed"
-        },
-        "requestMsgId": "2ae0c053-022f-4902-8bc5-b904bd85f90d",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "n_train_pred = 10 if SMOKE_TEST else 50\n",
-        "n_test_pred = 10 if SMOKE_TEST else 50\n",
-        "train_X = SobolEngine(dimension=DIM, scramble=True, seed=0).draw(n_train_pred).to(**tkwargs)\n",
-        "test_X = SobolEngine(dimension=DIM, scramble=True, seed=1).draw(n_test_pred).to(**tkwargs)\n",
-        "train_Y = branin_emb(train_X).unsqueeze(-1)\n",
-        "test_Y = branin_emb(test_X).unsqueeze(-1)\n",
-        "\n",
-        "gp = SaasFullyBayesianSingleTaskGP(\n",
-        "    train_X=train_X,\n",
-        "    train_Y=train_Y,\n",
-        "    train_Yvar=torch.full_like(train_Y, 1e-6),\n",
-        "    outcome_transform=Standardize(m=1),\n",
-        ")\n",
-        "fit_fully_bayesian_model_nuts(\n",
-        "    gp,\n",
-        "    warmup_steps=WARMUP_STEPS,\n",
-        "    num_samples=NUM_SAMPLES,\n",
-        "    thinning=THINNING,\n",
-        "    disable_progbar=True,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "id": "cb3b298f",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:47:17.835298Z",
-          "iopub.status.busy": "2026-01-08T16:47:17.835154Z",
-          "iopub.status.idle": "2026-01-08T16:47:17.843981Z",
-          "shell.execute_reply": "2026-01-08T16:47:17.843603Z"
-        },
-        "executionStartTime": 1668655921184,
-        "executionStopTime": 1668655921625,
-        "hidden_ranges": [],
-        "originalKey": "25139c91-a34c-4fa8-808f-70c1cf6952fd",
-        "papermill": {
-          "duration": 0.026117,
-          "end_time": "2026-01-08T16:47:17.844955",
-          "exception": false,
-          "start_time": "2026-01-08T16:47:17.818838",
-          "status": "completed"
-        },
-        "requestMsgId": "ad9413e7-09aa-47f5-b435-bf37cf0180d1",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "with torch.no_grad():\n",
-        "    posterior = gp.posterior(test_X)\n",
-        "median = posterior.quantile(value=torch.tensor([0.5], **tkwargs))\n",
-        "q1 = posterior.quantile(value=torch.tensor([0.025], **tkwargs))\n",
-        "q2 = posterior.quantile(value=torch.tensor([0.975], **tkwargs))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "id": "f21ff6c5",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:47:17.874960Z",
-          "iopub.status.busy": "2026-01-08T16:47:17.874777Z",
-          "iopub.status.idle": "2026-01-08T16:47:17.930961Z",
-          "shell.execute_reply": "2026-01-08T16:47:17.930629Z"
-        },
-        "executionStartTime": 1668655923525,
-        "executionStopTime": 1668655923743,
-        "hidden_ranges": [],
-        "originalKey": "39163b27-e252-4244-9712-f52503e00f74",
-        "papermill": {
-          "duration": 0.070137,
-          "end_time": "2026-01-08T16:47:17.931765",
-          "exception": false,
-          "start_time": "2026-01-08T16:47:17.861628",
-          "status": "completed"
-        },
-        "requestMsgId": "7c819fcc-5f74-48b1-9fd4-286839fdd0b6",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAicAAAIgCAYAAABeVcllAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbyFJREFUeJzt3Qd4U2X7BvCnLWWPAmUqG5RpQZQlewqIIqhQoCLg+BRQhvKJIoKKIP5VUBEcDG0pSxEoU6AM2XspskRAdhkFiqyS/3W//U5M0jRJm7TJOef+XVdMm5w2OZamd973eZ83yGKxWISIiIgoQAT7+wkQERER2WI4ISIiooDCcEJEREQBheGEiIiIAgrDCREREQUUhhMiIiIKKAwnREREFFAYToiIiCigMJwQERFRQGE4ISIiooCiy3CSnJws77zzjpQrV05y5colFSpUkPfff19sO/Hj4+HDh0uJEiXUMS1btpRDhw759XkTERGRQcPJRx99JBMnTpQvv/xS9u/frz4fO3asfPHFF9Zj8Pnnn38ukyZNks2bN0uePHmkTZs2cuPGDb8+dyIiInItSI8b/z322GNSrFgxmTx5svW2zp07qxGSmJgYNWpSsmRJGTx4sLz++uvq/sTERPU106ZNk65du/rx2RMREZEr2USHGjRoIN98840cPHhQ7rvvPtm9e7esW7dOPv30U3X/0aNH5cyZM2oqR1OgQAGpW7eubNy40Wk4uXnzprpo7t69KxcvXpTChQtLUFBQFp0ZERGRPmFg4OrVq2pwIDg42Hzh5M0335QrV65I5cqVJSQkRNWgjBo1Srp3767uRzABjJTYwufafY5Gjx4tI0eOzIJnT0REZFwnTpyQe++913zhZPbs2TJ9+nSJjY2VatWqya5du2TAgAEqrfXs2TND33Po0KEyaNAg6+eYBipdurQanSlUqJAY1e3bt2XVqlXSrFkzCQ0NFSMywzkCz9NYzHCeZjhHI5/nlSsiTz0VIjt2pIySFCyYKJculZZ8+fJ5/b11GU7eeOMNNXqiTc/UqFFDjh07pkY/EE6KFy+ubj979qxaraPB5zVr1nT6PXPkyKEujhBMMLVj5F+a3Llzq3M00i+N2c4ReJ7GYobzNMM5GvU8LRYEE5EdO1I+Dw8X+emn29KkifikFEKXq3WuX7+eaj4L0zuoEwEsMUZAWblypfV+TANh1U79+vWz/PkSEREZSVCQyLBhIjlzpgST+HiRatV89/11OXLSoUMHVWOCaRdM6+zcuVMVw/bu3Vvdj9SGaZ4PPvhAKlWqpMIK+qJg2qdjx47+fvpERES616KFyKJFIkWKYAZD5MIFk4cT9DNB2HjllVfk3LlzKnS89NJLqumaZsiQIZKUlCQvvviiXL58WRo2bChLly6VnIh5RERElC5Y0OpY/dC8uWQKXYYTFNuMGzdOXdKC0ZP33ntPXYiIiCjjEhNFWrcWad9exGYcINPoMpwQERFR1gaTLVtSLnnyiAwenLmPqcuCWCIiIsraYAIofsXnmY3hhIiIiDwKJliVg+LXzMZwQkRERAETTIDhhIiIiAImmADDCREREQVMMAGGEyIiIlLOn8fGff4NJsBwQkRERErFiiKrV4tERPgvmAD7nBAREZHVffelbOjnsIVdluLICRERkYlrTEaMELlzx/52fwYT4MgJERGRyYtf//hDJCZGJFuApAKOnBAREZl8Vc7KlSLHj0vAYDghIiIykcQ0lguXLy8Bg+GEiIjIJBIDpI+JOwwnREREJpCok2ACDCdEREQGl6ijYAIMJ0RERAb3xhv6CSYQIIuGiIiICK5fv64unsqdO7e6uPLRRyLbt6esyAn0YAIMJ0RERAFk//79sh1JwsY///wjFotFgoKCJFeuXHb31a5dW11cKVhQZMUKkdOnRapWlYDHcEJERBRAqlSpImXKlLG7LS4uTgUUBJMOHTrY3eds1AQ1JhaLSFiYfUDBRQ8YToiIiAJIbifTNNmzZ5fbt2+r63AUjXhQ/Ipw8ssv9gFFL1gQS0REZMBVOVu3inTvLrrEcEJERGTQ5cJjxoguMZwQERHpXKLO+pi4w3BCRESkY4kGCybAcEJERBTg7t69Kzdv3lTXRg8mwNU6REREAWr37t0ybtw4iYmJkTt37ki2bNkkPj5eBgwYIOXKRRgymABHToiIiALQjBkzVHM1LZgArvE5bp8/f4aULm28YAIcOSEiIgrAEZOoqChJTk5OdZ8WVHr1ipJNm6pKoUIR0q+fcYIJMJwQEREFmHHjxqlW9a7g/gkTxsnUqVPFaDitQ0REFEDu3r2rpnS0EZK04H4chz13jIbhhIiIKID8888/amWOJ3AcjjcahhMiIqIAkitXLsmRI4dHx+I4x12KjYA1J0RERF64fv26uqQFG/bduHFDEhISJDQ01OnGfraCg4MlMjLSbpWOM1hWjOPc1aboEcMJERGRF/bv3y/bt2+3uw1TLagFQXDImTOnJCYmyoIFC9TnWAaMiysDBgyQ6Ohol8fg++M4I2I4ISIi8kKVKlWkTJkydrfFxcWpgIIpl0cffVTWrl0rjRs3to6cuFO2bISULRstR45EYV0Oyl/tRkwQTBBeIiIixIgYToiIiLzgbJome/bsajoH1+Hh4Wr0BNcIJ+4k/q8l/ZEjkSJSVXLkGCfJyf92iO3Ro4caMTFqMAGGEyIiIh/XnNy6dUuFCVyj1iQ9NSezZ9u2pI+Q+PipsmtXc7l8+bIULFhQhROjYzghIiLycc3J+fPnrTUnqDVJT83J88+L/P23yFdf/duSfs+eYLUyx4jFr84wnBAREfm45mTy5MnWaZjHH388XTUnQUEiI0aIvPKKSLFiYkoMJ0RERF5wNk2D5cAY5cC1u5oT1Jjs3y9Sr559QClm0mACbMJGRETkJ1rxa/PmIqtX+/vZBA6OnBAREWXC/jgohg0JCXEbTLTi1+eeEzl4EHvmuC+wteWuwFaPGE6IiIh8ZPfu3WpHYa27K2pOfv/9d6lVq5bLYBIejt4oWIIssndv2k3dsDx57ty5dvd50tRNbxhOiIiIfAA7BEdFRalaE63tPK5jY2NVWClcuLC631kw0VblpFVg64rRRk2A4YSIiMiLvXNg3759KngkJyenuk8LKr169ZJy5R6QwYMj0gwmRp2mSS+GEyIiIi/2zkGL+mnTpqnPXQuSJ58cJwkJU9MMJqTj1Tply5ZV/yAcL3379lX3oxMfPsYQWt68eaVz585y9uxZfz9tIiLSIUyzdOrUye6SP39+1Zoe1x07dlThBUWwriQn35GEhBnYso/BxIgjJ1u3brUbOsNwWqtWreTpp59Wnw8cOFAWLVokc+bMkQIFCki/fv3UP6b169f78VkTEZER987JkyePWkXjmZtSuPA/Eh+fm8HEaOGkSJEidp+PGTNGKlSoIE2aNFEtgtGZDwVIzbFwXESmTp2qku+mTZuknm2XGxs3b95UF82VK1fUNf7x4WJU2rnxHPWP52ksZjhPPZ8jpnC0C1bkoNmau5ETCAoKlmXLsknlyvjbIoZy24cnFGRxP0kW0JBWS5YsKYMGDZK33npL4uPjpUWLFnLp0iUJCwuzHofKZ+ziiFEVZ0aMGCEjR45MdTtCjtkLk4iIyN6RI0esS4XLlSunygc8+XOKEgQsBTbiHjnXr1+Xbt26qUECTHeZbuTE1rx589ROjc+he42InDlzRg2z2QYTKFasmLovLUOHDlUBx3bkpFSpUtKsWTNVu2JUSLrLly9X02KebOWtR2Y4R+B5GosZzlPP5zhr1ixJSkpSUzr4O+Hp+3wch+ON+Kb3woULPvteug8nmMJp27atGj3xBnZ7xMURfmH09kuTEWY4TzOcI/A8jcUM56nHc7RdjIFRAvz9sC0NSAuOw/FGHDkJ9eHPUJerdTTHjh2TFStWyPPYX/p/ihcvrqZ6MJpiC6t1cB8REZEvod4kMjJSTfG4gvtxnBGDia/pOpyg0LVo0aLSvn17621o4Yv0tnLlSuttBw4ckOPHj0v9+vX99EyJiMjIUNPobmoH9+M4MvC0DqqiEU569uxpl1axdLhPnz6qfqRQoUJq+Kx///4qmKS1UoeIiMgbZctGSNmy0XLkSJRqtiaS0hUW8DdK+5sVERHh1+epF7oNJ5jOwWhI7969U9332WefqWE2VE9jDrBNmzby1Vdf+eV5EhGR8SBs4O8LusNqe+UcORIpIlUlR45xcudOjGq6hmDSvXt3qVmzpnTt2tXfT1s3dBtOWrduneYQWs6cOWXChAnqQkRElJm7DoeFxUtCAqZrIiQ8PELi46fK4sWVVYt7rMpBC4vFixf7+6nriq5rToiIiLJy12HUNWrBBHCdkBCDikfJl2+GtSU9Ru/R1oLFrxnDcEJEROTBiIm267AWTP6Fz5MlKSlK7t7d7adnaCwMJ0RERG5gKsfdKEhwcJA6jrzHcEJEROSm+BVTOqlHTOzhfhyn811hAoJuC2KJiIiyAgpbPen+CjjuxIkTKtAgpOA6ISFBbty4oa7Rh8vZLsdkj+GEiIjIBSwX9rQ9PVbvxMXFqX2DEE5wjY3+rl69qsIJpoZq1arFpqBucFqHiIjIhatXgyVfvki37+exQuehhx5SAUQbHdFGSLhqJ304ckJERJQGrcFaSh+TaJfHIoCMHj1aqlevbnc7Rk/Wrl0rjRs3tk7rkGsMJ0RERC6CyZYt+CxC8uWLVsuFsSrHtjgWUzmYwomOjpamTZum+j4IJ2gOGh4errvdl/2F0zpEREQug4lIeLjI+vWRsmPHdunRo4d1Tzdc4/Pt27erHYfJNzhyQkRE5ODll+2Didb5FSMo2MCvefPmcvnyZSlYsKAKJ+RbHDkhIiJyMHasSIUKjsHEvvgVK3hY6Jo5OHJCRETk4N57RVavFrl8WcShvpWyAMMJERGZHmpMcuTArvb2AQUXynqc1iEiIlPTil87dhS5ccPfz4aA4YSIiEzLdlXOsmUizz/v72dEwHBCRESm5Gy58H//6+9nRcCaEyIiMh1nwcTZqhy4fv26uti6deuWasSGa+yZY4sb+3mP4YSIiEwlPcEE9u/fr5qsOe5UbLuxn63atWurC2UcwwkREZlGeoMJVKlSRcqUKePxY3DUxHsMJ0REZAoZCSbAaZqsx4JYIiIyBWyHo2UMT4MJ+QfDCRERmUKePCILF4o89RSDSaDjtA4REZkqoMyZ4+9nQe5w5ISIiAxbY/LssyJnzvj7mVB6MZwQEZFhi1+jo0WaN2dA0RuGEyIiMvSqnPPnRS5c8PezovRgOCEiIsMvF65Wzd/PjNKD4YSIiEzdx4QCD8MJERHpHoOJsTCcEBGRrjGYGA/DCRER6drXXzOYGA2bsBERka69/rrI4cMiP//MYGIUHDkhIiJdCw4WmTRJZPt2BhOjYDghIiLd1Zj89lvqgFK6tL+eEfkawwkREemu+LVxY5Hdu/39bCizMJwQEZHuVuVcvCjStatIcrK/nxVlBoYTIiLS5XLh2bNFQkL8/cwoMzCcEBFRQGMfE/NhOCEiooDFYGJODCdERBSQGEzMi+GEiIgCzu3bIm3aMJiYFTvEEhGRz12/fl1dXLl9+7bcuHFDEhISpECBApI7d27rfaGhIt26iWzezGBiRgwnRETkc/v375ftaNlq459//hGLxSJBQUGSK1cu9XFiYqIsWLBAHnroIaldu7bd8a++KpIjh0iDBgwmZsNwQkREPlelShUpU6aM3W1xcXEqoCCYdOjQQY2crF27Vho3bqxGTiwWkaAg++/z0ktZ+7wpMLDmhIiIfA5TNOHh4XaX7NmzS7Zs2dS1dlvOnDnV9e3buVXX1/nz/f3MKRDoNpycPHlSevToIYULF1YpvEaNGrJt2zbr/RguHD58uJQoUULd37JlSzl06JBfnzMREaW9KmfdOpGnnsIIi7+fEfmbLsPJpUuX5JFHHpHQ0FBZsmSJ/P777/LJJ59IwYIFrceMHTtWPv/8c5k0aZJs3rxZ8uTJI23atFHFV0REFBiSkrJJu3Yh1lU5YWEiZcv6+1mRv+my5uSjjz6SUqVKydSpU623lStXzm7UZNy4cTJs2DB54okn1G0//PCDFCtWTObNmyddsSEDERFlqbt378rNmzfVaLY2YjJiRAM5dCjlfTJX5ZCuwwkquzEK8vTTT8uaNWvknnvukVdeeUVeeOEFdf/Ro0flzJkzaipHg2KrunXrysaNG52GE/zC4KK5cuWKukbBFi5GpZ0bz1H/eJ7GYqTz3L17t3zxxRcSGxsrd+7cUXUnixevkD17XpNDhx5Ux4SHW2TZsjtSuXJKjxMjMdLP0hVfnl+QBcMMOoMCKhg0aJAKKFu3bpXXXntNTeH07NlTNmzYoKZ9Tp06pWpONM8884xawjZr1qxU33PEiBEycuTIVLfjl8l27T0REXkOq3Ewkq2NnNi/N8afn2jJn7+TvPfeeilb9qrfnid5D31tunXrppaH58+f33zhBJXeWBOPEKJ59dVXVUjByEhGwomzkRNMHZ0+fVoV3Ro56S5fvlxatWqlaniMyAznCDxPYzHCeWLEpF69epKcnOziqBCJjl4vXbqkjKAYkRF+lp64cOGC+pvri3Ciy2kdnHzVqlVTran/6aef1MfFixdX12fPnrULJ/i8Zs2aTr9njhw51MUR/iEZ+R+Tmc7TDOcIPE9j0fN5TpgwQb0hdCU4WGTFionSo8c0MTo9/yw94ctz0+VqHYyKHDhwwO62gwcPWhv+oDgWAWXlypV2IyFYtVO/fv0sf75ERGaDKZwZM2aoGhPXxyXLzJkz1UIGIl2PnAwcOFAaNGggH374oZqq2bJli3zzzTfqAkjqAwYMkA8++EAqVaqkwso777wjJUuWlI4dO/r76RMRGR46wdpOlbuC43A86/tI1+Hk4Ycflp9//lmGDh0q7733ngofKLjq3r279ZghQ4ZIUlKSvPjii3L58mVp2LChLF261FpMS0REmQfLhTFV7klAwXHa8mIi3YYTeOyxx9QlLRg9QXDBhYiIslZwcLB07hwpsbExIpL21E5ISIhq7+CuNoXMRZc1J0REFNjQYG3PngH/Wy6cNtSa9OvXL8ueF+kDwwkREWXKXjn79kWoPiZYLhwSYj9Qj0ZsGDVBfWBEBI4j+hfDCRER+TyYaHvlhIdHypw52yUqqocKJIBrbNy6adMmaYytiImMUnNCRESBHky0vXIi5Kmnpkrz5s3VAgVs0opwguZk2GGeKFPDCZaCbd++Xe1rgza2WLbrbZc4IiLSczCxL5LFyhwWv1KWhJMTJ07IW2+9JXPmzLHb+Act5m07uU6ePFm+/vprtQnfL7/8wn+gREQG8eyzroMJUZaGE3Rdbd++vVy6dMmuw5+z4NGhQwfp27evCjAIJ9hZmIiI9G/0aPw9EME2OggmFSpcl4SE63bH3Lp1S3WMxXVCQoL6W3Djxg31Md60sgkb+SScYO7wiSeekIsXL6o9bNCFtVGjRlIjjbhctGhRadu2rSxYsEAWLVrEcEJEZBAYJEcoQTjBn4Dt2/eraX7HqX+8iUUomTt3rvoYm8ThbwJG2mvXru23508GCieff/65nDt3TsLDw9VuwKVLl3b7NS1btpT58+erlvNERKRPV6+KYKAjJOTf22z3Y8VmrNp+Z2lBSFm7dq1asYOREyKfhJO4uDg1fTNo0CCPgglUq1ZNXR85csSbhyYiIj8Xv953n8i0afYBRYMpGnfTNAgn2FIEb3CNvFsvZXE4OXz4sLpOzzp1LCHTdgkmIiL9rsrBBS/pn3/u72dFRuNVEzYUMkF6Ei824wNu8kREpP/lwi+84O9nRUbk1cgJClz//vtvOXr0qNop2BO7du1S1yVLlvTmoYmIKAPQgwoXT2nTM570MSEKiHBSt25dFU6WLFkizzzzjNvjUZn97bffqjoVrOohIqKstX9/2qto8NrsOKqNFTQVK9ZmMCH9hJPu3bvLjz/+KNOnT5fXXntNatas6fL4wYMHy+7du9UvQM+ePb15aCIiygBnq2iwuAEBBcEE/ahs3bmTm8GE9BVO0OOkWbNmsmrVKmnRooV88MEH0rlzZ+v9aLZz6tQpWb9+vVp2vGHDBhVMOnXqJA0aNPDF8ycionRwtoome/bsauUMrrFyRoOpnPbtGUxIhx1if/rpJxVMdu7cKf369VMXrTtsrVq17I7FsGG9evVkGtaeERFRQMNuJDdvpnzMYEK6Wa0DYWFhqgHb0KFD1SZ/CCDOLhguHDJkiKxevVry5Mnjm2dPRESZBoFkxQo0z2QwIR1u/IehwFGjRqnN/9asWSPbtm1TnWOTk5OlcOHCagQFnWHZAZCISH8BZflyfz8LMhufhBMNRkTatWunLkREpC937oj07ZuyiV/+/P5+NmRmXk/rEBGRvt29e1euX78pmzffla++Enn0UXTx9vezIjPz6cgJERHpp7EaWjuMGzdOYmJi1OrK4GD8SYiX/fsHyMmTERw9IX2Gkx9++MGrB3/22We9+noiIqMGCSztxRYhONZdvV5GGqsdPHhQoqKi1P0IJnD3Lq5j5MqVaNm1K1qqVInM0DkS+TWcPPfcc9Zlw+mFr2M4ISKz8TRI4PPExEQ5cOCA1KlTx6eN1bBpK4IJFi2kdkfu3hV1f9WqVSUiIiLD50rkt2kd/AIREZFnPA0SGDlZu3at3H///T5trAZvvPGG2zeWuB9TPlOnTk3H2REFQDjBhn+e7EKM4cPY2FjV6v6RRx6Rb775JtUvEhGRGXgaJPB5zpw5ff5aieLXGTNmWKdy0oL7cdyUKVMyPEJO5Jdw4pj+04KhwY4dO8rs2bOlW7du0r9/f1nOhfNERFkOIzQ3tbavbuA4HM83k2TopcTYuRgb/mEvnq+//jorH5qIiETU1FGOHDk8OhbHORbTEhmyzwkCCupUuL8OEVHmwfQNRj5wbSs4OFgiIyMlWzbXA+e4H8dxSodM0eekWLFi6hoV6ERE5FuOvUsQMpYujZcePQZI27YpK28GDBgg0dHRLr8P3kTiOCJTjJwcP37cWuxFRES+gwJW9DDRggngOjY2Rtq1qy3jx89Qt2F5MMJJSEhIqhEUfI7bcT+XEZMpwgkCydixY9XHFStWzMqHJiIy/IiJ1rsk9UocfJ4sAwZEya5du9UtmLJBv5UePXpYAwqu8Tlux/1EupzW0UZBXMF856VLl9ROxV9++aXs27dPzWF27drVm4cmIiIbmMpxVx8SEhIk48f/27sEIyP4uHnz5nL58mUpWLCgCidEug4n5cqVS/fXYB6zfv36MnDgQG8emojI0NC2Hu3rExISJDQ01Ce9S5KTnfcuQZEsVuaw+JUMEU7S2x22UKFC8tJLL8mwYcM8XspGRGRGWDRw7NgxWbBggTU0pLVfDlblsHcJGYlX4cSTtsZI5Pny5VOjLNWrV1eFVkRE5Bra1qMLd+PGja0jJ2ntl4ORE7Sk9ySgsHcJGT6coKEaERH5HkY20L4e7ey1cOJqv5ynn45Uq3RSil+dY+8S0ossX0pMRES+N3jwAAkKcj3Vzt4lpBcMJ0REBlCzZoTExERLUFCIhISwdwnpG8MJEZFOOa5J6NYtUnbu3C5RUWn3LsEqIKwAsr3cunVLrfTBteN9OJ4oIGtOevfu7fMHxpzn5MmTff59iYjMIDFRpHNnkREjRBo2/Pd2d71L9u/fr4KKLW0VEOpZ5s6da3cfOs7iQhRw4QSb9PmygEpbCsdwQkSU/s38QkNzSevWIlu2iGzaJLJ0qX1AcdW7pEqVKlKmTBmPH5NLjilgw0np0qVZ3U1EFCCb+aGmJDk5Hlv4Sa5cEVKggKQrbDBwkCHCyV9//ZX5z4SIiFKZOXOm9OrVS71B1DrAotOrCJYNR8vrr0dLjRrcB4eMxas+J0RElHnQhO31119Xm/mllhJU3n47Spo0KZdqM1XHIldbHD2hQMdwQkQUoNAR1t2UOu7/8MMP5bHHHrO7nUWupGcMJ0REAVLoattWHrf9+uuvbjfzw/2//PKLWmDgaW0gR00o0OkynIwYMUJGjhyZah+KP/74Q32MnTwHDx6s5mrxC9+mTRv56quvpFixYn56xkRE7gtd0ZMkPj5edXHFihqMengCr3N58uRh6CDD8Ek4wZzm9OnTZd68eeqXDfObGFJ0xba4KyOqVasmK1assH6uNRyCgQMHyqJFi2TOnDlSoEAB6devn3Tq1EnWr1+f4ccjInIGTcrS06hMq/eYMWOGREVF2b0W4hpBBZ1cMRKCPXU8CSjczI+MxutwcvDgQenYsaPa3hvzm1kFYaR48eKpbk9MTFS/1LGxsaoJEaAhEdb2b9q0SerVq5dlz5GIjM9VUzMED8fQgFoPvH4hmDgrdNWCSp8+feTBBx+UnTt3unwjx838yIi8CidJSUnStm1bVVGOhj9PPPGEFClSRL799lv1izJs2DC5ePGibNu2TTZv3qxuq1+/vrRq1crrJ37o0CEpWbKk2rUT33P06NGqHwteJPBOo2XLltZjK1eurO7buHFjmuEEw6K2241fuXJFXeN7eTq0qkfaufEc9Y/n6R9YJYPXIltLlixRAQXBBK+RtjBq8uqrr3pU6Aru3vTh/r59+wbM/w89/ywzi9nO0xeCLF4Md3zyySfyxhtvqA2lli1bpkYqfvvtN6lRo4b6xbJ9V4D0j3cKqAvBHCumWjIKv/jXrl1TdSanT59W9ScnT56Uffv2qep29ASwDRpQp04dadasmXz00Uce17EARmA4j0tE6XHkyBFrDUmFChXs7kOha5cuXTx6Ice0Tv/+/dVrpuNrKl53tV2GGzdunCnnQZQemN7s1q2bmsHInz+/+C2cNG3aVFWTd+3aVdWcQFrhBM6fP6/2fUBNCkYxfLWUDftHoHjs008/Ve9UMhJOnI2clCpVSoWfwoULi1HhBXL58uVqNAsvhEZkhnMEnmfgmDVrlhpZRpEqgogt3I79bjyF1000wvzyyy/V66wWerp3767e5Ol5l2E9/Cx9wSzneeHCBSlRooRPwolX0zq///67un7yySed3o93CJju0WDKZ9CgQTJkyBD1i4ZaEF8ICwuT++67Tw4fPqx++CjQRWDB7ZqzZ886rVGxLSjDxRH+IRn5H5OZztMM5wg8T//DmzPt4vgc8aKN1xrHN1DO4Gtx/EMPPaT2OGvRooXTzfz0LpB/lr5k9PMM9eG5/ZscMgC/JGC7iZTtH3i8Q3D0yCOPqOs1a9aIr2CKB8OoSGwYjcH/oJUrV1rvR7Hu8ePHVW0KEZE/4Q0bClhtVxg6g/sbNWpkV5uS1mZ+REbjVTjRajFsf1FsRysQCNJy5syZDD8u2jkj3GCoc8OGDWrkBvOv+IXH0mFUuWOEZtWqVapAFtM8CCZcqUNEgQB1Ip4Uunbo0CHLnhORYcJJuXLl1PWpU6est4WHh0uhQoXUx876imhL7rJnz57hx/37779VEEFB7DPPPKNqQrBMGNNG8Nlnn6lWzp07d1aFYpjOcWzfTETkL6gT+frraJS1pppdx4gJ3mxh2lt7jSUyG6/CCeZBAUuFbWFeFKn/448/VkuJNX/++aeMGTNGjbTUrFkzw4+Lzq8IRJizRVDB57YV8VhePGHCBPXYmFpCMHFVb0JElJUwaDJzJnYSxpu1HhIcnM0aTFBLgjdxWGhAZFZeFcSi+BQNzxYsWCDvvfee9Xas4Ud3VoQRFKpilQxCwrp161R9CMLJiy++6IvnT0SkO5gJR+eCzZsjJEeOqTJyZHNJTrYvdMWKB2zFgdWNWqEhdxoms/AqnGDqBNMmWDKMglRt9AJFr8OHD1eBBaMX2pSKNseKGhCshSYiMqsGDUSWLRPJm1dkz55gSUqyL3RFIf+xY8fUmz/tdu40TGbhVThBSl+9enWaTc1Qaf7dd9+p3idI+5UqVZJnn31W1YIQEZlpl2Fsv4NPbRfaaAsI9+xJ/T1QU4fu23gD6MkSTY6akJFk6q7EqD3BhYjIzLsM9+kzQAYPjhA0ch071j6guAobqJ/DIgMj98YgyvJwQkRkFq52GZ42DStzomXLlkjJl09k+HB/P1siA6/WefPNN9V+NkREZh8x0XYZdtxBOOVzbOURJWFhuyWNhtpE5KtwMnbsWLVe/4EHHlAfnzhxwptvR0SkS9rGfK4FSZMm46RGjSx6UkRmDSf4ZUTlOEZPhg4dqhoGNWnSRL799lu5dOmS754lEVEAF79iSsdxxCS1O7J06Qy3nWGJyMtwgpESNFqrVauW+oXDLyl6mfznP/9R+9x07NhR9TvxZIMrIiI9wvJeT1/jcByOJ6JMDCclS5aUwYMHq26G+/fvl2HDhkn58uVVUEGToLi4ONXlsFixYtK7d29ZsWIF3zUQkaFgubCzHc2dwXG2y4uJKBPCieOafDRdO3TokNrnpn///lK0aFEVRq5cuSLff/+9tGnTRu655x5roCEiMtMuwziOOwoTZWE4sVWnTh0ZP368nDx5UpYtW6aq2PPmzauCCnYjRvFY3bp1M+OhiYgCdpdhHEdEfgon1m8eHKz238Goyblz59Q+PGFhYeqXlNM7RGQUWLUYHR2tdhN2HEHRdhnG/TiOiPwcTgDr/hcuXCjPPfecmurBZlZEREaAl7M330Shq6gpG0xXY+M+LaDY7jKM+4nIzx1if/31V4mNjZUff/xRbf4H2mhJqVKl+ItKRLoPJq1bi2zZIvLbbyI//pgygjJ16lRp3ry5XL5sv8swEfkpnOzdu1cFEqz51xqyaYEEv6RPPfWUdO/eXW1kRURkhGACmzahtYJIxYr/TmljZQ6LX4n8FE6OHz+uAgku2H3YNpBg06rHHntMBZJ27dpx8yoiMlwwCQ8XiY//N5gQkZ/DSaNGjWTjxo12Ba54x4AhTQSSzp07Sz7sckVEZOBgwpb0RAEUTtavX2/9+MEHH1SBBE3X0B2WiMhIGEyIdBJO0A22W7duKpSgCRsRkdmCyfXr19XFFjpkY68dXCckJNjdlzt3bnUhokwKJ4cPH/bmy4mIdGHYsLRHTLB1h2PHa+yfg6nu27dvy9y5c+3uq127troQkR+WEhMRGcWHH4rs2iXyxx+pp3KqVKkiZcqUSdf3cxxNcTbSgmBz48YNNSpToEAB35wIkU4wnBARuYG6/sWLRU6eFKlcWbyapsEoiycjLfgcTSsPHDigtgQhMhOGEyIiJzUmt26JFCliH1Acg0lGeDrSgqCydu1a1vORKTGcEBE5KX5FjSumcGwDii94OtKCcIJeUSyeJTPK9L11iIj0uCpn3z6Rrl39/YyIzInhhIgojeXC48b5+1kRmRPDCRGZHhusEQUWhhMiMjUGE6LAw3BCRKbFYEIUmLhah4j8wlnbd1d83fb92jUGE6JAxXBCRH7hqu17UFCQ5MqVK1PbvuPbV62aEk4YTIh0GE6aN2/u8wfGi8/KlSt9/n2JSB+cNSOLi4tTAQXBpEOHDnb3+brfR0iIyHffiYSFifTuzWBCpLtwsnr1ahUm8I4mLbjflnasp7cTkbk4m6bJnj27aj6G63AMZ2QyBJTPPsv0hyGizAgnjRs3dhkmTp06JYcOHVIf47iyZctKsWLF1Odnz56Vv/76yzpUW6lSJSlZsmR6nycRkdfFrz16iIweLVK9ur+fDRH5ZOQkLUuWLJHu3btL/vz55e2335ZevXqleseDXTanTp0qH374oZw/f17GjRsnbdu29eShiYh8uipn8+aU+hIGFCKDLiU+ePCgPPPMM2pUZP369fLGG284HYrFbbgPx+DYLl26qK8lIsrq5cKYWXYxQ01Eeg8nn3zyiSQlJcmQIUOkWrVqbo+vWrWqOvbatWvyf//3f948NBGRW+xjQmTCpcTLly9XdSTpWc3TrFkzdb1ixQpvHpqITNoLBQWzN27cUNPFoaGhaRbZMpgQmTScnD59Ot1foxXWnjlzxpuHJiKT9kLRAgtefxxX+2i9UBhMiEwcTsLCwuTcuXOyZs0aqVu3rqSnuLZAgQLePDQRmbQXyoIFC9TICYrwH3/8cbv7EFYYTIhMXnPSqFEjVeA6ZswYjwpcccxHH32kRk8aNmzozUMTkQkgbKCg3vaCHijBwcHWXii2FxwfF8dgQmTqcDJo0CD1IpGYmCj16tVTS4QvXryY6rhLly7J+PHjpUGDBnL58mUVTgYPHuzNQxMROYVeJh9/zGBCZNppHQSSjz/+WAUNBBRcv/7661KuXDkpWrSoCiFownb06FE1wqJ1hx07dqz6WiKizPD66yK9eokULuzvZ0JEftn4b+DAgaojbP/+/VWnWASQI0eOyJ9//qnut215X6JECfniiy+kU6dO3j4sEZnU3bt35datW+oaUGOya5dIkyb2xzGYEJl8V+Inn3xSHnvsMZk/f75aIrx3717r9E7BggWlRo0a0rJlS+nYsWOqpX9ERIAVOAgdd+7cUddYKmxr37598vXXX8uPP/6ojsmWLZssW7ZK9uwZIAcPRsjcuSLt2/vt6RNRoIUTQOh46qmn1IWIKCPLhjENjBGRK1euyNy5c9UOxRh93bFjh0yfPl0dp42YIKDExsaISLS6vPRSpBw+LJIzp59PhIj8WxAbCLBSCLUtAwYMsN6GZYZ9+/aVwoULS968eaVz587qRY+IAnvZMDYMRYsCXGP6F8uF0a4AwQShRAsm/7ojIskiEiXjxu1mMCEyCJ+HE7x4YDj2+PHjkpyMF43Ms3XrVjXM+8ADD6Sqg4mLi5M5c+aoHiyohWGdC1FgwzJgLA/GdI22TBjXrjYe1YSEBMmiReOy5HkSkU7CCULI5MmTVd8TvMDgXU/58uXlwIEDdsctXLhQ7a0zatQorx8T+/NgN+Rvv/1W1bVosGoIz+XTTz9VbfXRLRI7Im/YsEE2bdrk9eMSUdbBmx28CUk9YmIvOfmOzJgxw64An4hMXHOCIVcUum7evNntCwNW9aCjI6Zh2rdvLzVr1szw42LaBt8DhbYffPCB9Xa0usbeG7hdU7lyZSldurRs3LgxzSXMN2/eVBcN5rwB3wsXo9LOjeeof0Y4T63lAC44D/xOorbEEzgWv7eOLe31ygg/T3fMcI5mPE+/hxOMmHTo0EG9s0EztqeffloaN24s/fr1c3p89erVVZv7LVu2yM8//5zhcDJz5kxVIIfHdYQ9ezAUjHlrWxjNcbWfz+jRo2XkyJGpbl+1apVhXuzcbeJodGY4R72fJ97sIIxgt/PFixerVX8hISEeTRGjKB+/r9r+XUah55+np8xwjmY4z+sOm3T6LZx8//33KiDgRQH7XbRp00bdnlY4AYycYJRl3bp1GXrMEydOyGuvvaZ+yDl9WP02dOhQ1fFWg3dgpUqVUrsoo7DWyEkX/y9btWpl2GXeZjhHo5znrFmzVDBB3RpW68TGxnoUTFCn0q1bNzWaahRG+Hm6Y4ZzNNN5XrhwITDCCeZ48S7lpZdesgYTd2rVqqWuHetRPIVpG7y7evDBB6234cVr7dq18uWXX8qyZctUjwS0ybcdPcFqneLFi6f5fXPkyKEujvAPycj/mMx0nmY4R72fJ15P8IYHdWIYjfV0SgfTQCiE1+t5G/Xn6SkznKMZzjPUh+fmVTjZs2ePunbcGdQVtLX3JmG1aNFCNXmz1atXL1VX8t///leNduB/0MqVK9USYi0IYfVQ/fr1M/SYRJQ1/vrrL5kyZYoKG+6KYLURExwbHR0tERERWfIciSjzeRVOMDoB6Zn20IZoMY+cEfny5VO1K7by5MmjnoN2e58+fdQUTaFChVSfBLTWRzDhfj5EgWn37t1q41BMFXu64gbBpEePHqrHEYMJkbF4FU7wxx9TLKgD0aZr3Dl06JC6LlKkiGSWzz77TA0JY+QEFfyYcvrqq68y7fGIyLvp4aioKPWxp8EEb27QMuDZZ5/N5GdHRLoLJ9WqVVPhBHPEnk7toOAN88oPP/yw+IpjkyYUyk6YMEFdiCjrKvXTU62PVXB4s4Jgkt6GjTje6MsyiczMq3CC/ibx8fGqEBXTKLbN0JzBhl3o3IpwotWDEJFx9sZBwbotbW8c/M7nypXL7j40SMRrR0aW/mpdZInImLwKJy+88IL83//9n5rWad26tZovrlq1aqrjMLoyfvx4+fjjj9ULEWpDnnnmGW8emogCcG+cMmXK2N2GNyMIKAgm6InkOMKJKR1PV+RoMGWLGhOj9TMhIh+FEyy9nT9/vjRt2lS9Y6pRo4bcf//91vtRrIY283/++ae16yMKV3/66Se+sBAZDKZpHBsWYnQD0y/aXjm20M/EtitzejRs2NCr50pEBt9bB+9gUHOC1TAIH3/88YddBf7hw4fVkkDcV6dOHdWArWLFit4+LBHpHEZTnPUWclUEi8vzzz+vehahnxGatdlefNmhkoh0vLcOIGysX79edX1Fp9ht27apqRwUrWGkBCt5UDCL7nhERNr0TNu2kTJvXoyIuJ7awUgrtr7AZp54TUEIQRdndJF1rGPBhYj0zSfhxHaolcOtROSpESMGyIIF0eKu39rw4cOt22JgmggdobGPl2NHSjPsg0VkBj4NJ0RE6Z0WjomJVsuJMTpiWxyLFTmYEkYH6EqVKllrVhBOUEyLz43cCpzIzIK9HZbFC8jvv//u8dccOXLE+nVEZC6JiSJjxojdSElkZKQqqEcBvfa6oHV/ff/991WtGhGZi9cJwdOOjr76OiLSD4x8YEUOil8RTFq3FtmyReTgQZHvvsMbnH9HULDZH2pKsC0GeiYhnEyfPl2t6iEic/Hb8AWXEhMZf6+cmJgYNVWDkZCwsHhJSBiAKCJxcSInTog4tEVRo6pYwcPXByJzy/JwguV+2mZ9RGSsdvS4aHvl2NaQ4DohAatyoiVfvmiJj49MFUzwWFgejGO1ZcKOn2s1Jzdu3FDHFyhQwLcnTUTGCSeevsvB8OwXX3yhPq5QoYIvHpqIAqgdPUZI0t4rJyWoJCVFyd276CQdkerxzp49q6aCtGXC2uMhkGjLhvF5YmKiHDhwgPUoRAaVrnBSvnx5p7ejdb27qnnMO6P3CV548MLm2MqaiPTdjh6jJn379nX7ZiU4OEhN+aDGxPHx9uzZk+b312hLiW27URORicPJX3/9leo2vIs5efJkuh60Xr16MmTIkHR9DREFdjt6vPHwZK8c3I/jpkyZYhdk8Fiuvr9GW0rMniZExpWucNKzZ0+7z7HRH15c0P01LCwsza/DMXgxKVGihDRo0EBV5LPgjUh/NSa2NSA41jYgYMTD071ycByOZ8AgIq/DieMwLMIJjBo1yuluxERkrBqTixcvWmtCcLxtq3htrxxPAgqOc6xZISLySUHsu+++q66LFi3qzbchIp3UmNh+juMdlwGjoZq2fDgtKJrFcRw9JaJMDSdEZI4aE9vPbY9Fg7WQEJEBAwZIdHS0y8fBSAyOIyLKlPb1RERa59d27dAiIEKFk5CQkFRbVOBz3I770RGWiChTwsmGDRvUiw2GeD1ZsYNjUBiLFynHuW0i0k87elyDbUv6X39F0bzrvXJwO+4nIsq0aZ2ZM2eqIdrHHntM7rnnHrfH4xjMW//0008SGxtrV0xHRIHr2LFjandg23b0S5fGy549A2TfvpRREKz8HTHC9V45RESZHk7WrVunitratm3r8de0b99ehRM0USKiwLdlyxYVNFDwatuOPjY2pR09LuHhkRIfL1Kjhv3Xcq8cIsrycHLkyBF1nZ5lxJUrV1bXhw8f9uahiSgLepvg9xTN0jBCqk3l/EtbkRMlEydWlRo1WEdCRAEQTrD5FqCOxFN4FwXcBp3I/wHkt99+UxdbqCnBSAcu8+fPV9cIJ2kJCQmSRYvGyVNP2fdBIiLySzgpVKiQ2i/n+PHjUrNmTY++5u+//1bXrjrKElHWNFfDRXvDoEE9yenTp2XNmjWyc+dOt98/Odl5O3oiIr+EE0znIJwsWLBAtbD3xLx589Q1N+0iCswN/N555x355ptvXI6WOGI7eiIKmKXE7dq1Uy9gP/zwg/yKdYRuoAgWPQ7w7gorfIgosOzbt08FE9SXpCecsB09EQXMyMlLL70kH330kVy4cEEFldGjR8vzzz+fqgYFtSl4wXv77bdVlT+mg15++WVvnzsRZXBa5/z589Y9c+bOnWu9fdq0aen+/mxHT0QBFU7y5s2r+pUgmKDg7rXXXpO33npL9S/BDsSAuett27ap+/FiiBcyzE/nz5/fV+dAROmc1pk8ebK1X0mnTp3UbXv27JHNmzc7WZUjHrWjd1Z4a7uLcUJCgtvv5ep4Z+31iciYvAon0LJlS1m2bJlERUXJqVOn5Nq1a6l6mGjDw2jChmmdpk2bevuwROQhZ3/U0X8EIx24xp45eMOAJmnpCSYINvjd1trRY3QmrcJb7MdjO0IDeFzHAOLqeLzpYeNGInPwOpxAs2bNVM8T1J4sXLhQVfhrLzp4AXrwwQdV0R1e/BxXBhCRf+3evVu9uUjviAl+nzFiou2T42yExpc4akJkHj4JJ4DQ8cILL6gLEenHuHHj0lUvgmMbNmyousba4rQLEfkKdyUmMjGMlmBKR2tL72k4efTRRzP1eRGRufls5ISI9BVKUHSKXcXRo8RTqFHBBoCZOX1DRMRwQmSy+hJM46CINTk5WYUNXDypN8Fx7733nhQpUiRLnisRmZdH4aR8+fLW4Vxtsz/b2zPC8XsRUebSVuRobevB0yJY/L4+++yzUrZsWe6LRUSBEU7++usvde1YNKfdnhFs2ESUtSMm3bt3T1fXV8ffV6zMQQdZIqKACCc9e/ZM1+1EFFiGDx+eoWCCqRz4z3/+o5YMM5wQUcCEE8clg+5uJ6LAgakb9B/yFIpkUY+CJmt169aVxo0bS6VKlVTvInZwJaKswIJYIoNDjUh6GqxNnDhR7YeFUZOrV6+qrz179qzq2MoOrkSUFRhOiMgOQgmaKmIDT4yEIJBgx2F0eXaFoyZE5CsMJ0QGlydPnnQtF0bxK6ZuMLXjiFM3RBQw4cRxIz9fwVw2EWWuq1eDJX/+x+Ty5QVuj61evbqaytGmbjBqglBz5coVNY3DqRsiCphwgl2Efb30V3t3RkSZJzFRpHVrkcuX3xMRFMXedfk7+f7776sN/DSrVq1S9SeY4sEGn7jWCmE5ikJEfp/WyWh/BCLybzDZsgWfRUi+fDGSlGTfhE0LJbig++uZM2fURaMVwOIaQcUWR1GIyK/hxPFFyRaWFA4bNky2bt2q2lo/88wzUqdOHSlWrJi6H1X+uG/27Nly7tw5efjhh2XUqFESGhrqu7MgIjsoF8HefCnBRCQ8XCQ+PlLu3q1q174ey4XRNRYN1rBc+Pr16x4/BkdNiMiv4aRJkyZOb8c7qnbt2sm2bdukT58+6kUPxXeOoqKiZMyYMeoF8LvvvpNPP/1UFi9e7P2zJyKnQkJEXnhBZPNmkcKFEUxEatTAPRGqP1HlypXVaAgCxpAhQ6xfx8BBRIEgpf1jBk2ePFmWLVsmLVu2lG+//dZpMLF90fvmm2+kVatW6mvwcUahD8MDDzwg+fPnV5f69evLkiVLrPdjjrxv375SuHBhyZs3r3Tu3FmN4BAFMoxaoJ7D04u7UY7evUW+/942mNivysmePTu3kSAi4y0lnjZtmnpxe+WVVzz+GoSG5cuXy/fffy8vvvhihh733nvvVSMxGIbG6A2+1xNPPCE7d+6UatWqycCBA2XRokUyZ84cKVCggPTr1086deok69evz9DjEWWF/fv3y/bt2+1u02o+8HuGXiOuaj6crPyVqKjMe75ERAEZTv744w91Xbp0aY+/plSpUnZfmxGOzaBQw4LRlE2bNqngghGd2NhYad68ubofw9hYgYD769Wr5/R73rx5U100WDoJWE6Ji1Fp58Zz9L+KFStKyZIl7W7DiKDWBK1t27apRiO1c0Lxa4cOwVK//r3SqpVn56kVxQb6/xe9/jy9ZYbzNMM5mvE8/R5OMH0CJ06ckFq1ann0NTgWbIOAN1DUhxEStOjG9A7eeeJ/EKaaNJhfR4DauHFjmuFk9OjRMnLkSKfFwGaYh8doltHp8RwvX76sltzj92WLVt3qICkpm4wY0UAOHSooW7Y8KCEh26Rhw1Muvy++H/qX4Fqv9V96/HlmhBnO0wznaIbzvJ6OgvpMDSd4p7d3716ZNGmSPP744x59DY6FChUqePPQ6nERRhCQUFfy888/S9WqVWXXrl1qLj0sLMzueKwesl0i6Wjo0KEyaNAgu5ETjPKgtwNqV4wKQQ6/MKgFMuoKqkA4R/zSpnclDC6zZs1SwRv1XCg+d4QRk3btQuTQoZTysbx5b8nTT1eXWrVquvz+Bw8eVCvt8Lvi7PsGskD4eWYFM5ynGc7RTOd54cKFwAgnWDa8Z88eVeCKuhOswkGTJmfwDm3w4MGydOlSNX/etWtXbx5a7r//fhVEEhMT5ccff5SePXvKmjVrMvz9sJcILo7wD8nI/5jMdJ7+PMfDhw9nqJ5E60GCi+NzRzBp315k69aUz8PDLTJs2HqpVauR3bHOgpHWyh7X+B2ypZfmamb4N2uW8zTDOZrhPEN9eG5ehROMNMTExKj6ka+//lrmzZunAgt6mRQtWlS9oGp9TjD1oo1cIFjYjlJkBN7xYeQG8CKOxxg/frx06dJFvSPEcLjt6AmeR/Hixb16TKKMQs1TmTJl7G6Li4tLc1M9d+HAvsFaSh+TZcvuyIkTV1Mdu3v3blUs7vhOTmtRjx5EtjBFi1FJIiJ/8SqcYJQENRnt27eXHTt2qPDxxRdfuCy+wwvfwoULnY5SeEObP0dQQXpbuXKlWkIMBw4ckOPHj/MFl/zG2WgEAjbCAa7DkS485CyYYLlw5cqo6fL8+WijNkREhtuVGLUcmzdvVrUkWDHz+++/p/nO8eWXX1aXEHSI8gLqQ7ByAUWu2KQMK3NWr16tppewdBgN4TAyU6hQIdUHpX///iqYpFUMS6QXaQUT9DFJq1A+IiJCLbv3lB6mdIjI2LwOJ4Cwgf4luGD0BMWqFy9eVPcVLFhQatSoISVKlBBfQRv8Z599Vk6fPq3CCBqyIZig2Ag+++wz1WQKIycYTWnTpo189dVXPnt8oqyijQhqNSkHDoj89lvqYOKKXmpIiIh8Gk5soa4js2s70MfE3XTThAkT1IVIj1Angu0gUNOFpcTYAyc+Pl5tAbF4cYT07CmyYIH7YEJEZLr29UTkezNmzFC1U1owAVzjc9x+8uQMNYLCYEJERpXNl8PPKI5FozNM7WDpIjq32k7nYBUNXmQxDeTrglgio4yYYKNMNBd0pAUV3I+ePqglISIyIp+MnGD1DZb1tm7dWt59911VGIv9bi5dumR3HHYkzpcvn1pmjMZSRGQPUznuVtDgfhxHRGRUXocT7EaMTff++usvtTQR3VS1ZcOOnn/+eVXAeu3aNdXRlYjsRx8xpaONkKQF9+O4tH7PiIhMHU4OHTqkVugANtnDMmKspEkL+jlgBQ1eVH/55RdvHprIcNCQzdM9p3AcjiciMiKvwgmW7OJdXLVq1dTmYdhgz51GjRqpa8eOlURmh+XCntZi4TjHlvdEREbhVTjB0kbMf2N5I0ZFPKG1nNd2JyaiFFevBku+fJFu69SxrDgyMpLdXYnIsLwKJ3///be6Ts+qAeyu6uutlYmM0vk1IWEANntweSymRfGGgIjIqLwKJ9o7t/QEDW1LZRTGElGKPn20lvQRki9ftAQHh6gRElv4HMvwo6OjuYyYiAzNq3Byzz33qOs///zT469Zt26dui5fvrw3D01kKGPHipQqldKSfv36SNmxY7v06NHDGlBwjc+3b9+upnSIiIzMqyZsTZs2lYMHD6qeJj3RT9uNxMREtUEgRlywuofIzGz3zUFWX71aBO1/Ujq/RsjUqVPV78nly5fVHlUIJ0REZuDVyMlLL72kgsaaNWtk2rRpbqdzOnbsqLrH4l3gf/7zH28emkjXXWC7d+8lvXv3lldffVVd9+rVS65e3Z2qJT02sMTKHBa/EpGZeBVOatWqJa+99poq0OvTp4906dJFZs+ebb1/w4YNEhsbq3qhYJXO2rVr1YvsO++8I2XKlPHF8yfS5b45sbHO983B/UREZuf13jqffPKJGppGy/off/xRXbR3eRhZ0WjdLLHKYNiwYd4+LFGWQcF3eoq+c+fOrS6OuG8OEVEWhRMEkQkTJqgpmzFjxqgpHsylOx5Tv359FUratm3r7UMSZan9+/erQlRb6M6KwI1/247N0DACgoujsWPHSXKyZ/vmoN6EiMisfLYrcatWrdTl6tWrqvsr2tjjHSL22qlZs6aEYxkCkQ5VqVIl1TRkXFycCigIJh06dLC7z9moyaVLKfvmiHi2b86UKVNYZ0JEpuVVOEEhH2A05Omnn1YfY9fhxo0b++bZEQUAZ9M06Ih8+/Ztde0ueKPBWqtWGGlJ3745zkIOEZEZeBVOsIQYUAhLRGl3ft2+HVM/2DfHfUDhvjlEZHZehZMiRYrI+fPnpVixYr57RkQGCyYpnV+xJDhS7tyJkeTktKd20AG2U6dO1k7Kt27dUlM9uE5ISPCo8JaIyNThBKsKUAB77NgxVVdCRPaC/7dYHzM/EycOkK5do10ejyLbChUqyNy5c+0KbzGFpN3mrvCWiMjU4QQdK1evXq2md5544gnfPSsiA8D2UUuXYnmwyKhR6PwaofbFwXJhFLtqy4cBjQkRQr766is1cuIJjpoQkVF51YQNXS1btGgh8+fPlxEjRlh7mRDRvwFlwQKtJb2ofXGwLDmtfXNefPFFVWDryYXhhIiMyquRk19//VVef/11VXfy/vvvy6xZs1Rx7AMPPKD2AsH8uStc1UNGqzEZPFjko49EChdO+zg0WOO+OUREmbjxn20vBmwCiJDiCcdhbSKjFL+iX9uKFa4DCnDfHCKiTGrCxqkcMjv7VTkif/8tcvas+3BCRESZEE5WrVrlzZcT6Ra2aECztNDQXHbBBKty4uOxks3fz5CIyKThpEmTJr57JkQ6gM37sPcNdhHGtGRISDZJTo7HlpYSHh6hgolW/EpERH7eW4fI6LDnjeMy4JSGajEiEi2vvx4tNWpE+vtpEhGZM5wsWrRIli5dqpqvYXO/kiVLquLYZ555RkJDQ33/LIkCYMQEwQT/3lNLCSpvvx0ljz5aVa3GISKiLAonZ8+elY4dO8oWbYLdBnZRHT58uMybN09qcFybAtj169fVxVPoJ4KpHHeranA/jsMyYSIiyoJwgneMjz/+uGzdujXNY44ePSpt2rSRPXv2uN2plchf9u/frxqe2dLaxCNgOG66V6tWLTWl427pO+7HcQjqXB5MRJQF4WT27NkqmOBFF3t/DB06VOrUqaOmcfbu3SuffPKJbNq0SY2u4OPRo0d78bSIvIOREWyed+PGDRUaEhMT5fDhw6oba/bs2eXBBx+0Ox7/thHA8+TJIx06dLC7D6EFK3M8geMQdNi9lYgoi8IJlC1bVk3rhIWFWe+777771HRPy5Yt1UaAc+bMYTghv4+OoIMxQgrCBYLH8ePH1RJgrQEaLhocg2CC4OI46nfp0l3Jnj2H3LrlPqCgqZrjyAsREWVSONm5c6caNRk8eLBdMNGgVf3IkSNVYSymd65evSr58uVL59Mh8o0qVapI0aJFrSMnGBnBiEZCQoK6v0iRItKsWTPr8QjVzqZt0GDt0UcRZCIlJCTmf6tznMOoDPbO4ZQOEVEWhRPsnwMPPfRQmsfY3oc/Agwn5C/atApGTm7fvq1GNBA+tOCA6UjsaWMbrh3DiX3n1wFqubArGH0ZMADHERFRloQTvOvEC3vevHnTPMZ2nh3vWIkCofAVoQE1J5jSQVCBU6dOydy5c63HXrx4UXLmzGkN1I4t6dFgDX1MsFzYcV8ojJjgMaKjo7mMmIgokJuwcc8dCoSpnTJlyqhAsnbtWklKSpK///5b/dtEoOjUqZP12Pnz58u1a9dUgEkdTFJa0qPBGvqY2HaIxffBjsIYMWEwISLyDXaIJcPCSB4uCCcYFcG1Nq2DYlgUvjq2o0fYCAuLl4QETM9E2ASTlO+JAII+Js2bN5fLly+rqSGEEyIi8mM4+eqrr1ShoS+OQ9M2okBqR4/rhISUdvT58kVLfHyk071yEG5Qx+Jp8auzxm+3bt1Sj4drrVDXMVgREZlRusPJxIkTXd6vvVi7Ow4YTshfUHOCXj2u2tEnJUXJ3bvYXjgiUxu/YUTHtv4FateurS5ERGaUzV91JFxuSf6EHiju/g0GB/uuHb1W/+IpjpoQkZl5HE5WrVqVuc+EKJP2y8HIBFaP4YIOrpiSQa1JVraj5zQNEVEmhJMmTZqk49sSZS1X0yYnT55U4XrXrl1qGgfhROsU6w7b0RMRZT2u1iFD7ByMKRPHaZO4uDg1ffP999+rz7VA4mkwAbajJyLKegwnZIidg50VkJ4+fVoFk/SEEVtsR09E5B8MJxSQbAtIEUpQL4KpGVyjZ4ntvjiA27TluFp9x9KlS716DmxHT0TkH7oMJ9jxGEsv//jjD/UOukGDBvLRRx/J/fffbz0Gf8SwSeHMmTNV3UCbNm1U75VixYr59blT+gtIMYKCC1rMYxQE0z2LFy92OYpSq1Yt2bhxY4ZGTdiOnojIv3QZTrCDbN++feXhhx9WKyreeustad26tfz+++9q23sYOHCgLFq0SObMmSMFChSQfv36qXbl69ev9/fTpwyOoqCGBKMoWhjRPu7QoYPd8Qg1uM/dahxbCDlaW3u2oyci8i9dhhPH4fpp06apbrR4d924cWO1ydvkyZMlNjZWtRkH9KrAH7lNmzZJvXr1/PTMyZtRlOzZs6tlwbgG7WO0obeFZcKfffZZuh4DwWT8+PFSqFAhtqMnIvIzXYYTRwgjgD8sgJCCP1wtW7a0HlO5cmUpXbq0Gup3Fk4w9YOL5sqVK+oa30fbydaItHPTwzkiQGgX289tnzum8Xr16uVVEasn/y9sn0ug/L/T08/SGzxP4zDDOZrxPH1B9+EENQUYgn/kkUekevXq6rYzZ86od9RhYWF2x6LeBPelVccycuTIVLejCNMMPS6WL18uge7cuXNqqga7C4P2MepP4OjRo6rOKKOrcxBy8T217+fpc/Hk+Kykh5+lL/A8jcMM52iG87yejvYPhg8nqD3Zt2+frFu3zqvvg31WBg0aZDdyUqpUKbUqpHDhwmLkpItfmFatWkloaKgEslmzZqkwoNUVaR+3a9dOff7888+nq8GaLYy0FClSRPLmzWv9fq56rly4cMFa81KnTp2A6Aarp5+lN3iexmGGczTTeV64cMFn30vX4QRFrgsXLpS1a9fKvffea729ePHiaqdXbGlvO3py9uxZdV9azbZwcYR/SEb+x6Sn80SA0C62n+N5I5AgvKSnCNYWVvcg2Gjfz9bhw4fT7LmCx0OhbiBt2qeHn6Uv8DyNwwznaIbzDPXhuekynOCPQv/+/eXnn3+W1atXS7ly5ezuxx8G/E9auXKldO7cWd124MABOX78uNSvX99Pz5oyE8KCbc1QeiCQaP9OnOGmfUREWSubXqdysBJn/vz5ki9fPmsdCZYMY5gd13369FHTNCiSzZ8/vwozCCZcqWNM+Llj5Cu9AQWjJRMnTlRhFgEHI25aMzfbsOG4IoiIiDKPLsMJ/phA06ZN7W7HcuHnnntOfYylpPjDg3fEtk3YyBgwjYOfq9bz5OrVYMmXL1Ju3oxBqazbr8e/DQRVbak5aoy0lTdo8BdI0zRERGajy3CiLSV1Be3MJ0yYoC5knEDy559/qkZ66FeDeg80TVu6NF727BkgCQloNR/tdgqnd+/eUrFiRVVA6wlO0xARZS1dhhMyFzRVGzdunPzwww+pVuIgoMTGxvwvlERLvnzRkpQUJcHBQXbFsSEhISrUoksw+t3gc07VEBEFJoYTCmgzZsyQqKgo9XHaS4S1EBIlU6Zsl0qVtqswExMTYx1dQedgTOHge3gy8kZERP7DcEIBPWKCYJKcnOzR8SEhQbJo0ThVe4QLwoi2nBxF0VevXlWN2oiIKLAF+/sJEKUFox/paUOfnHxHjbRgZARN0zBqgukbFLlil2qsxNFazmMEBatytIsvOxsSEZF3OHJCAQnhAUEjvU3VsIIHS4L379+vmu7h+2BlDi7ahoGAoGK7KocrcoiIAgfDCRmqqRp6nWB5MRqn7dmzR30frNxCm3vUnaCoVqtDQXGshityiIgCB8MJGaapGgJHZGSkmgpC2MBICaZ0cI2AgtU5Wot6XHO1DhFRYGLNCQUkhAcEDQQOT6GWBDtUExGRvnHkhDKVsx19XbHd0RdBIzradVM1QNEroAPwPffcY20/jykdFMJqBbDYwA9TOvgYK4Cctann9A4Rkf8xnFCmQmFqWjv6YnpFaz/vrDC1bNkIKVs2Wo4cQZ8TrNq54zSYYLlx69at1VJh2yJXLCNG4SsgkJw4ccJaYIvHZ5t6IqLAxHBCmTpKUrRoUWnWrJndbatWrVIjGhil6Nixo9192shFYqJI69YiR45EikhVyZFjnCQn/9tUDZs44lKjRg3p0aOH08e+dOmSJCYmqlGSvXv3qmMRlLQ9eRyfV8GCBX38f4SIiDKC4YSyfJTk4sWLaiQDIcNZUaoWTLZsSfk8PDxC4uOnyq5dKU3VECLw/ZKSkqx9UJxNyRw7dkx27NihHh8hZdeuXapAFl+DgIKQZAujJiySJSLyP4YT8hks3y1TpozdbXFxcSqgIJh06NDB7ra8efN6EExE4uNFatQQ2bMnWK3g8bQxm/Z8EEjWrl2rlhKHhoameTzrTYiIAgPDCfmMs9EL2+W82qiEdptWyOpJMPHm+eCxtKXErsIJEREFBi4lpoDxzz8iV674JpgQEZF+MZxQwChePCWQNGrEYEJEZGac1qEsh2JYbcWMoxIlRNasEUnHfn9ERGQwDCeUZXbv3q12Go6J+XdJ8OjR8TJlygCpVy/CehyDCRGRuXFah7LEhg0b1FJdLZgArvfvj5H69WvLtGkz/P0UiYgoQHDkhDIdOrNOmjRJTeeklhJU+vSJklq1qkpExL8jKBqtwRq6vSLQaF1ftY/Zhp6IyFgYTijTrVy50u0xwcFBaspn6tSpaTZ305q3XblyRdWroLkalgmzDT0RkbEwnFCmQpjYunVrGqMm/8IoyIwZM2TKlCmpmqxpzdScNXRzhqMmRET6xnBCmQp76Gg1Ju5gBQ/CB8KFN7sZExGRvjGcUKavzPEUWtNry4td7dPDqRwiImNjOCGfw/RMVFSUmp7xdNQEy4ojIyOtUzrO9ulxhaMmRETGwXBCPh8xQTBJTk5O19dhRGTAgAHWzzlNQ0RkXgwn5FRGaz4wlePprsHaiAmCSXR0tNNlxEREZD4MJ+SUq5oPhA/H1vOo96hVq5aa0vF0Kge7Evfo0UONmDCYEBGRhuGEnHJW8+FqKS9GTXAfVtx46uuvv5Y+ffr47DkTEZExMJyQU85qPrJnz65WyuA6PDw81ddcunRXgoJyiMVy06PpHKzOISIicsS9dcgnEhNFHn00WCyWSLeZNzg4WOrUqZOu2hQiIjIPjpyYvNAVIyFolIb9aUJDQ1Md78mqGQST1q1FtmzBZ1hxE+32eTRv3jxjJ0BERIbHcGLyQlcUuGLPmlOnTqkRDWeFrq6am9kHE5Hw8Ah5/fVoefvt1H1OtJU5L730kpQqVSozTo+IiAyA4cRkHAtdMXKCLq6oI8EIibNCVw32x0HBqxZgUgcTkfh4kRo1IuXRR6taO8QioCCYaCtz9u3bJ0lJSVl1ykREpDMMJybjOE2DcIIlvQgPaRW62rai14LGsmXxsns3gkaEQzBJ+RosDcYOw02aNJFLly5JgQIF5PHHH1f37dixQ32fW7duqekkV8+PiIjMh+GE0t2KHtezZsVIcjJqS6IlPDzSLpjYQn2LtsRY2w+He+QQEZErDCeUoVb0WlAJCoqSiROrSo0azpuo5c2bV107643iDEdNiIiI4YTS5Ekr+pCQIFm0aJw89dTUNO53PWVERETkiH1OyCkUv3rSih734zhM0xAREfkCwwk5lZ5W9DgOxxMREfkCwwk5hRoRT9vL4zjH/ihEREQZxZoTcgoN2Tp3jpTY2BhM3qR5HOpJIiMjVW2KY/dZwHJhLhsmIqL0YDgha3M126CABmt79rhvRY9aEzRWc9Z9FrhsmIiI0ovhxORLhT/99FOJjY21NleLj4+XPn0GyODBEf9rsIZwEqVW5SQnp25FHx0drRquOes+6w5HTYiIyBmGE5NKq7kausBOm5bSXE0kUjVYQx8TLBd21opeCybAaRoiIvIFhhMT8qS5GkZLwsKqSnx8hGqwhj4m2En48uXLUrBgQRVOiIiIMgNX65iQJ83VRIKkSZNxdi3pUSSLlTnuv5aIiMhk4WTt2rWqFXrJkiXVH8p58+bZ3Y9aiOHDh0uJEiXUEteWLVvKoUOH/PZ89dhcDSt0li5lczUiIsp6ugwnSUlJqtZhwoQJTu8fO3asfP755zJp0iTZvHmz5MmTR9q0aSM3btwQf8NSWyyp9fTiuDTXW2yuRkREgU6XNSdt27ZVF2fwTh/TFsOGDZMnnnhC3fbDDz9IsWLF1AhL165dxZ9cLbfFKJBjMzNfL7fVmqt5ElDYXI2IiPxBl+HElaNHj8qZM2fUVI6mQIECUrduXdm4cWOa4QR/rG3/YF+5ckVdoz8HLr5SsWJFNR1la8mSJSqgIAg4hi6sfvHl40OXLl1k+vRYu6XBjrAiB/+vbKd/EKC0i6+fU2bSnquennNG8DyNxQznaYZzNON5+oLhwgmCCWCkxBY+1+5zZvTo0TJy5MhUt69atSrTl8diBQxCAMLRli1bJLNVrvyQJCdPd1ubUrVqVbvGaadPn1YrfBDcHBuqIczgEsiWL18uZsDzNBYznKcZztEM53ndh2UIgf3XJAsNHTpUBg0aZP0cf4BLlSolzZo1k8KFC2fqY8+aNUvV0aA2pl27dpn6WOj8OmpUiIiEq+XCWJVj255ea6727rvvqhEnBCdNaGiouh/TT7a3Q61atdQlUNM8XhRatWqlzsGoeJ7GYobzNMM5muk8L1y44LPvZbhwUrx4cXV99uxZtVpHg89r1qzpsr7C2UZ3+IeU2f+Y8Mdeu2TmYyGYtG8vsnUrPotUfUwaNfpMliyZnqq5WqVKldKVgjG6FOi/dFnxswwEPE9jMcN5muEczXCeoT48N8OFk3LlyqmAsnLlSmsYwSgIVu28/PLLYlYIJq1bi2izRuHhohqsVa78rYwfX12yZ88uhQoVsmuuxm6vRETkD7oMJ9euXZPDhw/bFcHu2rVL/XEtXbq0euf/wQcfqHf/CCvvvPOOKkLt2LGjmBFalTz5pGMwEdVgDfVLbK5GRESBRJfhZNu2baoWRKPVivTs2VOmTZsmQ4YMUTUcL774oqqNaNiwoSxdulRy5swpZoTMMWyYyKZNInny/BtMiIiIApEuw0nTpk1ddi7FCMB7772nLnqGmo/01n2kNRXTvLnIokUpoyYMJkREFMh0GU7MwpuGbWiG6zhQZDPYREREFLAYTgJYlSpVpEyZMna3xcXFWRu2YX8hW9qoiVb8in5uI0Zk6VMmIiLyGsNJAHM2TYNVNVgzj+twzNG4WJWDC2pM3ngjC580ERGRGTf+I8+XCz/6qL+fFRERUfpw5MTQfUxSF786FtliFAYt6dGE7datW2onZE+LbImIiDIDw4mJgomzIlsU12rBBNeOe+b4eldkIiIidxhOdAYb8mGDQG2lTnqCibMiW4ycrF27Vho3buy09TBHTYiIKKsxnOjE7t27Zdy4cRITE2PdB2fp0njZs2eA7NsX4VEwcTZNg3CC5nQorjXyng9ERKQfDCc6MGPGDImKilK9TRBMANezZsVIcnK0iERLeHgkO78SEZEhcLWODkZMEEy0olVbycn4PFlEomTixN0MJkREZAgMJwEOUznuNuTLli1IFi0al2XPiYiIKDMxnAR48SumdBxHTBzhfhznar8hIiIivWA4CWBoU4+VOZ7AcTieiIhI7xhOAhiWC+fIkcOjY3Gc40aAREREesTVOm5cuHDB7XRJZnVRDQ4Ols6dIyU2NgaTN2keh2XFkZGRbmtTiIiI9IDhxI3Fixer4IEpE4QUBADHEQpvu6g6NlbToMEa+phgqbAreF4DBuA4IiIi/WM4caNdu3ZSqFAhiYuLUwEFAaJDhw52x2R01MRZY7X4+HgVNMqWjVCdX1MarCGcRElISND/lg+nwPEIJtHR0RIRkdKIjYiISO8YTtwoXLiwumTPnl11U8U1uqk647ipnivYw+aVV15J1VgNQQVho2zZaDlyJFLdjgZrEydWVcuFbYNMjx49VJBhMCEiIiNhOPEhx031wNl00IkTJ+TDDz9U0zmOtKBy5EiUiFSV8PCI/3V+jZCnnpoqzZs3l8uXL0vBggVVOCEiIjIahhMfctxUD5xNB/Xv39+D4tUgyZFjnMTHT7Xr/IoiWazMYfErEREZFcOJDzlbteM4HYTRkp9//lm1o3ftjlgsM6R69SkqqBAREZkF+5wEcGO1W7fYWI2IiMyHIycZkJ7C11u3btnVlmiN1TwJKGysRkREZsRwkomFr3Dx4kXJmTOn5MuXz1ozgoZp2qqbtLCxGhERmRXDSSYWvmq3O46SYPkvlgu7wsZqRERkVgwnmVT46ni7LTRYS+ljguXCGBlhYzUiIiINw0kWQ0t6dH5NabBWVS0XTk523ljNWW0LalhwLK4TEhKyZI8fIiKirMRw4odgsmVLyucpDdamyq5dzhuruaptwWgMusz6co8fIiKiQMBwkkVQ+2ofTOR/nV+xuZ/zxmrOaltc4agJEREZAcNJJtN2HM6ZM5cgZyCc2AYTVzhNQ0REZsRw4saFCxfUNIqrWg9n/Uyc7TjcrVu8PPXUABk+PMJtMCEiIjIrhhM3Fi9erEYv0K8E4ePSpUsqcLjqZzJjxgyJiopKteNwbGyMWCzR0qlTtNSokbLjMBEREdljOHGjXbt2UqhQIWsfk6tXr6rlwY79TObPny/Xrl2To0ePyogRI5zunaMFFQSXqlWrcqkwERGREwwnbhQuXFhdtH4l6PCKKRqtn4nj9I0nHV1xDL5m6tSpWXIOREREesKN/7yA6Rss3bVtRY/6FFxcwbH4WnfHERERmRHDSQYdO3ZMTc9g+sbVHjlpwQoe7jhMRESUGsNJBi1dutSrTfm44zAREZFzDCcZgFU7GzduzNCICXDHYSIiorQxnGQACmMzGkyAOw4TERGljeEknZ1eEUrwcUhISIZGTPB13HGYiIgobVxK7MbevXvl+++/V4HCsXcJpmVcrbjRpm1wjOOOw0REROQcw4kbLVq0UNe2rek17pYCoyfKyJEjJX/+/Kl2HCYiIiLnGE7ccBZK3MEoCYILRlvw9UlJSSx+JSIi8hBrTnwAwUMLH9r0zfbt29WKHCIiIkofjpz4gFZT8sknn6h9eDh9Q0RElHEcOfERrOJBjQmnb4iIiLzDcOIjGDkJDQ3199MgIiLSPUOHkwkTJkjZsmUlZ86cUrduXdmyZUumBZMGDRpw1ISIiMgHDBtOZs2aJYMGDZJ3331XduzYoXqLtGnTRs6dO5cpNSf43kREROQ9w4aTTz/9VF544QXp1auXVK1aVSZNmiS5c+eWKVOmZOB/kfP/Tagx0Tq+lilTxifPm4iIyOwMuVrn1q1bainv0KFD7YJEy5Yt1YZ9zqA1PS6axMREdZ0//2Jp0OB7+eWXWXY9T/D9unTpIi+++KLUqFFD5s6dK9evX1dTOxcuXLAeh9tsb8fH//zzj91jX758Wd2GPXsOHjxodx92Lkaoyix4TDwnPDej1syY4RyB52ksZjhPM5yjmc7z4sWLHjUo9YjFgE6ePIn/M5YNGzbY3f7GG29Y6tSp4/Rr3n33XfU1vPDCCy+88MKLZPhy5MgRr/+OG3LkJCMwyoIaFdvRDEzVHD9+XAoUKCBGdeXKFSlVqpScOHFCtdk3IjOcI/A8jcUM52mGczTTeSYmJkrp0qVVvy9vGTKchIeHq1qQs2fP2t2Oz4sXL+70a3LkyKEujhBMjPyPSYNzNPp5muEcgedpLGY4TzOco5nOMzjY+3JWQxbEZs+eXWrXri0rV6603oZ6EXxev359vz43IiIiMuHICWCKpmfPnvLQQw9JnTp1ZNy4cWoDPqzeISIiosBl2HCClTTnz5+X4cOHy5kzZ6RmzZqydOlSKVasmEdfjyke9EhxNtVjJGY4TzOcI/A8jcUM52mGcwSeZ/oFoSo2A19HRERElCkMWXNCRERE+sVwQkRERAGF4YSIiIgCCsMJERERBRSGEycmTJggZcuWlZw5c0rdunVly5Ytomdr166VDh06SMmSJdUeP/PmzbO7HzXRWNVUokQJtZcP9iA6dOiQ6M3o0aPl4Ycflnz58knRokWlY8eOcuDAAbtjbty4IX379pXChQtL3rx5pXPnzqma9QWyiRMnygMPPGBt5oS+PUuWLDHM+aVlzJgx6t/ugAEDDHWuI0aMUOdle6lcubKhzlFz8uRJ6dGjhzoXvM5gT7Jt27YZ6nUIfzccf5644GdolJ9ncnKyvPPOO1KuXDn1c6pQoYK8//77dvvp+ORn6XUDfIOZOXOmJXv27JYpU6ZYfvvtN8sLL7xgCQsLs5w9e9aiV4sXL7a8/fbblrlz56p9D37++We7+8eMGWMpUKCAZd68eZbdu3dbHn/8cUu5cuUs//zzj0VP2rRpY5k6dapl3759ll27dlnatWtnKV26tOXatWvWY/7zn/9YSpUqZVm5cqVl27Ztlnr16lkaNGhg0YsFCxZYFi1aZDl48KDlwIEDlrfeessSGhqqztkI5+fMli1bLGXLlrU88MADltdee816uxHOFXt6VatWzXL69Gnr5fz584Y6R7h48aKlTJkylueee86yefNmy59//mlZtmyZ5fDhw4Z6HTp37pzdz3L58uXqNXfVqlWG+XmOGjXKUrhwYcvChQstR48etcyZM8eSN29ey/jx4336s2Q4cYCNAfv27Wv9PDk52VKyZEnL6NGjLUbgGE7u3r1rKV68uOXjjz+23nb58mVLjhw5LDNmzPDTs/TdCwXOd82aNdbzwh9y/DJp9u/fr47ZuHGjRa8KFixo+e677wx5flevXrVUqlRJvcg3adLEGk6Mcq4IJxEREU7vM8o5wn//+19Lw4YN07zfqK9D+PdaoUIFdX5G+Xm2b9/e0rt3b7vbOnXqZOnevbtPf5ac1rFx69Yt2b59uxqCst0jAJ9v3LhRjOjo0aOqSZ3tOWM/IUxn6f2csQkVaJtQ4WeLrcttzxVD6NioSo/niuHVmTNnqs7HmN4x2vkBhsDbt29vd05gpHPFcDemXMuXLy/du3dXm40a7RwXLFigunU//fTTasq1Vq1a8u233xr6dQh/T2JiYqR3795qascoP88GDRqorWAOHjyoPt+9e7esW7dO2rZt69OfpWE7xGZEQkKCesF37CKLz//44w8xIvwjAmfnrN2nR9hLCfUJjzzyiFSvXl3dhvPBvkthYWG6Pte9e/eqMIL5a8xb//zzz1K1alXZtWuXIc5Pg+C1Y8cO2bp1a6r7jPKzxAv2tGnT5P7775fTp0/LyJEjpVGjRrJv3z7DnCP8+eefql4K24q89dZb6mf66quvqvPDNiNGfB1CbR92t3/uuefU50b5eb755ptql2UEK2ywi7+Zo0aNUsEafPWzZDghQ8I7brzAI9EbDf6QIYhgZOjHH39UL+5r1qwRI8HW8q+99posX75cFaYblfZuE1DojLBSpkwZmT17tiokNAq8WcDIyYcffqg+x8gJfj8nTZqk/v0a0eTJk9XPF6NiRjJ79myZPn26xMbGSrVq1dRrEd4I4jx9+bPktI6N8PBwlQQdq6fxefHixcWItPMy0jn369dPFi5cKKtWrZJ7773XejvOB0OteDej53PFu6+KFSuqnbexQikiIkLGjx9vmPMDDIGfO3dOHnzwQcmWLZu6IIB9/vnn6mO8CzPKudrCu+r77rtPDh8+bKifJ1ZtYHTPVpUqVaxTWEZ7HTp27JisWLFCnn/+eettRvl5vvHGG2r0pGvXrmrFVVRUlAwcOFC9FvnyZ8lw4vCijxd8zKfZJn58jmF0I8JyMPyDsT1nDNlt3rxZd+eMel8EE0xzxMfHq3OzhZ9taGio3bliqTFeIPV2rrbwb/TmzZuGOr8WLVqo6Su8K9MueOeNoWPtY6Ocq61r167JkSNH1B9zI/08Mb3quKwfNQsYJTLa6xBMnTpV1dagXkpjlJ/n9evXVS2mLbypx+uQT3+WPiziNcxSYlQVT5s2zfL7779bXnzxRbWU+MyZMxa9woqHnTt3qgt+5J9++qn6+NixY9ZlXzjH+fPnW/bs2WN54okndLeED15++WW1fG316tV2y/muX79uPQZL+bC8OD4+Xi3lq1+/vrroxZtvvqlWH2EJH35W+DwoKMjyyy+/GOL8XLFdrWOUcx08eLD694qf5/r16y0tW7a0hIeHq5VmRjlHbTl4tmzZ1DLUQ4cOWaZPn27JnTu3JSYmxnqMUV6HsMITPzOsUHJkhJ9nz549Lffcc491KTFaVODf7JAhQ3z6s2Q4ceKLL75Q/4DQ7wRLizdt2mTRM6yxRyhxvOAfmbb065133rEUK1ZMBbMWLVqoHhp64+wccUHvEw1+OV555RW1/BYvjk8++aQKMHqBJXzoF4F/m0WKFFE/Ky2YGOH80hNOjHCuXbp0sZQoUUL9PPGCj89te38Y4Rw1cXFxlurVq6vXmMqVK1u++eYbu/uN8jqE/i143XH23I3w87xy5Yr6PcTfyJw5c1rKly+v+mjdvHnTpz/LIPzHdwM+RERERN5hzQkREREFFIYTIiIiCigMJ0RERBRQGE6IiIgooDCcEBERUUBhOCEiIqKAwnBCREREAYXhhIiIiAIKwwkRUTqsXr1agoKC1AUfE5HvMZwQBaC//vrL+gfQmwsRkR4xnBAREVFAyebvJ0BEqd1zzz2yd+/eNO+vUaOGun7ooYfU9uxEREbCcEIUgEJDQ6V69epuj8uTJ49HxxER6QmndYiIiCigMJwQGUzTpk1VMSyu4dChQ9KvXz+pVKmS5M6dW92HgluYNm2atXhWu81dgS6+xpV58+bJ008/LaVLl5acOXNKWFiYmn4aOXKkXLp0KUPntHbtWuvjf/vtt26PHz16tPX433//3e6+P//8Uz755BPp0KGDlC1bVnLlyqUuZcqUkS5dusjSpUvFl///0zJixAiPCpcTExPV+TzyyCNSpEgRyZ49u5QoUUI9/x9//FEsFotXz5coEHFah8jA5s+fL927d5ekpKRMfywEj6eeekri4+Ptbr9586Zs375dXb766iv1nOrVq5eu792oUSMVdo4fPy6xsbHywgsvuDwex0DNmjWlatWq1tuPHj0qFSpUcPo1+N64zJ49W3r06KFqebJl8+9L5MqVK1VgunDhgt3tZ86ckYULF6pLu3btZNasWZI3b16/PU8iX2M4ITIo/KHFH1mMlrzzzjvqD3xISIhs3brV53/IEEBatmwpO3bsUI/RrVs39UezXLlycvv2bTXy8emnn8q5c+fU7Tt37lQjFZ7C6EJkZKR89NFH6nudPHlSFQ07s2fPHtm3b5/6GMHMVnJyshp5aNOmjbRq1UoFl0KFCsnFixfl4MGDMmHCBPntt98kJiZGypcvr0Z7/GX9+vXStm1b9f+vWLFi0r9/f4mIiJCSJUvKqVOnVCDB81y8eLH07NlTfvrpJ789VyKfsxCR7uBXF5cmTZqkug+3afeXLFnScuzYsTS/z9SpU63HHj16NM3jcJ92HL7G0VtvvaXuCwsLs2zbts3p9/jrr78sJUqUUMd169bNkl579uyxPoePP/44zeP++9//qmOCg4Mtf//9t919165ds5w6dSrNr717967lueeeU1+fJ08ey+XLl1Mds2rVKuvzwMdp/f939rOx9e6771q/j6Nbt25ZypYtq+579NFHLUlJSU6/xzfffGP9Hr/88ovLxyPSE9acEBnYmDFj1HRIZrp27ZoacYD3339fateu7fQ4jJRgBAfmzJmT7qkmLJ/WllBPnz7d6THIbTNmzFAfN2nSJNXoClY3oV7D1QgN6lEw+oPnt2LFCvGHmTNnqjof1Oz88MMPavTLGUxv1alTR33srhaISE8YTogMCtMXKEzNbGvWrFFFm4CaE1caN26srjFVgRqU9NKmaXbt2iX79+9Pdf+6devUdJbtsa7gefz999/qe2EqCBdMmRQuXFjdv3v3bvGHBQsWWAMWimA9+X+6cePGLHluRFmBNSdEBoXVOXjnndm2bdtm/djVqIQjFHWmF+pOhg4dqkZIMHrywQcfOC2EzZEjh3Tu3DnNQPLNN99IdHS0qn25detWmo+XkJAg/qD9P122bJnH2xBk5P8nUaDiyAmRQRUsWDBLHgdFrhlx/fr1dH8NpqhQ2GsbRGxDB6aLoH379moJsyMUvtavX18trd68ebPLYAL//POP+ENG/p/667kSZQaOnBAZFOomsgJWwGiwWgfdbT1x7733ZujxMF2DFTtYFoypDIQNbZRBW3Kb1pTOa6+9Zp1O6tixo/Tu3VseeOABKVq0qBpl0kYpEIJOnDjhtx4i2v9TrNYZO3asX54DkT8xnBCZWHDwv4Ond+/eTfM4V8WrWn0GoD4io6HDU6ijwbJajHpgakcLJ9pISoECBdTIiaMrV66o5bdaeMEy3LRktFmc7f9TV/8/Pfl/itoXnCO3JyAz4rQOkYnly5fPoz/I6AGSllq1atn15siK6SqMKAAapt25c0f9oUdzN60oFzUnjtApF1M/gMZmafnjjz/UCiRv/5+6Czie/D9F7Ym7qSciI2I4ITIxNElzVtjqSFue6wyar2lLXT///PMsmQrRpm3Onz8vy5cvVy3ztRqWtKZ0EGI8GbWYNGmST/6fInxcvXo1zUJbPO+0PP744+oaq6C46zSZEcMJkYlhygAdUuHLL79UnV4dYXRCKzR1BoWnKDCFDRs2yMCBA11OaZw9e1a+++47r5439pXJnz+/+hhTO9qUDvqaYPmtMxUrVrTWlHz//fdOQ1RcXJz6/+AN7fEx4vHFF1+kuh+jN88//7zLAlZ0fC1VqpT6+PXXX1c1Nq5gCTWWdBMZBcMJkYlh75iXXnpJfYweH82bN1fTI1hiiw3w+vTpo5bvNmjQwOX3ee+996Ru3brq4/Hjx8uDDz6oGrNhmgc9SVatWqX+6KMIFcWm3o5OoHi1U6dO6mOMmmijEHiutnU0jnUcaJ0POLfWrVvL3LlzVYHskiVLVGB48sknVdt6d71FXEG9i9aaH03nBg0apMIDRqYQirCvEPqYuNpfCNNSCIW4xhQTfi7YigAb/eH5YgsCfI93331XFfRiBdPevXsz/JyJAo6/W9QSUea0r3fXPl2D1uj16tWzfk/HS9OmTS379u1z2b4erly5YunUqVOa38f20qxZM6//HyxfvjzV9925c6fLrzl+/LildOnSaT4v3Pfbb79ZypQpoz7v2bNnutvXw6+//qra3zt7jJCQEMv48eNdtq/XbNy40VKqVCmP/p9+//33Gfi/SBSYOHJCZHKoF8FOwqNGjVLt4XPlyqWmTB5++GE12oEW7mj77kkhKDaf+/XXX9UoxP33369uw+gMpo7w/fr27as2qnNVb+EpjCbYNn3DJn7YhdgVTJVgufMbb7wh9913nxqZwOoebKiHUQiM8tjuYpxRDRs2VCMcUVFRaqM+LK/Gc0VjOEzRvPrqqx59H4yuoJAXI00YkcH3QudfjBzhXDD6g58binifffZZr583UaAIQkLx95MgIiIi0nDkhIiIiAIKwwkREREFFIYTIiIiCigMJ0RERBRQGE6IiIgooDCcEBERUUBhOCEiIqKAwnBCREREAYXhhIiIiAIKwwkREREFFIYTIiIiCigMJ0RERBRQGE6IiIgooDCcEBERkQSS/weeOH9M701DSQAAAABJRU5ErkJggg==",
-            "text/plain": [
-              "<Figure size 800x600 with 1 Axes>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "fig, ax = plt.subplots(1, 1, figsize=(8, 6))\n",
-        "ax.plot([0, 80], [0, 80], \"b--\", lw=2)\n",
-        "\n",
-        "yerr1, yerr2 = median - q1, q2 - median\n",
-        "yerr = torch.cat((yerr1.unsqueeze(0), yerr2.unsqueeze(0)), dim=0).squeeze(-1)\n",
-        "markers, caps, bars = ax.errorbar(\n",
-        "    test_Y.squeeze(-1).cpu().numpy(),\n",
-        "    median.squeeze(-1).cpu().numpy(),\n",
-        "    yerr=yerr.cpu().numpy(),\n",
-        "    fmt=\".\",\n",
-        "    capsize=4,\n",
-        "    elinewidth=2.0,\n",
-        "    ms=14,\n",
-        "    c=\"k\",\n",
-        "    ecolor=\"gray\",\n",
-        ")\n",
-        "ax.set_xlim([0, 80])\n",
-        "ax.set_ylim([0, 80])\n",
-        "[bar.set_alpha(0.8) for bar in bars]\n",
-        "[cap.set_alpha(0.8) for cap in caps]\n",
-        "ax.set_xlabel(\"True value\", fontsize=20)\n",
-        "ax.set_ylabel(\"Predicted value\", fontsize=20)\n",
-        "ax.set_aspect(\"equal\")\n",
-        "ax.grid(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "19284b99",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "hidden_ranges": [],
-        "originalKey": "34e976cd-7d09-40d2-8987-aecdefa7c0fd",
-        "papermill": {
-          "duration": 0.019776,
-          "end_time": "2026-01-08T16:47:17.978761",
-          "exception": false,
-          "start_time": "2026-01-08T16:47:17.958985",
-          "status": "completed"
-        },
-        "requestMsgId": "34e976cd-7d09-40d2-8987-aecdefa7c0fd",
-        "showInput": false,
-        "tags": []
-      },
-      "source": [
-        "## Look a the lengthscales from the final model\n",
-        "\n",
-        "As SAASBO places strong priors on the inverse lengthscales, we only expect parameters \n",
-        "0 and 1 to be identified as important by the model since the other parameters have no effect.\n",
-        "We can confirm that this is the case below as the lengthscales of parameters 0 and 1 are \n",
-        "small with all other lengthscales being large."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "id": "e8e561a9",
-      "metadata": {
-        "code_folding": [],
-        "customInput": null,
-        "customOutput": null,
-        "execution": {
-          "iopub.execute_input": "2026-01-08T16:47:18.003809Z",
-          "iopub.status.busy": "2026-01-08T16:47:18.003647Z",
-          "iopub.status.idle": "2026-01-08T16:47:18.006614Z",
-          "shell.execute_reply": "2026-01-08T16:47:18.006277Z"
-        },
-        "executionStartTime": 1668655927129,
-        "executionStopTime": 1668655927142,
-        "hidden_ranges": [],
-        "originalKey": "33147b57-ea6b-4c67-9c7d-796bb54d5c84",
-        "papermill": {
-          "duration": 0.01625,
-          "end_time": "2026-01-08T16:47:18.007452",
-          "exception": false,
-          "start_time": "2026-01-08T16:47:17.991202",
-          "status": "completed"
-        },
-        "requestMsgId": "b32e63df-16ee-45f1-af94-7f6f4bb78173",
-        "showInput": true,
-        "tags": []
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Parameter  0) Median lengthscale = 7.48e-01\n",
-            "Parameter  1) Median lengthscale = 2.20e+00\n",
-            "Parameter 27) Median lengthscale = 4.60e+02\n",
-            "Parameter 16) Median lengthscale = 5.25e+02\n",
-            "Parameter 26) Median lengthscale = 5.91e+02\n",
-            "Parameter  4) Median lengthscale = 6.43e+02\n",
-            "Parameter  2) Median lengthscale = 6.53e+02\n",
-            "Parameter 18) Median lengthscale = 6.71e+02\n",
-            "Parameter 29) Median lengthscale = 7.05e+02\n",
-            "Parameter 10) Median lengthscale = 7.09e+02\n"
-          ]
-        }
-      ],
-      "source": [
-        "median_lengthscales = gp.median_lengthscale\n",
-        "for i in median_lengthscales.argsort()[:10]:\n",
-        "    print(f\"Parameter {i:2}) Median lengthscale = {median_lengthscales[i].item():.2e}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8e0890ef",
-      "metadata": {
-        "papermill": {
-          "duration": 0.012113,
-          "end_time": "2026-01-08T16:47:18.031271",
-          "exception": false,
-          "start_time": "2026-01-08T16:47:18.019158",
-          "status": "completed"
-        },
-        "tags": []
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "fileHeader": "",
-    "fileUid": "d9b695e8-72dd-408b-b482-b264b8b50ba8",
-    "isAdHoc": false,
-    "kernelspec": {
-      "display_name": "python3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.13"
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "## High-Dimensional sample-efficient Bayesian Optimization with SAASBO\n",
+    "\n",
+    "This tutorial shows how to use the Sparse Axis-Aligned Subspace Bayesian Optimization (SAASBO) \n",
+    "method for high-dimensional Bayesian optimization [1]. SAASBO places strong priors on the \n",
+    "inverse lengthscales to avoid overfitting in high-dimensional spaces. Specifically, SAASBO \n",
+    "uses a hierarchical sparsity prior consisting of a global shrinkage parameter \n",
+    "$\\tau \\sim \\mathcal{HC}(\\beta)$ and inverse lengthscales $\\rho_d \\sim \\mathcal{HC}(\\tau)$ \n",
+    "for $d=1, \\ldots, D$, where $\\mathcal{HC}$ is the half-Cauchy distribution. \n",
+    "While half-Cauchy priors favor values near zero they also have heavy tails, which allows the \n",
+    "inverse lengthscales of the most important parameters to escape zero. To perform inference in the \n",
+    "SAAS model we use Hamiltonian Monte Carlo (HMC) as we found that to outperform MAP inference.\n",
+    "\n",
+    "We find that SAASBO performs well on problems with hundreds of dimensions. As we rely on HMC \n",
+    "and in particular the No-U-Turn-Sampler (NUTS) for inference, the overhead of SAASBO scales \n",
+    "cubically with the number of datapoints. Depending on the problem, using more than a few hundred\n",
+    "evaluations may not be feasible as SAASBO is designed for problems with a limited evaluation budget.\n",
+    "\n",
+    "In general, we recommend using [Ax](https://ax.dev) for a simple BO setup like this one. See [here](https://ax.dev/docs/tutorials/saasbo.html) for a SAASBO tutorial in Ax, which uses the Log Noisy Expected Improvement acquisition function. Therefore, this tutorial shows a minimal illustrative example of how to use SAASBO with only BoTorch. To customize the acquisition function used with SAASBO in Ax, see the [custom acquisition tutorial](/docs/tutorials/custom_acquisition), where adding `\\\"surrogate\\\": Surrogate(SaasFullyBayesianSingleTaskGP),` to the `model_kwargs` of `BOTORCH_MODULAR` step is sufficient to enable the SAAS model.\n",
+    "\n",
+    "[1]: [D. Eriksson, M. Jankowiak. High-Dimensional Bayesian Optimization with Sparse Axis-Aligned Subspaces. Proceedings of the Thirty-Seventh Conference on Uncertainty in Artificial Intelligence, 2021.](https://proceedings.mlr.press/v161/eriksson21a.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b53528f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:17.676669Z",
+     "iopub.status.busy": "2026-01-08T16:43:17.676305Z",
+     "iopub.status.idle": "2026-01-08T16:43:17.684172Z",
+     "shell.execute_reply": "2026-01-08T16:43:17.683740Z"
     },
     "papermill": {
-      "default_parameters": {},
-      "duration": 243.894431,
-      "end_time": "2026-01-08T16:47:20.664782",
-      "environment_variables": {},
-      "exception": null,
-      "input_path": "/Users/saitcakmak/botorch/tutorials/saasbo/saasbo.ipynb",
-      "output_path": "/Users/saitcakmak/botorch/tutorials/saasbo/saasbo.ipynb",
-      "parameters": {},
-      "start_time": "2026-01-08T16:43:16.770351",
-      "version": "2.6.0"
-    }
+     "duration": 0.019369,
+     "end_time": "2026-01-08T16:43:17.685182",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:17.665813",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Install dependencies if we are running in colab\n",
+    "import sys\n",
+    "if 'google.colab' in sys.modules:\n",
+    "    %pip install botorch"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "47a9cce7",
+   "metadata": {
+    "code_folding": [],
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:17.701332Z",
+     "iopub.status.busy": "2026-01-08T16:43:17.701182Z",
+     "iopub.status.idle": "2026-01-08T16:43:19.247188Z",
+     "shell.execute_reply": "2026-01-08T16:43:19.246797Z"
+    },
+    "executionStartTime": 1668653404823,
+    "executionStopTime": 1668653404909,
+    "hidden_ranges": [],
+    "originalKey": "26933c08-82d6-439d-9fcb-6e358b080ab6",
+    "papermill": {
+     "duration": 1.555946,
+     "end_time": "2026-01-08T16:43:19.248116",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:17.692170",
+     "status": "completed"
+    },
+    "requestMsgId": "1806f0c7-d668-4248-a390-14add9bcb451",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[KeOps] Warning : There were warnings or errors :\n",
+      "/bin/sh: brew: command not found\n",
+      "\n",
+      "[KeOps] Warning : CUDA libraries not found or could not be loaded; Switching to CPU only.\n",
+      "\n",
+      "[KeOps] Warning : There were warnings or errors :\n",
+      "/bin/sh: brew: command not found\n",
+      "\n",
+      "[KeOps] Warning : OpenMP library not found, it must be downloaded through Homebrew for apple Silicon chips\n",
+      "[KeOps] Warning : OpenMP support is not available. Disabling OpenMP.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "import torch\n",
+    "from torch.quasirandom import SobolEngine\n",
+    "\n",
+    "from botorch.fit import fit_fully_bayesian_model_nuts\n",
+    "from botorch.acquisition.logei import qLogExpectedImprovement\n",
+    "from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP\n",
+    "from botorch.models.transforms import Standardize\n",
+    "from botorch.optim import optimize_acqf\n",
+    "from botorch.test_functions import Branin\n",
+    "\n",
+    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e0e850ae",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:19.293052Z",
+     "iopub.status.busy": "2026-01-08T16:43:19.292759Z",
+     "iopub.status.idle": "2026-01-08T16:43:19.294909Z",
+     "shell.execute_reply": "2026-01-08T16:43:19.294637Z"
+    },
+    "executionStartTime": 1668653405125,
+    "executionStopTime": 1668653405130,
+    "hidden_ranges": [],
+    "originalKey": "f1e3c7f0-1afc-42e2-af59-5f5fae755ce5",
+    "papermill": {
+     "duration": 0.017579,
+     "end_time": "2026-01-08T16:43:19.295618",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.278039",
+     "status": "completed"
+    },
+    "requestMsgId": "068ddee5-939e-4f5b-8210-2f6a490f6c4e",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tkwargs = {\n",
+    "    \"device\": torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\"),\n",
+    "    \"dtype\": torch.double,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d1c2e99",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "08a3d790-52a5-4821-af21-1040f1a037f0",
+    "papermill": {
+     "duration": 0.019641,
+     "end_time": "2026-01-08T16:43:19.325175",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.305534",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "The time to fit the SAAS model can be decreased by lowering\n",
+    "`WARMUP_STEPS` and `NUM_SAMPLES`. \n",
+    "\n",
+    "We recommend using 512 warmup steps and 256 samples when\n",
+    "possible and to not use fewer than 256 warmup steps and 128 samples. By default, we only\n",
+    "keep each 16th sample which with 256 samples results in 32 hyperparameter samples.\n",
+    "\n",
+    "To make this tutorial run faster we use 256 warmup steps and 128 samples. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e833c35e",
+   "metadata": {
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:19.341365Z",
+     "iopub.status.busy": "2026-01-08T16:43:19.341223Z",
+     "iopub.status.idle": "2026-01-08T16:43:19.343141Z",
+     "shell.execute_reply": "2026-01-08T16:43:19.342877Z"
+    },
+    "executionStartTime": 1668653405353,
+    "executionStopTime": 1668653405445,
+    "originalKey": "363224de-347c-46a7-9c84-970cbb8e825d",
+    "papermill": {
+     "duration": 0.010996,
+     "end_time": "2026-01-08T16:43:19.343986",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.332990",
+     "status": "completed"
+    },
+    "requestMsgId": "09e1ff1f-9c11-4053-8123-08aa3397dfc1",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "WARMUP_STEPS = 256 if not SMOKE_TEST else 32\n",
+    "NUM_SAMPLES = 128 if not SMOKE_TEST else 16\n",
+    "THINNING = 16"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53e25989",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "af8beafd-352c-421d-8797-7660ddfa39f3",
+    "papermill": {
+     "duration": 0.007009,
+     "end_time": "2026-01-08T16:43:19.364083",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.357074",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "## Simple model fitting\n",
+    "We generate a simple function that only depends on the first parameter and show that the SAAS\n",
+    "model sets all other lengthscales to large values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "caaadea4",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:19.383405Z",
+     "iopub.status.busy": "2026-01-08T16:43:19.383147Z",
+     "iopub.status.idle": "2026-01-08T16:43:19.385763Z",
+     "shell.execute_reply": "2026-01-08T16:43:19.385412Z"
+    },
+    "executionStartTime": 1668653405681,
+    "executionStopTime": 1668653405771,
+    "hidden_ranges": [],
+    "originalKey": "f506aa6b-904c-4a7e-8a38-0443e983df06",
+    "papermill": {
+     "duration": 0.011204,
+     "end_time": "2026-01-08T16:43:19.386592",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.375388",
+     "status": "completed"
+    },
+    "requestMsgId": "a6b6bfcd-c30c-4339-a342-02dd398a8274",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_X = torch.rand(10, 4, **tkwargs)\n",
+    "test_X = torch.rand(5, 4, **tkwargs)\n",
+    "train_Y = torch.sin(train_X[:, :1])\n",
+    "test_Y = torch.sin(test_X[:, :1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "330044d3",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "cc9314b1-f255-4f7d-9f6d-eb349b34805e",
+    "papermill": {
+     "duration": 0.007496,
+     "end_time": "2026-01-08T16:43:19.401389",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.393893",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "By default, we infer the unknown noise variance in the data. You can also pass in a known \n",
+    "noise variance (`train_Yvar`) for each observation, which may be useful in cases where you for example\n",
+    "know that the problem is noise-free and can then set the noise variance to a small value such as `1e-6`.\n",
+    "\n",
+    "In this case you can construct a model as follows:\n",
+    "```\n",
+    "gp = SaasFullyBayesianSingleTaskGP(train_X=train_X, train_Y=train_Y, train_Yvar=torch.full_like(train_Y, 1e-6))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db012225",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:19.416322Z",
+     "iopub.status.busy": "2026-01-08T16:43:19.416072Z",
+     "iopub.status.idle": "2026-01-08T16:43:25.616161Z",
+     "shell.execute_reply": "2026-01-08T16:43:25.615854Z"
+    },
+    "executionStartTime": 1668653406085,
+    "executionStopTime": 1668653471282,
+    "hidden_ranges": [],
+    "originalKey": "148855fb-cf0c-4fc5-8431-06a5e61c5da5",
+    "papermill": {
+     "duration": 6.2083,
+     "end_time": "2026-01-08T16:43:25.617083",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:19.408783",
+     "status": "completed"
+    },
+    "requestMsgId": "0c13f0b6-28b9-43ea-8d1b-00871e5e4f02",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gp = SaasFullyBayesianSingleTaskGP(\n",
+    "    train_X=train_X,\n",
+    "    train_Y=train_Y,\n",
+    "    outcome_transform=Standardize(m=1)\n",
+    ")\n",
+    "fit_fully_bayesian_model_nuts(\n",
+    "    gp,\n",
+    "    warmup_steps=WARMUP_STEPS,\n",
+    "    num_samples=NUM_SAMPLES,\n",
+    "    thinning=THINNING,\n",
+    "    disable_progbar=True,\n",
+    ")\n",
+    "with torch.no_grad():\n",
+    "    posterior = gp.posterior(test_X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58028f75",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "5f4fa168-2662-499b-ac82-3ab122dfe2ad",
+    "papermill": {
+     "duration": 0.016223,
+     "end_time": "2026-01-08T16:43:25.652051",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.635828",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "Computing the median lengthscales over the MCMC dimensions makes it clear that the first feature has the smallest lengthscale\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b8e7237c",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:25.678544Z",
+     "iopub.status.busy": "2026-01-08T16:43:25.678235Z",
+     "iopub.status.idle": "2026-01-08T16:43:25.681636Z",
+     "shell.execute_reply": "2026-01-08T16:43:25.681375Z"
+    },
+    "executionStartTime": 1668653471605,
+    "executionStopTime": 1668653471693,
+    "hidden_ranges": [],
+    "originalKey": "44a1f7c0-9649-4d89-8226-0405fdf88518",
+    "papermill": {
+     "duration": 0.015169,
+     "end_time": "2026-01-08T16:43:25.682451",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.667282",
+     "status": "completed"
+    },
+    "requestMsgId": "e815926b-5a2d-4b78-8b89-3c0720e45592",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([ 3.1031, 20.1120, 29.0710, 19.8204], dtype=torch.float64)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(gp.median_lengthscale.detach())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "372b0c45",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "cf15a6ca-3377-40d1-9821-fad8f6600657",
+    "papermill": {
+     "duration": 0.010072,
+     "end_time": "2026-01-08T16:43:25.702269",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.692197",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "### Make predictions with the model\n",
+    "\n",
+    "In the next cell we show how to make predictions with the SAAS model. You compute the mean\n",
+    "and variance for test points just like for any other BoTorch posteriors. Note that the mean \n",
+    "and posterior will have an extra batch dimension at -3 that corresponds to the number of MCMC\n",
+    "samples (which is 8 in this tutorial)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a43c31c2",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:25.744423Z",
+     "iopub.status.busy": "2026-01-08T16:43:25.744262Z",
+     "iopub.status.idle": "2026-01-08T16:43:25.746777Z",
+     "shell.execute_reply": "2026-01-08T16:43:25.746483Z"
+    },
+    "executionStartTime": 1668653471916,
+    "executionStopTime": 1668653472023,
+    "hidden_ranges": [],
+    "originalKey": "898039a4-6ec8-46bd-a583-5a1614a3ccf6",
+    "papermill": {
+     "duration": 0.036982,
+     "end_time": "2026-01-08T16:43:25.747574",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.710592",
+     "status": "completed"
+    },
+    "requestMsgId": "4328636f-fb02-44ee-8c48-842c3845297f",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([8, 5, 1])\n",
+      "torch.Size([8, 5, 1])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(posterior.mean.shape)\n",
+    "print(posterior.variance.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f02bb5df",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "02b33f7f-4f31-432a-bac7-8cad1831e9a1",
+    "papermill": {
+     "duration": 0.007008,
+     "end_time": "2026-01-08T16:43:25.761952",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.754944",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "We also provide several convenience methods for computing different statistics over the MCMC samples:\n",
+    "```\n",
+    "mixture_mean = posterior.mixture_mean\n",
+    "mixture_variance = posterior.mixture_variance\n",
+    "mixture_quantile = posterior.quantile(q=0.95)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cb484111",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:25.778844Z",
+     "iopub.status.busy": "2026-01-08T16:43:25.778674Z",
+     "iopub.status.idle": "2026-01-08T16:43:25.781693Z",
+     "shell.execute_reply": "2026-01-08T16:43:25.781341Z"
+    },
+    "executionStartTime": 1668653472240,
+    "executionStopTime": 1668653472326,
+    "hidden_ranges": [],
+    "originalKey": "b387d057-a497-401b-bfc2-ab427669c451",
+    "papermill": {
+     "duration": 0.013012,
+     "end_time": "2026-01-08T16:43:25.782426",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.769414",
+     "status": "completed"
+    },
+    "requestMsgId": "64e0ee73-6ffd-4ad5-b9b2-bd9ea4e637ee",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ground truth:     tensor([0.7361, 0.1658, 0.2783, 0.4090, 0.7812], dtype=torch.float64)\n",
+      "Mixture mean:     tensor([0.7358, 0.1632, 0.2735, 0.4077, 0.7820], dtype=torch.float64)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Ground truth:     {test_Y.squeeze(-1)}\")\n",
+    "print(f\"Mixture mean:     {posterior.mixture_mean.squeeze(-1)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "733aa578",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "executionStartTime": 1644277314184,
+    "executionStopTime": 1644277314189,
+    "hidden_ranges": [],
+    "originalKey": "d9bec8be-2acd-40b8-aebb-612b62bbdfc3",
+    "papermill": {
+     "duration": 0.007506,
+     "end_time": "2026-01-08T16:43:25.798670",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.791164",
+     "status": "completed"
+    },
+    "requestMsgId": "d9bec8be-2acd-40b8-aebb-612b62bbdfc3",
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "## Optimize Branin embedded in a 30D space\n",
+    "We take the standard 2D Branin problem and embed it in a 30D space. In particular,\n",
+    "we let dimensions 0 and 1 correspond to the true dimensions. We will show that\n",
+    "SAASBO is able to identify the important dimensions and efficiently optimize this function.\n",
+    "We work with the domain $[0, 1]^d$ and unnormalize the inputs to the true domain of Branin \n",
+    "before evaluating the function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e4697bdc",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:25.815096Z",
+     "iopub.status.busy": "2026-01-08T16:43:25.814920Z",
+     "iopub.status.idle": "2026-01-08T16:43:25.817451Z",
+     "shell.execute_reply": "2026-01-08T16:43:25.817083Z"
+    },
+    "executionStartTime": 1668653472540,
+    "executionStopTime": 1668653472545,
+    "hidden_ranges": [],
+    "originalKey": "15baa08e-ca35-4da7-a495-c63fe5d5779d",
+    "papermill": {
+     "duration": 0.011102,
+     "end_time": "2026-01-08T16:43:25.818236",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.807134",
+     "status": "completed"
+    },
+    "requestMsgId": "6c3f8d91-9139-4c07-986f-77629b1887e5",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "branin = Branin().to(**tkwargs)\n",
+    "\n",
+    "\n",
+    "def branin_emb(x):\n",
+    "    \"\"\"x is assumed to be in [0, 1]^d\"\"\"\n",
+    "    lb, ub = branin.bounds\n",
+    "    return branin(lb + (ub - lb) * x[..., :2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4ae7ff47",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:25.834019Z",
+     "iopub.status.busy": "2026-01-08T16:43:25.833873Z",
+     "iopub.status.idle": "2026-01-08T16:43:25.836125Z",
+     "shell.execute_reply": "2026-01-08T16:43:25.835809Z"
+    },
+    "executionStartTime": 1668653472768,
+    "executionStopTime": 1668653472776,
+    "hidden_ranges": [],
+    "originalKey": "98b6936b-2f06-4d1f-82c0-2f1bd660d0b2",
+    "papermill": {
+     "duration": 0.01027,
+     "end_time": "2026-01-08T16:43:25.836830",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.826560",
+     "status": "completed"
+    },
+    "requestMsgId": "1b5baaf2-e690-4b4d-9011-b6124e083410",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using a total of 50 function evaluations\n"
+     ]
+    }
+   ],
+   "source": [
+    "DIM = 30 if not SMOKE_TEST else 2\n",
+    "\n",
+    "# Evaluation budget\n",
+    "N_INIT = 10\n",
+    "N_ITERATIONS = 8 if not SMOKE_TEST else 1\n",
+    "BATCH_SIZE = 5 if not SMOKE_TEST else 1\n",
+    "print(f\"Using a total of {N_INIT + BATCH_SIZE * N_ITERATIONS} function evaluations\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ac5211a",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "27fd793f-18ee-49cb-9aa5-c8cd78b0b807",
+    "papermill": {
+     "duration": 0.007282,
+     "end_time": "2026-01-08T16:43:25.851396",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.844114",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "### Run the optimization\n",
+    "We use 10 initial Sobol points followed by 8 iterations of BO using a batch size of 5, \n",
+    "which results in a total of 50 function evaluations. As our goal is to minimize Branin, we flip\n",
+    "the sign of the function values before fitting the SAAS model as the BoTorch acquisition\n",
+    "functions assume maximization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "eefbc014",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:43:25.866031Z",
+     "iopub.status.busy": "2026-01-08T16:43:25.865875Z",
+     "iopub.status.idle": "2026-01-08T16:46:54.574548Z",
+     "shell.execute_reply": "2026-01-08T16:46:54.574269Z"
+    },
+    "executionStartTime": 1668653473096,
+    "executionStopTime": 1668655621405,
+    "hidden_ranges": [],
+    "originalKey": "269287e0-500f-474d-891a-5439487e9a77",
+    "papermill": {
+     "duration": 208.7194,
+     "end_time": "2026-01-08T16:46:54.577665",
+     "exception": false,
+     "start_time": "2026-01-08T16:43:25.858265",
+     "status": "completed"
+    },
+    "requestMsgId": "5117b535-1fe7-40be-9f68-361db9d9b51b",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best initial point: 5.322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3) New best: 3.360 @ [1.000, 0.121]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4) New best: 1.432 @ [0.517, 0.211]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5) New best: 0.620 @ [0.556, 0.153]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6) New best: 0.492 @ [0.539, 0.173]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7) New best: 0.427 @ [0.542, 0.163]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8) New best: 0.398 @ [0.543, 0.151]\n"
+     ]
+    }
+   ],
+   "source": [
+    "X = SobolEngine(dimension=DIM, scramble=True, seed=0).draw(N_INIT).to(**tkwargs)\n",
+    "Y = branin_emb(X).unsqueeze(-1)\n",
+    "print(f\"Best initial point: {Y.min().item():.3f}\")\n",
+    "\n",
+    "for i in range(N_ITERATIONS):\n",
+    "    train_Y = -1 * Y  # Flip the sign since we want to minimize f(x)\n",
+    "    gp = SaasFullyBayesianSingleTaskGP(\n",
+    "        train_X=X,\n",
+    "        train_Y=train_Y,\n",
+    "        train_Yvar=torch.full_like(train_Y, 1e-6),\n",
+    "        outcome_transform=Standardize(m=1),\n",
+    "    )\n",
+    "    fit_fully_bayesian_model_nuts(\n",
+    "        gp,\n",
+    "        warmup_steps=WARMUP_STEPS,\n",
+    "        num_samples=NUM_SAMPLES,\n",
+    "        thinning=THINNING,\n",
+    "        disable_progbar=True,\n",
+    "    )\n",
+    "\n",
+    "    EI = qLogExpectedImprovement(model=gp, best_f=train_Y.max())\n",
+    "    candidates, acq_values = optimize_acqf(\n",
+    "        EI,\n",
+    "        bounds=torch.cat((torch.zeros(1, DIM), torch.ones(1, DIM))).to(**tkwargs),\n",
+    "        q=BATCH_SIZE,\n",
+    "        num_restarts=10,\n",
+    "        raw_samples=1024,\n",
+    "    )\n",
+    "\n",
+    "    Y_next = torch.cat([branin_emb(x).unsqueeze(-1) for x in candidates]).unsqueeze(-1)\n",
+    "    if Y_next.min() < Y.min():\n",
+    "        ind_best = Y_next.argmin()\n",
+    "        x0, x1 = candidates[ind_best, :2].tolist()\n",
+    "        print(\n",
+    "            f\"{i + 1}) New best: {Y_next[ind_best].item():.3f} @ \"\n",
+    "            f\"[{x0:.3f}, {x1:.3f}]\"\n",
+    "        )\n",
+    "    X = torch.cat((X, candidates))\n",
+    "    Y = torch.cat((Y, Y_next))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93db4c3b",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "a9704a99-0712-40bb-a263-6798e0925291",
+    "papermill": {
+     "duration": 0.015334,
+     "end_time": "2026-01-08T16:46:54.615678",
+     "exception": false,
+     "start_time": "2026-01-08T16:46:54.600344",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "## Plot the results\n",
+    "\n",
+    "We can see that we were able to get close to the global optimium of $\\approx 0.398$ after 50 function evaluations.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0f045f2f",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:46:54.640940Z",
+     "iopub.status.busy": "2026-01-08T16:46:54.640666Z",
+     "iopub.status.idle": "2026-01-08T16:46:54.972304Z",
+     "shell.execute_reply": "2026-01-08T16:46:54.971992Z"
+    },
+    "executionStartTime": 1668655621761,
+    "executionStopTime": 1668655621936,
+    "hidden_ranges": [],
+    "originalKey": "fd0d7aa7-8d55-4942-adc2-de356666ac84",
+    "papermill": {
+     "duration": 0.345164,
+     "end_time": "2026-01-08T16:46:54.973795",
+     "exception": false,
+     "start_time": "2026-01-08T16:46:54.628631",
+     "status": "completed"
+    },
+    "requestMsgId": "4024717d-fc5c-4939-90ce-fb24b3e06ea3",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAI5CAYAAABDx+koAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe5RJREFUeJzt3QeUU9XWwPE9HYbeOwgiVQUUUVGaCAiIgqgoqKBYECyI/akUn9337AVFBRWRpiCKKIgUUUBAUBRFRJr0OnRmmMm39pl382Vm0mZSb/L/rXVJSG5uTnKSzM7JPvskOBwOhwAAAAAxKjHSDQAAAABCiYAXAAAAMY2AFwAAADGNgBcAAAAxjYAXAAAAMY2AFwAAADGNgBcAAAAxjYAXAAAAMY2AFwAAADGNgBcAimjjxo2SkJBgtnHjxkW6OQAADwh4ARTJ/PnzncGeu61kyZLSoEEDuf766+Xbb7+NdHMhIqeccorHvqpRo4Y0a9ZMbrjhBnn11Vdl69atEit27dol77//vtxxxx3SunVrqVu3rpQqVUrS0tKkWrVq0qVLF3nzzTflyJEjfh9z1qxZ0qtXL6lZs6Y5jp7q//VyANEnweFwOCLdCAD2DHg7dOjg9/4aSL333nuSlJQksTTCq8GTGjt2rAwYMECiPeDdtGmTX/tqP1122WXywgsvmNvZ2TvvvCO33HKLz/3q1Kkjn3zyiZx99tke98nJyZFbb71V3n33XY/73HzzzfLWW29JYiJjSkC0SI50AwDY3+233y6DBw92/l+/R+/bt08WL14sL774ohlh++CDD6RWrVryxBNPSKzQQNCOYwbVq1eXr7/+2vn/rKws2b9/vwmGf/jhB5kyZYpkZGTItGnTZO7cuTJ+/Hjp0aOH2JWOYp922mnSvn17adGihRnN1pHd48ePm8esj0+fDz3fqVMn+fXXX81z5M4jjzziDHb1WA888ICceuqpsn79ennuuedk5cqVJsCuVKmSPPXUU2F+pAA80hFeACisefPmaaRnthEjRnjc77fffnMUK1bM7FeqVCnHiRMnwtpO/L86deqYftBTbw4dOuQYNmyYs3+LFy/uWLZsmcOusrKyfO7z4osvOh/vPffc43aftWvXOpKTk80+LVu2dBw9ejTP9UeOHDGX6/W637p164L2GAAEht9bAIRUkyZNpHv37ub8oUOH5I8//oh0k+CD5vT+97//lWeeecb8/9ixY+ZnertKTvb9Y6bm9+rjVt99953bfV566SU5efKkOa95zsWLF89zfXp6urlc6X766waA6EDACyDkrDxXdeLEiQLXa4UDawKV5sXqPhpcnHfeeVKxYkVz+ciRI537Z2Zmyueff26ClHPOOUfKlSsnKSkpUqFCBTn33HPNvnv27PFrApeVd7t27VqT56mX6ySkKlWqmElIS5YsKXKVBm2Hdb3Sn9Cff/55Oeuss8ykKd1atWolr732mjOQiib6c70+n+rnn3+WL7/8UmKVBsXFihVz9lN+mrry2WefmfONGjUyr0139PKGDRua87q/HVNegFhEDi+AkHOdKFW7dm2v+2qgqoHmqlWrPO6jk4Z01n1+mjf8448/mk2DSA04LrjgAp/t01zV6667To4ePeq8TPOOp0+fbgLrjz76SPr06SOB2Llzp1xyySUFHteyZcvMNnv2bHN/0TTRSQP1u+++W/r27Wv+r+3r1q2bxCLNVba+JGlAm9+GDRtk27Zt5ny7du28Hkuv1y9QWunCdWIjgMiJnk9WADFJUxi++OIL5+iXjpx6M3DgQDOaqFUdZs6cKStWrDABqTXSqHQ0tF69enLvvffKpEmTzOQ4DRqnTp0qgwYNktTUVNm7d68JnDVw9Wb16tUmoNN2aZCsI7p6PB2d1RG/7OxsE2Dv3r07oOfhiiuukDVr1shdd90lc+bMMY9rwoQJ0rhxY3O9BtZjxoyRaHPxxRc7z3v6qd+uNMVG+0T7Wl8rFg3y89P9LO4CYleu1//+++9Bay+AAASYAwwgTrlOWrv99tsdq1evdm6//PKLY+HChY5nn33WUbVqVbNPmTJlHIsXL3Z7rLFjxzqPpds777zj9b7/+usvR05Ojsfr9f5LlixpjvXoo496ncCl29lnn+3IyMgosM/48eOd+7zwwgsFrt+wYYPzen0M+elkPuv6lJQU85zlt3fvXkeVKlXMPmeeeaYjGiat5VezZk3nRKyiyN+/Rd2CwbVP8m9JSUmO1157ze3t3nzzTed+U6ZM8Xofer217+jRo4PSbgCBYYQXQMC0aP8ZZ5zh3M4880xp27atPPjgg2aEVUddNc3AU96jq4suusiM8nqjZaCsvFh3tA3WJCv9Gd4XrQ9cunTpApfryK9VnirQ0c0777zTlMXKr3z58nLjjTc6R5u1HFi00dxoa2T94MGDEos6duxoypENGTLE42iwxZrc5kmJEiWc5w8fPhzEVgIoKnJ4AYSUFuqfOHGiSQ/QWf86Icybfv36Ffo+tIas5u/qZCNrklDZsmWdP0VrnVmd1OaOFaC7o0G11lrV3M2///5bAuHtcVkLHWjbNVe0efPmEk1cAzwN/Nx9OfCmZ8+e0rJlS4kGWi/6yiuvNOd1ZTVNOdAa0ZrDq3nab7/9dp70GYvrRDZNmfHG9TWuFS4ARB4BL4CAjRgxIk8VBesP/V9//SUffvihKc+kVReWL19uCvxr+SZPPAWf+eloqB5Xl3LdsWOH14BbA+LKlSu7vd5XPqaOwOYf4SsKb/dj3Ucw7icUXNtU2GDX+vJhfQGJNH0duL4WNLjVSh1PPvmkPProo2YUXic7du7cOc/trAoOVpUQb1wrkeQvXQYgMkhpABAS+odeR0919ak33njDXLZo0SKfq09piTFfdKUrLe2ly/l6C3b9GWXzFnwrq2qCTl4LhLf7ca3MEOj9hIJVvUBLd2kptVikK6hpiTgdydXydPnLxLk+bl9pCjpy7G/6A4DwYIQXQMhpTu5DDz1k0g40X9bb8sJJSUk+qz5oTrAGJDpSd//995u8X62fq0GJlbqg92PlAlMLteg0B9sqx2XVly2sAwcOyD///BNwW04//XQJpcsvv9zkmm/evNmctm7d2nldzZo1ned9PZYtW7Y4z+ty2gAij4AXQMjpCOZpp50mS5cule3bt5uSYdZEqMLSBR402NXAeMGCBR5TBTS4RuC0hJrlwgsvLNIxdOKgNTEvEKH+4lKpUqU8taNdA15dMdDia7VA1+utsnMAIouUBgBh4foTcSCriv3222/mtFmzZl7zYjVfGIEHmK+88orz/661amORLhThKRVBF4+wKnboFy1vFi5caE5r1KhhfnkAEHkEvABCTlcwswr3a26vLhdcVFaw7JonmZ+OIs+YMaPI94Fczz77rPlpX2nOdJcuXYp0HJ0UpsFzoFso6eTGTz75xPl/zT/PX7FDUx6sEVxPS07r5dYIr+7vrXwegPAh4AUQclrBwZo4pkGTrzxdbzQ1Qq1bt05++OEHt8G11s+NpXJQujytBk66uavlG2w6Keu+++6Thx9+2Dnh7p133hG70hXsvE0G1GBXV+3TOryqTZs2bkdmhw4d6nztal3l/K8x/b9ebk3w0/0BRAdyeAEEZWKTFSxYdLa7BqVa4/Srr75ylnZ6/PHHA7qv66+/Xl599VUTpHTv3t1MWtPcUj22Lterpcr0fi+44AL5/vvvA7qvWKV1iV37S/+vE8s0sNYvEbpEs/5flSlTRj766CNTj9iudGnoUaNGmfq7uvhJnTp1TBCv5epWrlxp8sJ/+eUXZ9m1119/3e1xGjRoYF5vWk9aU2b0NaaLq+hCKOvXrzcj4no8pftZX84ARB4BL4CgrLSmm68JQePHjy/wU3FhnXPOOSZ40dq/GpRpOan8dLROZ/THSsDrOpJY1Ml+rrTqgq9+0BHKyy67TF544QUTIMZCfu7LL79sNk90gpmv16jW69UveFoFRIPba665psA+Wh3EWyUSAOFHwAsgJHQ1Kl1QoWnTptKtWzczS9+fGrv+GD58uFm5S4OXZcuWmXxeLVGmdVS1ZFmnTp3MqF2sWLx4sfP8PffcE/Tj62injuRqbrVOBtTnsXfv3s5JWnanI/+6QInm1+pKdjt37jRflvRx62PU/GSdkKc5t55W5HOtOKJ1oPX50VXZ9PWndYr1udMvY7fddpt07do1bI8NgH8SHBSoBICoppO+3n//fenQoYN8++23kW4OANgOk9YAIMpZZbB0ZBsAUHiM8AJAFNNVvXS1Lq0cYNV3BQAUDgEvAAAAYpotUxq0nuJjjz1mVr7RIvZaEubf//53yAuTAwAAwH5sWaVBax1qCSSdxKEzwLUeos4A11nGd911V6SbBwAAgChiy5SGSy+9VKpUqWJKw1i0RIyO9moNRQAAAMDWI7ytW7c29Q///PNPs/LNzz//LIsWLTIF0t05ceKE2Sy6QtO+fftMAXfWOQcAAIg+OiZ76NAhUy9ba2DHXcD70EMPycGDB6VRo0ZmXXPN6dXVb/r16+d2/6efftqszAQAAAB72bJli9SsWTP+UhomTpxo1il//vnnTQ7vqlWrZOjQoWaEt3///j5HeDMyMqR27dpmhFhXgvLmiScS5aWXkuTWW7PlqadyQvJ4EFpZWVkyb948U7Tf1ypKsD/6O77Q3/GF/o4v+/btM7/k68qIOk8r7kZ4NdjVUV5rDXNd93zTpk1mJNddwJuWlma2/DTY9bUufcmSuaepqbqGfbAeAcL9AalLiGpf8wEZ++jv+EJ/xxf6Oz4lBCH91JZlyY4ePVogl0NTGzQ3N9is5zgEhwYAAEAY2HKEt0ePHiZnV9MSNKVh5cqVJp3hpptuCvp9WXG1/RI/AAAAYNuA99VXXzULTwwePFh27dplZu/ddtttIVln3gp4GeEFAACwJ1sGvKVKlZKXXnrJbKFGwAsAAGBvtszhDSdyeAEAAOyNgNcHcngBAADsjYDXB1IaAAAA7I2A1wdSGgAAAOzNlpPWwomUBgAoGl3IUxcKCEWNdIsePzk5WY4fP26WmUdso7/tJzEx0SwSEozFIwJBwOsDKQ0AUDgaiOzZs0cOHTpkApRQB9VVq1aVLVu2RPwPKkKP/ranlJQUU2GrYsWKZqGwSCDg9YGAFwAKF+xqMHLixAkpU6aMlCxZ0vyBC1VwoqPHhw8fNveTfwVOxB76235fULKzs02fHThwQI4dOya1atWKSNBLwOsDObwA4D8d2dVgV1fCLF68eFgCoMzMTClWrBgBUBygv+2pZMmS5gvw5s2bzWdElSpVwt4GXi0+kMMLAP6P5mgag/5hC0ewC8A+ihcvLqVLlzafEfpZEW4EvD6Q0gAA/tF8Xd10NAcA8tM8XutzItwIeH0g4AUA/1jVGCI1KQVAdEv632dDKCu3eELA62cOLykNAOAfZs8DiLbPBgJeHxjhBQAAsDcCXh8IeAEAAOyNgNcHypIBAADYGwGvD5QlAwAAsDcCXh9IaQAAALA3Al4fCHgBAJGgxfmnTJkivXr1kjp16pjC/Vrj+NRTT5ULL7xQhg0bJtOmTZODBw/6PFafPn3MDHndHnnkkSK36dxzz3UeZ8yYMX7fbs2aNXLXXXdJs2bNzMIkqampUr16dWnRooX069dPRo8eLX/++WeB282fP995f7ppWaty5cqZ07S0NKlZs6ZceumlMnHiRL8WMzh+/Li89dZb5jbWaoDansaNG8utt94q8+bNK/RzAptwxKGMjAx9Vzj27Nnjc98PP9R3kMPRqVNYmoYQyMzMdEyfPt2cIvbR35Fz7Ngxx5o1a8xpuGRnZzv2799vTmOJPqZ27dqZv1XWlpyc7Chfvrw5db187NixXo+lf+tSU1Od+9eoUcNx8uTJQrdp9erVee73vPPO8+t2zz33XIE2ly1b1lG8ePE8l+njzW/evHnO68uVK+eoUqWKo3LlyubU9THp1qVLF8fx48c9tmP27NmOmjVr5rlN6dKlHWlpaXku69q1q1/xAUL/GaH9oH2icVugGOH1gRFeAEC43XDDDbJgwQIzknnvvfea0c8TJ07I3r175dixY/Lzzz/Ls88+a0ZMfRk/frxkZmZKt27dzOjw1q1b5euvvy50m959911zOmDAALNi1pIlS8zIrTeffvqpPPDAA3Ly5Elp27atzJ4927R///79cvToUfnnn3/k448/liuvvNKM+vo61rZt22Tt2rXmVEdr161bJ3379jXX62N64YUX3N520qRJ5vHr/dWoUUPeeecd2bdvn2RkZJjj/P777zJ06FBJTk6WWbNmyXnnnSe7du0q9HOEKOaIQ4UZ4f3449wR3g4dwtI0hAAjfvGF/o4cRniD488//3SONj799NM+9z969KjX68844wxzrIkTJzpGjhxpzl9xxRWFatOJEyccFStWNLddsmSJY8CAAeb8sGHDvN6udevWZr/TTz/dkZWVVejH4TrCq+fd9beOVjdo0MDs06pVqwLH0Ndkenq6uV6fi127dnlsw8yZM50jxx07dvTaXhQeI7xRjLJkAIBwWrVqlfP85Zdf7nN/zUP1ZNmyZbJ69WqTp6rH0pFjzYX9/PPPZffu3X636bPPPpM9e/ZIw4YNTR5v//79naPHWVlZPh+Ljq7q6GlRH4c3Ogp+xhlnmPOHDx8ucP2jjz5qRpM151dzoitVquTxWNpO3V/NnTtXZs6cWaQ2IfoQ8PpAWTIAQKToT/CBsNIQrr76ailWrJjUrVtX2rRpY4LUDz/8sNDH0YBZtWvXzkyk05/9NXgO9ePwJicnR3799VdzXgNyV9u3b5fp06eb89dee22B69255557TMqGev3110PSZoQfAa8P5PACQPDo4MGRI7G1BXtA5JxzzjGjsMrK3y0KHdXU/FjXQFVZo7PvvfeeX8fZsmWLzJkzx7TpuuuuM5fpeeuYVjDsTqtWrczp5MmTZcKECSY4Daa///7b5BRrXq+O9Gqwmr/Kg3WfvXv39uuYWgmjc+fO5vx3331n8o9hfwS8PhDwAkDwHD2qAUXwttKlE6VmzbLmNJjHLcymjymYTjnlFLn55pvNeU1HaNSokZx11lkyZMgQE6TqaKY/JbimTp1qSpZZZcwsV111lUkf+O2332Tp0qU+jzN27FgTNHbo0MGU8rJYAa9OFtNJZO6MHDnSpDJo0Kjlx3TCmJZIe/75500JsCP6jcFPV1xxhSllpqO0eqoj1vrYNJDWAPWbb74xo9eu9DFatASav5o3b+5Mkdi0aZPft0P0IuD1M4eXlAYAQLi88cYb8thjj0mJEiVMcLty5Upz2cCBA02+atWqVU0d3p07d3o8hjXyev311+e5XH+u19q+rvt4ovetAW/+UWJVv359ad26tWRnZ8u4cePc3l5TH7766itnKsGOHTvMaK9WbrjoootMTd3u3bvLwoULfT4nWtlBH6+mUeipVq1Qev9acUGrT+SnVS0sFSpUEH9VrFjR7TFgXwS8PjDCCwDBk56uo2bB2w4ezJF//jlgToN53MJs+piCTUdFH3/8cRPEaa6tjvhqCTKrdJcGfS+++KKcfvrp8uOPPxa4/V9//WV+jtfUg/wBr2tagy7YoKkPnnz77beyceNGE3i7SwmwjmMFxe507NjRlC/T9IKHH37YBLrly5c312ku8ZdffmkC4+HDh3t9TnREWINbDXz1VG+rKQ3PPPOMGfXWdIuHHnrI6zEQvwh4fSDgBYDg/mpWokRsbdYvgaGg1RU0kNNVzbTigdaN1XzaHj16mOu1coIGolpL1pWmPujo7AUXXCD16tUrcNyLL77YpBccOnTIVC7wxBoB1hFhzW3Nz5oMpwG21g32JDEx0QS1Tz31lKl+oKOmWvtWg1wNptW///1v+eKLLwr1pUAn4T344IPy3HPPmcu0NrFrO1xHdQszUqvPq7tjwL4IeH0g4AUARAsNLjVYnTFjhnN0VSsgaNqARUc/33//fXN+0aJFeZbmdV2i10oB8JTWoCOpunSxVX7M3XE0JcEKtn2lR+SnucmjRo0yj8WapKcLQhSFpnpYx7Am6qkmTZo4z//0009+H09TSJQG+VqNAvZHwOsDObwAgGh06623Os9rlQKLrhTmaRKZO5r6oCuW5ffRRx8VGDn2Z5JcYWmKg+YD538chZGenu7Mu92wYYPzcp1op6PL6pNPPvHrWDpRTUfRlU6C81U/GPZAwOsDI7wAgGjkmmKgiyq4S0PQlAVvm1Z/8FSizDrO3Xff7fUYmmahiznoksGuo6tFeSyuj6MwNDC3UhasFAlVrVo15+Idmq/sT0CtudH6uNTgwYOL1B5EHwJeHwh4AQDhpCOU/tTetdIWlBW4avUCKw9Wy39pIOlt0xJl1rE0FcL1539rlTRdsMHbMUqXLm1KhrlLa5g9e7bPEmo///yz2VwfR2FpMGvV223ZsmWe6zQ3WMuwaVUHfbyu+bn56ej4E0884Rwd1goSiA0EvD6Q0gAACCetHdu4cWMTbH3wwQemSoJFKxNofumNN94oL7zwgnNxB6vOru6vNW81wLv00kt93pdOOrNWJNNqCRYrcNX8VV1K2N/j6FLG1qpnqm/fviZXV4NOvS4zM9N5nZYo09FUzUnWYFVTB3Q0uTC0jq8G69btNPjWfF5XTZs2NbnBmresdY21Hq+OaB84cMC5j37B0DJvl112mWmjTvTT+r5WXjBigCMOZWRkaPjq2LNnj899587VUNfhaNo0LE1DCGRmZjqmT59uThH76O/IOXbsmGPNmjXmNFyys7Md+/fvN6ex4quvvjJ/o1y31NRUR/ny5R0JCQl5Lj/rrLMcW7dudd62UaNG5vLevXv7fX96DL1Nz549zf+1/8qWLWsuu/fee/06xsmTJx2VK1c2txk6dKjz8qpVq+Zpb2JioqNcuXKOtLS0PJeXKlXKMWXKlALHnTdvnnMfvV2VKlXM/ehphQoVzPGs6/X50f09mTVrlqN69ep57rdMmTKOYsWK5bmsc+fOjl27dvn9/CF0nxEap2mfaNwWKDKxfSClAQAQTl26dDGTyHTEVass6IipVmLQEUmdnKWrjOkopaYR6E/01qSs77//Xv744488I67+0H01hUFTITQlQlcss0Y//T2Ojp5qe0aPHm0qOmh5MK0ZrCOnuhKb1tDV+1i/fr2p/qBtrlKlihnJ7tSpkxmV1f97o7fLf59atk1HkLt27SqDBg0yucSeXHLJJaZ8mi6SoY9V0yg0vUHbqSvI6QQ1Td/QusGIPQka9Uqc0Vmk+ibRF7qv+nq6+Eu7diK6SMz/PkdgM1Zh827duklKSkqkm4MQo78jRycOaf6p1kbV8lnhoD+F62e6/pRtBX6IXfR3fH1G7N2711Tf0ImR2ueB4NXiAzm8AAAA9kbA6wMpDQAAAPZGwOsDAS8AAIC9EfD6QEoDAACAvRHw+sAILwAAgL0R8PpAwAsAAGBvBLw+EPACAADYGwGvD+TwAgAA2BsBrw+M8AIAANgbAa8PBLwAAAD2RsDrZ8BLSgMAAIA92TLgPeWUUyQhIaHANmTIkJDl8DLCCwAAYE/JYkPLli2T7Oxs5/9//fVX6dSpk1x11VVBvy9SGgAAAOzNlgFvpUqV8vz/mWeekVNPPVXatWvndv8TJ06YzXLw4EFzmpWVZTZvcuPqFMnJcUhW1slgNB9hZvWxr75GbKC/I0efc4fDITk5OWYLB70/6zRc94nIob/tLScnx/SdflYkJSX53D+Yn+O2DHhdZWZmyvjx42XYsGEmrcGdp59+WkaNGlXg8nnz5kl6errX42/bVkJELjbB7pdffhm0diP85syZE+kmIIzo7/BLTk6WqlWryuHDh81nczgdOnQorPeHyKK/7SkzM1OOHTsmCxculJMnfQ8iHj16NGj3neCwvi7Z1OTJk6Vv376yefNmqV69ut8jvLVq1ZLt27dLhQoVvB5//XqRxo1TpGRJh+zbxwivHek3RA1+NO0lJSUl0s1BiNHfkXP8+HHZsmWLmWdRrFixsNyn/gnT4KdUqVIeBz0QO+hv+39GbNy40cRg/nxG7N27V6pVqyYZGRlSunTp+B7hfffdd6Vr164eg12VlpZmtvz0j6GvP4jWzXJyEvjjaXP+9DdiB/0dfjq3QoOQxMREs4WD9bO2db+InHHjxsmNN94oderUMUGNnfq7ffv2smDBAhkxYoSMHDlS7MCObU5MTDR95+/nczA/w20d8G7atEm++eYb+fTTT0N2H5QlAwBEelTs/fffl88//1x++eUX2b17t6SmppqBnjZt2si1114rHTp0CNn9a/CqwayyS2AFxFTAO3bsWKlcubJ07949ZPdBWTIAQKRoes5NN90k//zzj/My/WlX0/T++OMPs40ZM8b80vnhhx/6TNMrasBrzYPxFvCWKVNGGjZsKDVq1Ah6G4BA2fb3H/1ZQwPe/v37m4kSoUJZMgBAJEyaNEm6detmgl0NIt955x3Zt2+fyWfUUd/ff/9dhg4dav4Gzpo1S8477zzZtWtXxNrbq1cvE4DPnTs3Ym0AYi7g1VQGnaim33xDiYAXABBuGszq3zedyX7GGWfIypUrZeDAgVKuXDnnPo0aNZIXX3xRPvvsM5Pi8Ndff5lJ3ABiKODt3Lmzma3ZoEGDkN6PldJADi8AIFweffRRU5JJJ1xPmTKlQP15VzoKrPsrHV2dOXNmgZQEa0VSPb9u3ToZMGCA1KxZ0xy/du3aMmjQINm2bVuBY2vFDdf84PwrnOpxLJrnq5fpbfLTVAi9TidaqRkzZkjHjh1NCoamaLRu3VqmT5+e5zaaonHBBReYIL9kyZLStm1br6PHugiV3s9FF11kavMXL17cHLtFixbm+dmzZ48Ek34JsZ4Hza325oYbbjD76WMOR5utds2fP9/jPu3btzf7eEtT+f777+W6664zExG1qoKmrbRq1UqeffZZU37QVhxxKCMjQ8NXx549e3zuu2OHhrq5G+wpMzPTMX36dHOK2Ed/R86xY8cca9asMafhkp2d7di/f785jRXbtm1zJCYmmr9TAwYM8Os2hw4dcpQqVcrcpmvXrnmu27Bhg7lct4kTJzr3K1mypKN48eLO68qXL+9YsWJFntu2bNnSUa5cOec+VapUybPdddddzn3Hjh1r9qlTp06B9o0YMcJc165dO8fw4cPNeX2MZcqUcR5bt9GjRztycnIc/fv3N/9PTk52tle3pKQk8xjc9bfer7VfsWLFzONJSEhwXlajRg3HH3/84fb503bpPtrOwmjatKm53X333edxn8OHDztKlChh9hs3blxY2mzdft68eR7b1c7L7fX51b517Rt9vejzb/2/YcOGjo0bNzpC+RmhcZrel8ZtgbLtCG+4uFY9YZQXAIJj95HdRd6OZR3zeNw9R/cU+bhHMo94PO6+Y/vc3iYUdFTOKr/Vu3dvv26jI6D6y6f67rvvPBb1v+2226Ru3bqydOlSU8/2yJEj8vXXX5tRXs0P1jxc10Udli1blqcS0o4dO/JsL7/8cqEe26pVq+TJJ580m97fgQMHTI5yly5dzPX333+/GXHUGvujR482+cpaO//PP/+Uli1bmtJ39913n9tV1nS1VR1l1gpOuriB1nDVXGdNgdRRya1btwY95UNHbtWECRM8rvw2bdo08zyXKFGiQH9Gos3+0FJnr7zyiikM8Prrr5t26etC26iLdukI9Nq1a+WKK66wzYp3tq7SEImAlzrXABC4yv+pXOTbvtb1NRnSaojb6xq/3tgEvUUxot0IGdne/c+7bca2kTW71xS43GEGLoPrt99+c57XwMJfzZs3l08++cT81KwBlP5Enp9OcNPKDxrIKP1JWwPlr776ytxe58ZooKmBZyhoAPvEE0/Iv/71L+dlOiFPA1wts6ZB1eOPP25WUO3Xr59zn9NOO00mTpwo9evXNwHyDz/8YFIcXGnptvw0t1nTCDQVQm/7008/yaJFi+TCCy8MyuPRNj788MMmHUSDVOtLR/7UDKVfJvSLSaTb7IumvegKtZpeMXv2bGnWrFmeurhW/d8mTZqYtml6Ss+ePSXaMcLrg2uAa5MvMQAAG9PRNEthyoxVrFjR7TFcaa6uFey6aty4sVx55ZXmvAaWoaJ5oFpZIj/NWz3//PPNeR1tdjeqqQG8BoBq9erVhbpfDTR1NFVp8BgsGqxr/q1rYOtKV3S18o6vv/76qGizLzrirCPpl1xySZ5g15WudGcFufoLgR0wwluIEV4CXgCAnVnBmafr9Kd5nYClS3SHYqVCHRXUn/bdqVKlijnV1AVPywbrPlqNYv/+/W6v/+KLL0zgqakYO3fuNBP/8nOtaRystAYd3XVNXbDo86nBo45eX3zxxVHTZm90oprS0d2qVat63M+atKa/JtgBAa8PBLwAgHByHdXVkVp/F3JwndHvaWTY27Gs6zT/V/NrrQA0mHRk0BOrpr4/+2hA7krzSLWawMcff5xnX63woCkCyqpfrEFpMGke6+DBg00AqPnOriO51qivpj7kXwo5km32xqrWoffpz/26C9CjEQGvD0xaA4Dg23Vf0RdIKJmaNw/S1e9DfjclK4siPSXd43Xf3fidZOdkSzjoKKhFcyT9DXi1TJb1U7iWkYon7777rgkck5KS5JFHHjFBZ7169fIEmXqZ5gYX9fXhiY7oatD7wQcfmM0KeDXt4ueff3bedzS12RsdkVYPPvigPPPMMxIrCHh9IIcXAIKvUgnPdWUDUTH9//NYg6l88fISLlr3VoMeHQHUSWg9evTweRsdXdTJaKpNmzYeVyDVWf+6/K+n65Tetnz58D3eYLDyjm+++WbnMsj5aVWJUNHAVIPdb7/91jyP+iXFGt3VyYC6eEg426xBtAauOjrsSUZGhtvLNY1BKzDYJVXBX0xa84GUBgBAOFWrVk0uv/xyZ1CkwYcvuuKaVU5Mf173REtK+bruzDPPzJO/6zriGM6RxsLYsmWL16oW+oVAS7GFiuY/60Ie+iXFKlGmp66ly8LZZmtFPus+8tPXiq7m544u9qE0L9lbwGw3BLw+kNIAAAi3f//736Ys1IkTJ+Sqq67yuuLWrFmzTKkva3S4e/fuHvfVkmPujqVB9dSpU835Pn36FKigYNG6udFIVwBTVgqBu+fTtb5wsOmXAquMmo7sWiO9OtLqqY5uKNtsVVfQXwjc+c9//mNeW+7oktY6yq+vE63H601mZqZtVlwj4PWBlAYAQLg1bdpU3nnnHRMwaS6ojgK+9957eQJOXYxh2LBhctlll5nAQ/M/dVTRU4UDa7JXp06dTEUAa8RWR/J04QcNgGrVqmVKl7lq0KCBcxKVtikaR3m1hJYaM2aMvP322+b5sFIC7rnnHnnuuecKVeKtKFxzd7U2r9K6vJ4m/4Wyzddee62zZJgGrQcPHjT/1yBWayDrF6SyZcu6va2Wf3vsscfMeW2DjlDrEsgWndSoC4hovWQtE6fn7YCA1wdSGgAAkaAjg1qySktaaVmqgQMHmp+qNVDR0V/NxdVUBg1ANLBasmSJ1zJS6q233pL169ebVby0GoJOcNMAWPM19bhaZcB1RFelp6c7g7kHHnjAOSnulFNOMaueRYN7771XGjVqZJ4LXU1Onx99rvS5e+mll8xll156aci/pJx11lnm/PLly72mM4S6zQMGDDCj/UoD07Jly5q8bK3BrBPRnn32WY81dpUGvLrplycdsdYcZH0daK1nraWsX8A0kNaUCW9fsKIJAa8PBLwAgEjRUUCtO/vGG29It27dzGQozavUHFsdedUgWEdodSSvUiXfEwHPPfdcE4xpIKY/qWuwpce85ZZbzMik1sB1R5eX1SV/rclXuiKbBsneUi3CSQM6XX1NF7XQQFxHxvVneV0VTCshaCpHOLgGuPrFwcrFDneb9VgzZ840k+E0qE5NTXWuqqeTG319UdF9NVDWmsyaE64Lk+gxdaKbBuWtW7c2q/Fp+62c32iX4IjG3yZCTIf29Y2ub1RfPxfos2MFvbt2ifjxeYIooz/hffnll+aPRSgKqSO60N+Ro4HYhg0bpG7dumYUKBx0cpB+pmtwkb/OKf5/qVjtE6X9o8GVXdHf8fUZsXfvXjOqrIF2/l8eCotXiw/k8AIAANgbAa8frC+RBLwAAAD2Q8BbiIA3/pI/AAAA7I+AtxBpDYzwAgAA2A9LC/uBlAYAgF3pJLU4nJ8O5MEIrx8IeAEAAOyLgNcP5PACAADYFwGvH8jhBQAAsC8CXj+Q0gAAAGBfBLx+IKUBAPzHBCkA0fbZQMDrB0Z4AcA3a6nX7OzsSDcFQBTK/t9nQySWhSbg9QM5vADgW0pKitkOHz4c6aYAiEKHDh1yfk6EGwGvHxjhBQDfEhISpFSpUpKRkSHHjh2LdHMARJFjx47JwYMHzWeEflaEGwtP+IEcXgDwT8WKFc0fts2bN0vp0qXNH7ekpKSQ/YHLycmRzMxMOX78eER+JkV40d/2y9nNzs42I7sa7KalpZnPiEgg4PUDKQ0A4B8NbmvVqiV79uwxf+QOHDgQ8j+oGmAXL148IqNGCC/6255SUlKkbNmyJtjVz4hIIOD1AykNAOA//YNWpUoVqVy5smRlZZlRuVDR4y9cuFDatm0bkbxAhBf9bT+JiYmmryL9BYWA1w+kNABA4ekfuNTU1JAH1ydPnpRixYoRAMUB+htFRQKMHxjhBQAAsC8CXj+QwwsAAGBfBLx+YIQXAADAvgh4/UAOLwAAgH0R8PqBlAYAAAD7IuD1AykNAAAA9kXA6wdSGgAAAOyLgNcPjPACAADYFwGvH8jhBQAAsC8CXj8wwgsAAGBfBLx+IIcXAADAvgh4/cAILwAAgH0R8PqBHF4AAAD7IuD1AykNAAAA9kXA6wdSGgAAAOzLtgHv1q1b5brrrpMKFSpI8eLF5YwzzpDly5eH5L5IaQAAALCvZLGh/fv3ywUXXCAdOnSQWbNmSaVKlWTdunVSrly5kNwfI7wAAAD2ZcuA99lnn5VatWrJ2LFjnZfVrVs3ZPdHDi8AAIB92TLgnTFjhnTp0kWuuuoqWbBggdSoUUMGDx4st9xyi9v9T5w4YTbLwYMHzWlWVpbZfElISDLZH5mZJyUri6jXbqw+9qevYX/0d3yhv+ML/R1fsoLYzwkOh/3GLYsVK2ZOhw0bZoLeZcuWyd133y2jR4+W/v37F9h/5MiRMmrUqAKXT5gwQdLT033e3yOPXCC//VZR7r9/mVxwwbYgPQoAAAB4cvToUenbt69kZGRI6dKlJe4C3tTUVGnZsqX88MMPzsvuuusuE/guXrzYrxFeTYnYvn27mfTmS6dOSbJgQaJ89NFJueoq2z1dcU+/Ic6ZM0c6deokKSkpkW4OQoz+ji/0d3yhv+PL3r17pVq1akEJeG2Z0qAPvkmTJnkua9y4sXzyySdu909LSzNbfvpm8ecNk5Rk5fImC+8v+/K3vxEb6O/4Qn/HF/o7PqQEsY/9CniTrIgviBISEuTkyZNFuq1WaFi7dm2ey/7880+pU6eOhAJVGgAAAOzLr4A32rIe7rnnHmndurU89dRTcvXVV8uPP/4ob7/9ttlCgTq8AAAAMR7wjhgxwuv1M2fOdC760LRpU2nVqpVUqVLF/H/nzp0mt/bXX381o7qae9utW7eAGn3OOefItGnT5OGHH5bHH3/clCR76aWXpF+/fhIKlCUDAACI44BXA04Ndps1a2ZGWDUYdUeD3ttuu83s2717dxk+fHjRWy0il156qdnCgZQGAACAOF1aeO7cuabkV4MGDWTRokUeg12l13333XdSv359UyLsm2++EbsgpQEAACBOA95XXnnFpCk89NBDUqJECZ/76z66r+YEv/rqq2IXpDQAAADEacBr5e2eeeaZft9GUx+sFAe7IKUBAAAgTgPeffv2mVMtCOwva1nf/fv3i10Q8AIAAMRpwFu9enVz6mnBB3emTp3qXDzCLsjhBQAAiNOA95JLLjH5uG+99ZZMnjzZr2BX99W830BLk4UTObwAAABxGvD+61//Mmsb5+TkyLXXXis9e/aU6dOny9atW81617qSmp7Xy3r16iV9+vSR7OxsKVWqlKmhaxekNAAAAMR4HV5PatSoIZ9//rn06NHD5Obqed080dFgDXY/++wzc1u7IKUBAAAgTkd4VZs2bWT16tXSu3dvSUxMNEGtu02vu+KKK+SXX36Rdu3aiZ2Q0gAAABCnI7yWWrVqyZQpU8wywvPmzTMBsFXBoVy5cnLGGWdIhw4dpGrVqmJHpDQAAADEecBrqVKlilxzzTVmiyUEvAAAAHGc0hAPyOEFAACwLwJeP5DDCwAAYF9BS2nYu3evLF68WP7++285dOiQKT/my/Dhw8UOSGkAAACI44B3165dcs8995hFJbTubmEQ8AIAACCqA979+/fLhRdeKOvXrzelx2I9hzeGHyIAAEDMCiiH95lnnpG//vrLBLudO3eWr776Snbv3m3SGXT1NV+bXTDCCwAAEKcjvLpiWkJCgnTv3l1mzJghsYqAFwAAIE5HeDdv3mxOhwwZIrGMsmQAAABxGvCWLFnSueBELKMsGQAAQJwGvLpksNq0aZPEMlIaAAAA4jTgve2228yEtQ8//FBiGQEvAABAnAa8V199tfTr10+mTZtmKjbEKsqSAQAAxGmVhoULF8rAgQNlw4YN8sgjj8inn34qffv2lUaNGkl6errP27dt21bsgBFeAACAOA1427dvb8qSWVasWGE2f+jtCrsyW6QQ8AIAAMTx0sKxvMKahbJkAAAAcRrwzps3T+IBZckAAADiNOBt166dxANSGgAAAOK0SkO8IOAFAACwLwJeP1CWDAAAwL4IeP3ACC8AAECc5vBedNFFRb6tliWbO3eu2CngnT1b5LrrIt0aFFZOTpJs23aWTJqU5OxLxK5w9XeXLiLXXx+64wMAoiTgnT9/vglcvZUmc63Tq6x9818ezSpWzD1dty53g91o1FMr0o1AjPX35MkiffqIpKaG/K4AAJEMeHWlNF+B65EjR+Svv/6SAwcOmH0bNGgg1apVEzu58UYRXTjuwIFItwRFkZ2dLb//vkYaN24iSUlJkW4OYqC/H3xQJCtLZPt2kTp1QnIXAIBoGuH115dffil33XWX7Nu3T95991254IILxC402NWgF/aUlZUjX375t3Tr1khSUgh4Y104+vvVV0U2bBD55x8CXgCwg7BlNHbr1k0WLVokycnJ0qtXL9m6dWu47hoAgqpmzdxTDXgBANEvrFN4qlatKvfcc4/s2bNHnnvuuXDeNQAEDQEvANhL2OesX3jhheZ05syZ4b5rAAgKAl4AsJewB7yp/5vSvG3btnDfNQAEBQEvANhL2ANezeNV6ToTDABsiIAXAOwlrAHv4sWL5fHHHzflyVq1ahXOuwaAoCHgBYA4KkumwasvOTk5sn//flm+fLksXbrU/F8DXp28BgB2Dni1Du/JkyLJAX2SAgBCLaCP6ZEjRxZqxTRdZU3LkmmFhk6dOgVy1wAQMVWqiOiaFtnZIjt3itSoEekWAQC8CXhcwtuywkoD4lKlSkndunWlXbt2cuutt0qTJk0CvVsAiBgNdqtXF9myJTetgYAXAGI44NX0BACI17QGK+A999xItwYAEFVVGgAgFjBxDQDsg4AXAIqAgBcA4jzgPXnypOzevdtsej7YrMlyrlujRo2Cfj8A4AkBLwDYR9CK6fz+++/yxhtvyDfffCPr1q1zTmbTYPS0004zVRkGDRoUtAlrTZs2Nfdl0eoPABAuBLwAYB9BiRIffvhh+c9//mMmseWv2qD/X7t2rfz555/y5ptvyv333y9PPfVUwPepAW7VqlUDPg4AFAUBLwDEUcB75513mpFdK9Bt3LixnHvuuc5gdMeOHfLjjz/KmjVrJDs7W5599lk5cuSIvPzyywHdr44iV69eXYoVKybnn3++PP3001K7dm23+544ccJsloMHD5rTrKwssyG2WX1MX8eHcPW31uIVSZGtWx1y4sRJSWRGRETw/o4v9Hd8yQpiPyc4fBXS9eL777+XNm3amLQFDXTffvttad26tcdlhTWlYfXq1Wb/7777zuO+vsyaNUsOHz4sDRs2lO3bt8uoUaNk69at8uuvv5qav+5yfnWf/CZMmCDp6elFagOA+HbyZIJcdVUPcTgSZNy4r6Rs2f//Ug0ACNzRo0elb9++kpGRIaVLl45cwHvDDTfI+PHjpV69erJixQopU6aM1/21wWeffbZs2LBB+vXrJx988IEEw4EDB6ROnTrywgsvyMCBA/0a4a1Vq5YJlitUqBCUNiC6vyHOmTPH5JGnpKREujmIof6uUydZtm9PkCVLsuSss0J6V/CA93d8ob/jy969e6VatWpBCXgDSmnQUVodrX3ooYd8BrtK93nwwQfltttuM7cNlrJly0qDBg3kr7/+cnt9Wlqa2fLTNwtvmPhBf8eXcPS35vFu366pW3pfIb0r+MD7O77Q3/EhJYh9HFDWmebnqhYtWvh9m7P+NwyyUxegDxJNb1i/fr35FgAA4cLENQCwh4ACXp0wpnQSmr+sfd2NuPrrvvvukwULFsjGjRvlhx9+kF69eklSUpJce+21RT4mABQWAS8AxEHAW7duXXP6+eef+30ba1/N+y2qf/75xwS3Omnt6quvNnm4S5YskUqVKhX5mABQWAS8AGAPAeXwduvWTVatWiWvvvqqXHLJJdKxY0ev+8+bN8/sq3m/etuimjhxYpFvCwDBQsALAHEwwjt06FAza05nTXbt2lXuuOMO+emnn8wCFBY9r5fpdRoUZ2ZmmtvobQHAzgh4ASAORngrVqwokydPlssuu8wEsrqSmm6pqalSvnx5M5KrJSX0OqUV0PS6KVOmUA4MQEwFvFrgMSEh0i0CALgT8NpAnTt3NvmzLVu2NAGtblrzVmvcbtu2zZy3Ltd9li5dKhdffHGgdwsAEVejRu7p8eMi+/ZFujUAgJAtLayaN29ulg9etmyZfPPNN2bFs33/+/TXkd7TTz/dBLnnnHNOMO4OAKKCFpupXFlk167cUV5+uAIAGwe8M2bMMKc6Ka1EiRIe99OAlqAWQLylNVgBb7NmkW4NAKDIKQ09e/aUK664QjZt2pTn8ptuusks5avpCwAQj5i4BgAxlMOrObj5jRs3zmz79+8PdrsAwBYIeAEgRgJea1U0XcIXAPD/CHgBIEYC3hr/m4r83Xffhbo9AGArBLwAECOT1nSy2pgxY+Rf//qXqcbQoEEDSUlJcV7/xhtvSGWdqlxIw4cPL/RtACCaEPACQIwEvI8++qh8+umnZhGJqVOnFsjt1cUmioKAF0CsBLxbtrD4BADYOqWhVq1aZnngm2++WU455RQzuquBrq6kpqyFJQq7AUCsLD5x5IjIwYORbg0AIKCFJzToffvtt/NclpiYaILe1atXS5MmTfw9FADEjPR0XWAnd6U1TWsoUybSLQIABH1pYQCId+TxAkAMLy08duxYc1rT+rQHgDikH4G//ELACwAxGfD2798/eC0BAJtihBcAohspDQAQIAJeAIhuBLwAECACXgCIbgS8ABAgAl4AiG4EvAAQIAJeAIhuBLwAEKSA98ABkcOHI90aAEB+BLwAEKBSpURKl849v3VrpFsDAMiPgBcAgoC0BgCIXgS8ABAEBLwAEL0IeAEgCAh4ASBGV1pzlZOTI/PmzZPFixfLjh075OjRo/Lkk09KtWrVnPtkZmbKyZMnJSkpSdLS0oJ11wAQcQS8ABDjAe8XX3whd911l2zatCnP5ffdd1+egPedd96RO++8U0qWLCnbtm2TEiVKBOPuASDiCHgBIIZTGsaMGSOXX365bNy4URwOh1SoUMGcunPzzTdLmTJl5PDhwzJt2rRA7xoAogYBLwDEaMC7bt06GTJkiDl/0UUXyZo1a2TXrl0e909NTZXevXubgHj27NmB3DUARBUCXgCI0YD3xRdfNDm5TZs2lS+//FIaNWrk8zZt2rQxpytXrgzkrgEgKgPePXtEjh+PdGsAAEELeL/99ltJSEiQoUOHmtFbf9SvX9+cbtmyJZC7BoCoUrasSHp67nkWnwCAGAp4//nfb3fNmjXz+zbWRDWt4gAAsSIhgbQGAIjJgFdHdwsbvO7du9ec6uQ1AIglBLwAEIMBb40aNczp33//7fdtFi1aZE7r1asXyF0DQNQh4AWAGAx427dvbyouvP/++37tn5GRIaNHjzYjw1rVAQBiCQEvAMRgwHvbbbeZ4HXBggUybtw4n6kMPXv2NKuwJScny6BBgwK5awCIOgS8ABCDAW+LFi3k7rvvNqO8AwcOlD59+sjkyZOd1//www8yYcIEU6tXqzMsXLjQBMiPPfaY1KlTJxjtB4CoQcALADG6tPB///tfOXHihLz55psydepUs1mT2XQE2GKtvqYlzB599NFA7xYAog4BLwDE6NLCGty+/vrr8vXXX5ucXv2/Breumzr//PNl5syZ8sILLwSj3QAQtQHvzp0imZmRbg0AIGgjvJZOnTqZ7dChQ2YVNV1iODs7WypUqCDNmzeXihUrBuuuACAq6cecrsGjwe727SJkbgFAjAW8llKlSknbtm2DfVgAsM3iE1qpUdMaCHgBIEZSGgAA/488XgCIPgS8ABBEBLwAEGMpDTfddFORb6uT2959991A7h4Aog4BLwDEWMCri01YJcgKQys3EPACiEUEvAAQYwFv7dq1fQa8R44cMausWUGuVmtIT08P5G4BIGoR8AJAjAW8Gzdu9Gu//fv3y8cffyzDhw+XsmXLyowZM6Rhw4aB3DUARCUCXgCI00lr5cqVk8GDB8v3339v6vN27drVBMHB8Mwzz5iRY13BDQCiJeDVOrwnT0a6NQCAsFdp0FHdu+66y4wM65LEgVq2bJm89dZbcuaZZwalfQAQqMqVRZKTRbKzc1dcAwBEXtjLkl188cXm9NNPPw3oOIcPH5Z+/frJmDFjzAgyAESDpCSR6tVzz5PWAAAxutKaLyVLljSnmzdvDug4Q4YMke7du5sA+oknnvC674kTJ8xmOXjwoDnNysoyG2Kb1cf0dXyIhv6uUSNJNm9OlI0bT8pZZzki1o54EA39jfChv+NLVhD7OewB78qVK81pSkpKkY8xceJE+emnn0xKgz+efvppGTVqVIHL582bR8WIODJnzpxINwFx0t+JiS017JU5c36XYsX+jlg74gnv7/hCf8eHo0eP2jPg3bBhg4wcOdJMMmvevHmRjrFlyxa5++67zYu9WLFift3m4YcflmHDhuUZ4a1Vq5Z06NBBKlSoUKR2wF7fEPX10qlTp4C+aMEeoqG/589PlO+/FylTpol069YoIm2IF9HQ3wgf+ju+7N27NzoC3g8++MDnPjk5OaYiw/Lly+Wzzz4z0boGvIMGDSrSfa5YscJUejjrrLOcl2VnZ8vChQvltddeM6kLSZpE5yItLc1s+embhTdM/KC/40sk+7t27dzTrVuTJCUl7+cRQoP3d3yhv+NDShD7OKCAd8CAAYVaaU0Xn1BaqaFPnz5Fus+OHTvK6tWr81x24403SqNGjeTBBx8sEOwCQLhRixcAokvAKQ1WEOuLLjjRtm1bU4+3c+fORb6/UqVKyemnn57nshIlSpjUhPyXA0AkEPACQAwFvJqT60tiYqIJUjXgBYB4Cni3btW0Lv0cjHSLACC+BRTw1qlTR6LB/PnzI90EAHCqWjU3yNWV1nbtyv0/ACByGHcAgCDTeRZWkEtaAwBEHgEvAIQAebwAED0IeAEgBAh4AcBmObz16tUL+h1rObP169cH/bgAEA0IeAHAZgHvxo0bg37HhanfCwB2Q8ALADYLePv37x/6lgBADCHgBQCbBbxjx44NfUsAIIYQ8AJA9GDSGgCEOOD1c0FKAECIEPACQAhUr557euKEyN69kW4NAMQ3Al4ACIG0NJHKlXPPk9YAADZeWthTRYc9e/bIsWPHxOHjd7y2bdsG++4BIKrSGnRpYQ14mzePdGsAIH4FJeBdu3atPPXUUzJjxgw5ePCg32XJTupC8wAQwwHvTz8xwgsAtg94p0+fLv369ZPjx4/7HNEFgHhCpQYAiIGAd8uWLXLdddeZ9IUaNWrI/fffL+np6XLrrbeaEdxvvvlG9u3bJ8uXL5cPP/xQtm3bJhdeeKGMHDlSkpKSgvcoACAKEfACQAwEvK+88oocPXpUSpUqJUuXLpXq1avLb7/95ry+Q4cO5rR3794yfPhwGThwoEyaNEneffdd+eijjwJvPQBEMQJeAIiBKg06gqsjuYMHDzbBrjfFixeX8ePHS4sWLWTixInyySefBHLXABD1CHgBIAYCXq3IoFq3bu28TANgS/5JaYmJiXLXXXeZXN/33nsvkLsGgKjH4hMAEAMB75EjR8xprVq1nJdpDq8lIyOjwG2aNm1qTn/++edA7hoAol6NGrmn+lHp5uMQAGCHgLdMmTLmVCs0WCpUqOA8v379+gK3sYJgrdULALFMv/+XL597nrQGALBpwNuwYUNz+vfffzsv0wlsderUMednz55d4DZz5swxp2XLlg3krgHAFsjjBQCbB7znn3++OV2yZEmeyy+99FKTp/v888/LvHnznJdPnjxZXn75ZZPne8EFFwRy1wBgC1bGFwEvANg04O3WrZsJbD/99FPJzs52Xm7V4z18+LBcfPHFUqlSJTPye+2115r0B528pvsAQKxjhBcAbB7wtm/fXkaMGCE33nijbN261Xl57dq1ZcqUKSbHVwPivXv3mgluej4tLU3GjBkj5513XjDaDwBRjYAXAGy+8ISmJmjA607Xrl1l3bp1MnXqVLMYhZYoO+200+Tqq682q7IBQDwg4AUAmwe8vmjFhttuuy2UdwEAUY2AFwBsntIAAPCOgBcAbB7wah7ua6+9Jrt37w5eiwAghlgZXFqC/NChSLcGAOJTQAHvjz/+KHfffbfJydWc3fHjxztXXwMAaG1yXaQn97zL3F4AgF1yeHUSmk5M0wlpusiEboMGDZLLLrtM+vXrJ5dccokkJSUFr7UAYNO0Bh3h/fhjXV5dbK1lS5F69SLdCgAIY8C7du1aWbFihUyYMEEmTZok27Ztk6NHj5rzuumkNa3K0LdvX2ndunUgdwUAtl584rffRB5/XGyvcmWRbdtEGMsAEFdVGs4++2yz/ec//zGrqmnwqwtRHDhwQPbs2SNvvvmm2XS5YR311eC3cePGwWk9ANjAgw+K5OSIZGaKrS1aJLJrl8jGjSKnnhrp1gBABMqSaU3eiy66yGxvvPGGzJw50wS/eqqrq23cuFGeeuopszVr1kyuu+46GTZsWLDuHgCiVvv2uZvdNW8u8vPPImvWEPACsJeQlCVLTU2VXr16mdXWdu7cKe+++6507NjRLCmsq62tWrWKpYUBwGaaNMk91YAXAOwk5HV4S5UqZZYe1glt48aNk7Jly4b6LgEAIQx4f/890i0BgChaaU399NNPJrVh4sSJsn379lDfHQAgRBjhBWBXIQl4//77b/noo49MoPvnn3+ayzSVQZUoUUJ69uxpJrABAOzDmm+sAa9+pCckRLpFABDmgFdXW9NRXA1ydUEK1yA3OTlZOnfubILcyy+/XNLT04N1twCAMKlfXz/PRXR9oS1bRGrXjnSLACAMAa+uqqYlyHQ099tvv5Xs7Ow8ge75559vglytxVuxYsVA7goAEGEpKSINGuSO8OpGwAsgLgLeypUrm5JjrkFuo0aNnPV269atG5xWAgCiJo/XCngvuSTSrQGAMAS8x44dM6fVq1eXa665xgS6LVq0COSQAIAoxsQ1AHEX8Gq5MQ1yO3ToYBaeAADENkqTAYi7gFcXlAAAxA8qNQCwo5AvPAEAiB06aS0xUeTAAZEdOyLdGgDwDwEvAMBvxYqJnHpq7nnyeAHYBQEvAKBQmLgGwG4IeAEAhULAC8BuCHgBAIVCwAvAbmwZ8L755pty5plnSunSpc2mK7rNmjUr0s0CgLhAaTIAdmPLgLdmzZryzDPPyIoVK2T58uVy0UUXyeWXXy6//fZbpJsGADGvYcPc0927czcAiOk6vJHSo0ePPP9/8sknzajvkiVLpGnTpgX2P3HihNksBw8eNKdZWVlmQ2yz+pi+jg/0d+ilpoqcckqybNyYIKtXn5Q2bXKXlo8E+ju+0N/xJSuI/WzLgNdVdna2TJkyRY4cOWJSG9x5+umnZdSoUQUunzdvnqSnp4ehlYgGc+bMiXQTEEb0d2hVqHCubNxYVaZM+U0OHdoY6ebQ33GG/o4PR48eDdqxEhwOXSunaOrWrSuJiYny9ddfS/369f26zebNm6V9+/ZmKeL169cX9a5l9erVJsA9fvy4lCxZUiZMmCDdunVzu6+7Ed5atWrJ9u3bpUKFCkVuA+zzDVE/HDt16iQpKSmRbg5CjP4Oj4ceSpQXXkiSIUOy5cUXcyLWDvo7vtDf8WXv3r1SrVo1ycjIMHO2IjbCu2nTJhO4ZmZmFurFunHjRnO7QDRs2FBWrVplnoSpU6dK//79ZcGCBdLEmk3hIi0tzWz56ZuFN0z8oL/jC/0dWqefnnv6xx9JkpKSFOnm0N9xhv6ODylB7GPbpjSkpqY6R5XPPvtsWbZsmbz88svy1ltvRbppABDzqNQAwE7CXqVBR2RVsHNnc3Jy8qQtAABCp1Gj3NNt20QOHIh0awAgykZ4x48fb07r1KlT5GM8/PDD0rVrV6ldu7YcOnTI5O/Onz/f5BIDAEKvTBmRGjVEtm7NHeX1MGcYAOwX8Gq9W3duvPFGKVGihNfb6ujr33//Lbt27TL5u507d5ai0mPccMMNZtJZmTJlzCIUGuxqEjsAIHxpDRrw6oprBLwAYibg1VFUDVZdCzvoec2fLYx69eqZUdqievfdd4t8WwBA8AJerQ7FEsMAYirgbdu2bZ7qCloVQf+vk8a8jfDqPsWKFTOlJVq3bi3XXHONzxFhAIA9Jq4R8AKIuRFeV1qDV40bN85tOTAAQOwi4AUQF5PWNI9WR2/LlSsXvBYBAGyhcePc082bRQ4fFilZMtItAoAQBLw6sgsAiE+6UGXlyjqRWBegEGnZMtItAoAI1uHVJYSXLl0qO3fuDMfdAQDChLQGADEf8Gp5sDfeeMNs1oISrv766y8zoa1BgwZmslqNGjWkd+/esn///kDuFgAQJQh4AcR8wPvpp5/KHXfcYZb01Xq4+evu6uIQq1atMqXLdNPV0KZPny6XX355oO0GAEQBAl4AMR/wzp4920xa69Wrl9v8Xk1lUJdddpkJinv06GEC3++//14mTZoUyF0DAKIAAS+AmA94165da07PO++8Atfpcr/W6mw6qnvnnXfKZ599JhdffLEJeidOnBjIXQMAoijg3bBB5NixSLcGAEIQ8O7evduc1qxZM8/lx44dkyVLlpjR31tvvTXPdTfddJM5/emnnwK5awBAFNAqDVqZMidH5M8/I90aAAhBwHvgwIE8C1BYNNjNysoyAa+O6LqqW7euc8IbAMDedPFN0hoAxHTAW/J/VcZ37NjhdkU2XX0t/6IUKSkp5jQ5OaASwACAKEHACyCmA95GjRqZ06+++irP5Z988okZ3W3Xrl2B21jBcZUqVQK5awBAlCDgBRDtAhpm7d69u0lfePvtt6Vx48bSpk0bU51hzZo1JuC94oorCtzGyt3VmrwAAPsj4AUQ0wGv1uDVRSe2b99uzrs6//zzpUOHDgVu8/nnn5tg+JxzzgnkrgEAURbwrlsnkpkpkpoa6RYBQBBTGnSxiW+++UbOOuss5+ISuulI7+TJkwvs//PPP8uyZcvM+U6dOgVy1wCAKKE/2JUqJZKdrStsRro1AFBQwDPHNJVh+fLlsmHDBpOfW61aNTnllFM87j927FhnfV4AQGxUamjcWOTHH3PTGqwRXwCIFkErlaDlxqySY540a9bMbACA2KJBrhXwAkBMpTQAAKCYuAYgLkZ4c3JyZN68ebJ48WKT2nD06FF58sknTYqDJTMzU06ePClJSUmSlpYWrLsGAEQYAS+AmA94v/jiC7nrrrtk06ZNeS6/77778gS877zzjtx5551mwYpt27ZJiRIlgnH3AIAoCXjXrhU5eVIXF4p0iwAgiCkNY8aMkcsvv1w2btxoKjRUqFDBnLpz8803m8oOhw8flmnTpgV61wCAKFGnjkjx4rllyf7+O9KtAYAgBrzr1q2TIUOGOKsu6IITu3bt8rh/amqq9O7d2wTEs2fPDuSuAQBRJDFRV9/MPf/775FuDQAEMeB98cUXTU5u06ZN5csvv3QuNeyN1uhVK1euDOSuAQBRhjxeADEZ8H777bdm1bShQ4ea0Vt/1K9f35xu2bIlkLsGAEQZAl4AMRnw/vPPP+a0MLV1rYlqWsUBABA7CHgBxGTAq6O7hQ1e9+7da0518hoAIHZYAa/m8ObkRLo1ABCkgLeGLqAuOiPX/ym5ixYtMqf16tUL5K4BAFFGP9Y1u+3YMZF8VSoBwL4Bb/v27U3Fhffff9+v/TMyMmT06NFmZFirOgAAYofW3m3YMPc8lRoAxEzAe9ttt5ngdcGCBTJu3DifqQw9e/Y0q7AlJyfLoEGDArlrAEAUatw495Q8XgAxE/C2aNFC7r77bjPKO3DgQOnTp49MnjzZef0PP/wgEyZMMLV6tTrDwoULTYD82GOPSR2tUg4AiClMXAMQjQJe/PG///2vnDhxQt58802ZOnWq2azJbDoCbLFWX9MSZo8++migdwsAiEIEvABicmlhDW5ff/11+frrr01Or/5fg1vXTZ1//vkyc+ZMeeGFF4LRbgBAlAe8HlaZBwD7jfBaOnXqZLZDhw6ZVdR0ieHs7GypUKGCNG/eXCpWrBisuwIARKnTThNJShI5dEhk61aRmjUj3SIACGLAaylVqpS0bds22IcFANiAliXToPePP3JHeQl4AcRESgMAAO4qNVCaDEDcBLz79++X3bt3O3N5AQCxjYlrAGIi4D158qT8+uuvsmLFChPM5nf8+HEZPny41KxZ0+TuVq1a1aQ6XHnllfLbb78Fo90AgChFwAvA1gGvjtJqIKtBbLNmzaRVq1YmmL3wwgtl2bJlZp/MzEzp0qWLPPnkk7J9+3ZnpYajR4/KtGnTzG3mzp0bqscDAIiSgFfHN/hxD4DtJq3deOON8uGHH5rzrikKusDEJZdcIkuXLpU33nhDvvvuO3N5+fLl5bTTTjMjwmvWrJFjx46ZrV+/frJ27VopU6ZMsB8PACDCdHlhLce+f7/Irl0iVapEukUA4p3fI7zz5s2TDz74wJxPS0uT3r17y3333SdXXXWVFC9eXA4cOCAvvviiWWI4JSVF3n77bZPusHjxYjP6u2fPHrO/0st9LUUMALCn4sVF6tXLPU9aAwBbBbxjx441p5UrVza5u1OmTJHnnntOJk2aZP5fpUoVE+RmZGTIPffcIzfffLNzxTWlQbHur+kOOjqsi1AAAGI7rYFKDQBsFfBquoIGsBrMNrZqzvxPo0aNzOW60IS6/vrrPR6nf//+5pTJawAQu6w/E4zwArBVwLtt2zbnEsHuuF5ev359j8fRnF61b9++wrQTAGAjVGoAYMuA98iRI86JaO6ULVvWeV5zfD0pVqyYs5oDACA2EfACsHUdXte8XH8uBwDEn0aNck937hTZuzfSrQEQ72y5tPDTTz8t55xzjlnMQifR9ezZ05Q5AwBEh1KlRGrXzj3PxDUAkWbLgHfBggUyZMgQWbJkicyZM0eysrKkc+fOzrQLAEDkNW2ae/rjj5FuCYB4V6iFJ5QuLKGjqvnt0uri//P44497vL3rfkX11Vdf5fm/1vS1yqW1bds24OMDAALXtavIrFkikyeLDBsW6dYAiGeFDnjffPNNj9dZebyjRo2ScNLav94m1J04ccJsloMHD5pTHRnWDbHN6mP6Oj7Q39GjVy+RoUOTZenSBPnjjyw59dTg3wf9HV/o7/gSzH5OcLiuEexFYmJwsx80OLbq9gYiJydHLrvsMrPS26JFi9zuM3LkSLdB+IQJEyQ9PT3gNgAA3Bsx4nz5+efK0rfv73L11X9GujkAbOTo0aPSt29fM7BZunTp8AS8mjcbbO3atQv4GLfffrvMmjXLBLs1a9b0e4S3Vq1asn37dqlQoULAbUD0f0PUXO9OnTqZZa8R2+jv6PLBBwly883J0qiRQ37++aQEu6AP/R1f6O/4snfvXqlWrVpQAt7kcAanwXbHHXfIF198IQsXLvQY7Fp1gd3VBtY3C2+Y+EF/xxf6OzpceaXIkCEif/yRIL//niLNmoXmfujv+EJ/x4eUIPaxLas06KC0BrvTpk2Tb7/9VurWrRvpJgEA3ChTRqR799zzH38c6dYAiFe2DHi1JNn48eNNDq7W4t2xY4fZjh07FummAQDyufba/w94c3Ii3RoA8ciWAa9WitB8jvbt25vcDmubNGlSpJsGAMhHR3h1IYrNm0UWL450awDEI9umNLjbBgwYEOmmAQDyKV5c5Iorcs9PmBDp1gCIR7YMeAEA9kxr0EUoKKEKINwIeAEAIdexo0ilSiJ79ojMnRvp1gCINwS8AICQS04Wufrq3POkNQAINwJeAEBY9O2bezptmghFdQCEEwEvACAszj9fpE4dkcOHRb74ItKtARBPCHgBAGGhywq71uQFgHAh4AUAhI0V8M6cKXLgQKRbAyBeEPACAMLmjDNEmjYVyczMzeUFgHAg4AUAhDWtwZq8RrUGAOFCwAsACKtrrsk9/fZbkR07It0aAPGAgBcAEFb16omcd55ITk7uymsAEGoEvACAiE1eI60BQDgQ8AIAwk5XXUtMFFm6VOTvvyPdGgCxjoAXABB2VauKXHRR7nlq8gIINQJeAEBEuFZrcDgi3RoAsYyAFwAQEb16iaSmiqxZI7J6daRbAyCWEfACACKibFmR7t1zzzN5DUAoEfACACKe1jBxYm6ZMgAIBQJeAEDE6AhvqVIimzaJLF4c6dYAiFUEvACAiClePDeXV1GtAUCoEPACAKJiEQpdde3kyUi3BkAsIuAFAERUx44ilSqJ7N4tMndupFsDIBYR8AIAIiolReSqq3LPU60BQCgQ8AIAoqZaw6efihw7FunWAIg1yZFuAAAA558vUru2yObNItOni/Ts6d/tsrJETpxINEGyv/m/SUm5C14AiB8EvACAiEtMzJ289uyz/z/a658UEelRqPvSgPftt0VuuqmwrQRgV6Q0AACiws03566+FmrZ2SLPPSficIT+vgBEB0Z4AQBRoX59kV27RI4f9/82WVlZMnv2bOncubOk6Ow3H44cETn1VJG1a0V+/FHk3HMDazMAeyDgBQBEDY1Z/Yhb8+TwFi9+0qzW5s/tdL8rrhAZP15k3DgCXiBekNIAAIgr/fvnnk6cWLjRZAD2RcALAIgrHTqI1KwpcuCAyOefR7o1AMKBgBcAEFe0SsP11+eef//9SLcGQDgQ8AIA4jat4auvRHbujHRrAIQaAS8AIO40bChy3nm5Jco++ijSrQEQagS8AIC4HuXVag3U5AViGwEvACAu9ekjkpYmsnq1yKpVkW4NgFAi4AUAxKVy5UQuuyz3PJPXgNhGwAsAkHhPa5gwIXcRCwCxiYAXABC3unQRqVJFZPdukVmzIt0aAKFCwAsAiFvJySL9+uWeJ60BiF0EvACAuGalNeiqa3v3Rro1AEKBgBcAENfOPFOkRYvcHN6PP450awCEAgEvACDuWaO8pDUAsYmAFwAQ9/r2zc3nXb5cZM2aSLcGQLAR8AIA4l6lSiLduuWeZ5QXiD0EvAAAuKQ1jB8vkp0d6dYACCYCXgAARKR7d5Hy5UW2bRP55ptItwaAxHvAu3DhQunRo4dUr15dEhISZPr06ZFuEgDA5tLSRK69Nvc8aQ1AbLFlwHvkyBFp1qyZvP7665FuCgAghgwYkHs6bZpIRkakWwMgWJLFhrp27Wo2AACC6eyzRZo0ya3UMHmyyC23RLpFAOI24C2sEydOmM1y8OBBc5qVlWU2xDarj+nr+EB/x5dQ9Pd11yXKv/6VJOPG5ciAAcxeiya8v+NLVhD7OS4C3qefflpGjRpV4PJ58+ZJenp6RNqE8JszZ06km4Awor/jSzD7u2rVYpKY2Fl++CFR3n33W6lW7UjQjo3g4P0dH44ePRq0Y8VFwPvwww/LsGHD8ozw1qpVSzp06CAVKlSIaNsQnm+I+uHYqVMnSUlJiXRzEGL0d3wJVX9PnOiQ2bMTZMuWDjJwYE7QjovA8P6OL3v37g3aseIi4E1LSzNbfvpm4Q0TP+jv+EJ/x5dg97dOXps9W+Sjj5Lk3/9OkkRbTvGOXby/40NKEPuYtzAAAPn07ClSurTIpk1aCjPSrQEQlwHv4cOHZdWqVWZTGzZsMOc3b94c6aYBAGJA8eIiV1+de37cuEi3BkBcBrzLly+XFi1amE1pfq6eHz58eKSbBgCIsZq8U6fqQEukWwMg7nJ427dvLw6HI9LNAADEsNatRerXF/nrL5FPPxW54YZItwhAXI3wAgAQagkJ/x/kvveeCOMsgH0R8AIA4IEGvFqhYcECreke6dYAKCoCXgAAPKhTR+S//809/8gjImPGRLpFAIqCgBcAAC+GDtUFjHLPDxqUm88LwF4IeAEA8OHJJ0UGDhTJyRG59lpdmj7SLQJQGAS8AAD4MYFt9OjcBSkyM0Uuv1xk5cpItwqAvwh4AQDwQ3KyyMcfi7RrJ3LokMgll+SWLAMQ/Qh4AQDwU7FiIp99JtKsmciuXSKdO4ts3x7pVgHwhYAXAIBCKFNG5KuvROrV06XtRbp2FTlwINKtAuANAS8AAIVUtarI7NkiVaqI/Pxzbk7vsWORbhUATwh4AQAoglNPFfn6a5HSpUUWLsyt3nDyZKRbBcAdAl4AAIpIc3k//1wkLS03t/e221iCGIhGBLwAAASgbVuRSZNylyB+7z2Rf/0r0i0CkF9ygUsAAEChaA6vLjusi1M884xIuXIi119fuDq/mg+spwCCj4AXAIAguOkmkd27RR56SOTBB3O3wmjYUOSRR3JzgbXmL4DgIaUBAIAgeeABkREjRNLTRZKS/N90ZHftWpEbbhBp1Cg3NSIrK9KPBogdBLwAAASJBq4jR4ocOZJbscHfTev4Pv20SMWKIuvX56ZGnHZa7nLGJ05E+lEB9kfACwBAhGlpM02F2LhR5L//zc3n3bRJ5Pbbc8ufvfoqdX6BQBDwAgAQJUqUEBk2LHcFt1deEalRQ2TrVpG77spd2e2FF3JHjwEUDgEvAABRpnhxkTvvzE1vePNNkdq1RXbsELn3XpFTTsmtBHHoUKRbCdgH80ABAIhSuqDFoEG5FSA+/FDkqadE/v5b5OGHcys6VK4sUq2aSPXquafuzmt6REpKpB8JEFkEvAAARLnU1NyJbP37i3z8sciTT+ZWddBRX91WrvQ+kU4nw1WtGp7AV+9PN12Iw92p63mtUHHGGSI9eohceCGBOUKHgBcAAJvQ+ry6oMV11+UGutu3//+2bVvB87qPVoHQ+sC6RaNvvhF58UWRsmVFunYVuewykUsuyf0/ECwEvAAA2IyOjlppC97k5Ijs3ZsbAO/cKZKdHfq2ORy59+t66umy48dF5s8XmTlTZM+e3NFr3TSwb9MmN/jV0V+tVAEEgoAXAIAYpakDlSrlbtFqwIDcQHzJEpHPPxeZMUPk999F5s3L3e65R6RJk9zAt1u3hLAE7Yg9cR3w7jmyR3KK5RT6diVTS0rxlOLuj3l0jzj0a2sRpKekS4nUEm6v23dsn2TnFO1dXiy5mJRKK+X2ugPHD0hWdtGW80lNSpUyxcq4vS7jeIZkZmcW6bgpSSlStpj737IOnTgkx08eL9TxsrKyJONkhnkOq6RUcbvPkcwjcjTraJHam5CQIBXTK7q97ljWMTmceViKqlIJ93+lTpw8IQdPHCzycSukV5DEhIJFWrTPtO+KqlzxcpKcWPBj5WTOSdl/bH+Rj6uvM3295ZfjyJG9R/e67e/dR3ZLio+EwNJppSUtOc3tdXr7ouIzwl6fEZakxCQpX7y82+v4jAjtZ4Qj4aQ0aL5f7m0ucu9jIn9vEJn9tcjXs0UWLxZZs1Fkzasiz74qkpB4viQm6udJwv8f4HgZScgp+BnhkByR9LyfEYVyorQkZLv/jHCkB5AjkllSEk66/4xwFN8jklC0zwjJSpeELPefEY5i+0QSi/ht4WQxScgs+BmhH7E16x+QOvWyTPWQU+rkVhHRrXYdkWLunzq/PyM0TguWuA54G73ZSKRY4W/3WtfXZEirIW6va/x6Y/MHrShGtBshI9uPdHtdm7FtZM3uNUU67uCWg+X17q+7va7nxJ6yYNOCIh33yiZXypSrpri97ubPb5apa6YW6bjt6rST+QPmu73uoW8ekjeWv1Gk4zbe0VjWDHH/HD7/w/MyasGoIh1X/5Dtvt/9B997K9+TO2bdIUXlGOH+Q2/G2hly9dSri3zcXfftcvuH8octP0iH9zsU+bi/3v6rNK3ctMDla/esldPfPL3Ix53Xf560P6V9gcs12K38n8oeGuP7uJOvnCxXNb3K7XUej+sHPiPs+RnRpFIT+W3wb26v4zMiQp8Rrf+3udBHXCBsGzdPZGPBzwgT7A4r+ntZJk8WWeP+MyKg4858TWSZ+88IGdRYpEQRA735I0Tmu/+MkBvaiFQu2meE/DhY5MuCnxGaH77u7J6y7pT/fUbod6xf/rcF4zPip6J9RrgT1wEvAACwvylTRFpXL3j53mMiZ44v+nFHvyXSo57762qMKfpxtcrGgIJxv3HGhyL7ivYjhVm05N6P3F/XYYrInweKdtz+A0SecvN4dfW/K2aI/FL0HxPChoAXAADYmpZd05rD+aUEuCpd+XLujxuoMmU8H1fzrouqVCnPx00OoORbiXTPxy1X7n8ju1GOldYAAAAQ0xIcRZ09YWMHDx6UMmXKyB+b/pDyFdxPUPCGCSn2mpCik5i+mfuNdOnURaqUZtJaPExa0/6+uOPFTFqLg88I7e8vv/xSunXrZvqbSWux/Rnh6f1dmM+IwuAzIrKfETt27ZBGdRpJRkaGlC5dWgIR1ykNFUtUlAolKgT3mB4+1ALl6UM4UJ4Cy0B5egEHSt9wnt503j4gyySX8foc6geEpw+JQOgHmqcPtUDoB3Cl5ODXGdIPH09/QAOhf+BCcVz9g5z/uFZ/6+W+Al5vQtFexWdE9H1G+IPPiOj4jCjs+9vdZ0Sw8BkR+s+IkyVOBu14pDQAAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCm2Trgff311+WUU06RYsWKybnnnis//vhjpJsEAACAKGPbgHfSpEkybNgwGTFihPz000/SrFkz6dKli+zatSvSTQMAAEAUsW3A+8ILL8gtt9wiN954ozRp0kRGjx4t6enp8t5770W6aQAAAIgiyWJDmZmZsmLFCnn44YedlyUmJsrFF18sixcvLrD/iRMnzGbJyMgwp/v27QtTixFJWVlZcvToUdm7d6+kpKREujkIMfo7vtDf8YX+ji/7/henORyO+Ax49+zZI9nZ2VKlSpU8l+v///jjjwL7P/300zJq1KgClzdo0CCk7QQAAEBg9AtOmTJl4i/gLSwdCdZ8X8uBAwekTp06snnz5oCfQES/gwcPSq1atWTLli1SunTpSDcHIUZ/xxf6O77Q3/ElIyNDateuLeXLlw/4WLYMeCtWrChJSUmyc+fOPJfr/6tWrVpg/7S0NLPlp8Eub5j4oX1Nf8cP+ju+0N/xhf6OL4mJifE5aS01NVXOPvtsmTt3rvOynJwc8//zzz8/om0DAABAdLHlCK/SFIX+/ftLy5YtpVWrVvLSSy/JkSNHTNUGAAAAwPYBb58+fWT37t0yfPhw2bFjhzRv3ly++uqrAhPZ3NH0Bq3f6y7NAbGH/o4v9Hd8ob/jC/0dX9KC2N8JjmDUegAAAACilC1zeAEAAAB/EfACAAAgphHwAgAAIKYR8AIAACCmxWXA+/rrr8spp5wixYoVk3PPPVd+/PHHSDcJQbBw4ULp0aOHVK9eXRISEmT69Ol5rtf5mVrVo1q1alK8eHG5+OKLZd26dRFrL4pOlws/55xzpFSpUlK5cmXp2bOnrF27Ns8+x48flyFDhkiFChWkZMmS0rt37wKL1cAe3nzzTTnzzDOdiw1ovfVZs2Y5r6evY9szzzxjPtOHDh3qvIw+jx0jR440/eu6NWrUKOh9HXcB76RJk0wNXy1z8dNPP0mzZs2kS5cusmvXrkg3DQHSOszan/qFxp3nnntOXnnlFRk9erQsXbpUSpQoYfpe30ywlwULFpgPwCVLlsicOXMkKytLOnfubF4DlnvuuUc+//xzmTJlitl/27ZtcsUVV0S03SiamjVrmqBnxYoVsnz5crnooovk8ssvl99++81cT1/HrmXLlslbb71lvvC4os9jS9OmTWX79u3ObdGiRcHva0ecadWqlWPIkCHO/2dnZzuqV6/uePrppyPaLgSXvrSnTZvm/H9OTo6jatWqjueff9552YEDBxxpaWmOjz/+OEKtRLDs2rXL9PmCBQucfZuSkuKYMmWKc5/ff//d7LN48eIIthTBUq5cOcc777xDX8ewQ4cOOU477TTHnDlzHO3atXPcfffd5nL6PLaMGDHC0axZM7fXBbOv42qENzMz04wQ6E/Zrusz6/8XL14c0bYhtDZs2GAWKHHt+zJlypiUFvre/jIyMsxp+fLlzam+z3XU17W/9Sey2rVr0982l52dLRMnTjSj+ZraQF/HLv0Vp3v37nn6VtHnsWfdunUmHbFevXrSr18/2bx5c9D72rYrrRXFnj17zIdl/tXY9P9//PFHxNqF0NNgV7nre+s62FNOTo7J7bvgggvk9NNPN5dpn6ampkrZsmXz7Et/29fq1atNgKspSJrHN23aNGnSpImsWrWKvo5B+qVG0w41pSE/3t+x5dxzz5Vx48ZJw4YNTTrDqFGjpE2bNvLrr78Gta/jKuAFEJujQPrB6Jrzhdijfww1uNXR/KlTp0r//v1NPh9iz5YtW+Tuu+82+fk6uRyxrWvXrs7zmqutAXCdOnVk8uTJZoJ5sMRVSkPFihUlKSmpwOw+/X/VqlUj1i6EntW/9H1sueOOO+SLL76QefPmmYlNFu1TTWE6cOBAnv3pb/vSUZ769evL2Wefbap06ATVl19+mb6OQfoztk4kP+ussyQ5Odls+uVGJx3reR3do89jV9myZaVBgwby119/BfX9nRhvH5j6YTl37tw8P4fq//WnMsSuunXrmjeHa98fPHjQVGug7+1H5yVqsKs/a3/77bemf13p+zwlJSVPf2vZMs0Lo79jg352nzhxgr6OQR07djQpLDqib20tW7Y0uZ3Wefo8dh0+fFjWr19vSogG8/0ddykNWpJMfwrTN0yrVq3kpZdeMpMfbrzxxkg3DUF4k+g3QteJavrhqBOZNMFd8zyfeOIJOe2000yA9Nhjj5kkea3hCvulMUyYMEE+++wzU4vXyuXSiYj6E5ieDhw40Lzftf+1duudd95pPiDPO++8SDcfhfTwww+bnz31fXzo0CHT9/Pnz5evv/6avo5B+p628vEtWkZS67Bal9PnseO+++4zNfQ1jUFLjmnZWP01/tprrw3u+9sRh1599VVH7dq1HampqaZM2ZIlSyLdJATBvHnzTKmS/Fv//v2dpckee+wxR5UqVUw5so4dOzrWrl0b6WajCNz1s25jx4517nPs2DHH4MGDTfmq9PR0R69evRzbt2+PaLtRNDfddJOjTp065jO7UqVK5r07e/Zs5/X0dexzLUum6PPY0adPH0e1atXM+7tGjRrm/3/99VfQ+zpB/wlV1A4AAABEWlzl8AIAACD+EPACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgi5hIQEs40cOTLSTYla2dnZ8vLLL5slz3X5TOs5i9elr2PxNdO+fXvzmPQUQHgR8AIhNH/+fOcfbt369Onj8zYDBgxw7o/4oevGDx06VJYtWyaHDh2KdHMAIKYQ8AJhNGXKFFm9enWkm4Eo88MPP5jXhurevbvMmTNHfvnlF/NaeeWVVyLdPPjxBfWUU06JdFMAeJHs7UoAweVwOGTEiBHy6aefRropiCLffPONOU1KSpIJEyaYlAbE5i8+ACKDEV4gTCpWrGhOp02bJitXrox0cxBFtm7dak6rVKlCsAsAIUDAC4TJXXfdJWlpaeb88OHDI90cRJETJ06Y05SUlEg3BQBiEgEvECa1atWSW2+91Zz/4osv5McffyzScTRXUHMGNXewqLmFGzdudE6MGzdunLlM0yw6d+4slStXlhIlSkizZs3k1VdflaysrDwpGfqTu84y1/3S09PlrLPOktGjR5vrCvMT/mWXXSbVqlWTYsWKSb169eSOO+5wjnT68tNPP8mgQYOkYcOGUrJkSdNePX/77bfLn3/+6fF2+litx63PgQaaL730kpx33nlmBD6QqgCab6v9e9ppp5nnpVSpUtK0aVO55557zH25Y7Xl/fffN//ftGlTnkmOgUxcnDdvnvTv3988t9oeHTk+44wz5P7775dt27YV2P/o0aOmzXqf/fr183n8xYsXO9v4xhtv5Llu//79MnbsWLnuuuukSZMmpo9SU1OlatWq0qVLF3n77bclMzOzyI9N+8if58d10qi7dIKcnBz59ttv5b777pMLLrjAvAb0S0fZsmWlefPm5vLNmzd7bYO3vsvfPn+rNCxatEiuv/56897V94e2p0WLFvLoo4/K7t27C/V4J0+eLB07dpRKlSpJ8eLFzfvkgQcekH379nltg76P7rzzTjn99NPN60L7r3r16uZ5uemmm2TSpEnOL2qALTgAhMy8efM0CjTb2LFjHdu2bXMUL17c/L9z585ub9O/f3/nbdypU6eOuU7388Y6ju6f34YNG/K06/bbb3f+P/92xRVXOE6ePOk4fvy448orr/S43y233OKxLdY+I0aMcIwcOdLjMcqUKeNYuHChx+NkZ2c77rnnHkdCQoLHYyQnJzveeustt7fXx2rtt2zZMkfz5s0L3F7bWFhPPfWUIzEx0WOb0tLSHO+//77H58XbVljHjh1zXHPNNV6PWaJECceMGTMK3Pa6665zXn/48GGv9zNkyBDn87179263r1FvW4sWLRzbt2/3eHxv/aGX+fP8uL7/9Ly343ja0tPTHZ9++mmRbpu/fe3atTOX6amn17f1vHp7j8yePdvn4507d66zP91t9evX9/j8T5482ZGamurzsa1evdrr8w9EEwJeIIwBrxo2bJjzsu+++y7iAe+5555rTrt162b+sK9YscIxffp05+W6jRkzxnHnnXea83379nV88cUXZr+JEyc6GjVq5Nxv1qxZbttiXd+yZUtz2rBhQ8e7775rgs5vvvnGcdtttzkDxtKlSzs2b97s9jiDBw92Hqtt27aO9957zzF//nzHjz/+aNrYtGlT5/WfffaZ14D3zDPPNIHzDTfc4Jg5c6Z5PNOmTXN8+eWXjsJ4/fXXncesVKmS4z//+Y9j8eLFjkWLFpngXoNHvU7vS+/HlQYMul1++eVmn+rVqzsvs7bCyMnJcXTv3t3Znh49ejg+/PBDx/fff2/a9PLLLztq165trtOARp9/V9p/1m0/+ugjj/eTlZXlqFy5stlP7y+/mjVrmtfPv//9b/Na0fvRNowfP95xySWXOO/DU+AXroD3kUcecVSrVs28rqznyXr9P/DAA46SJUua2xYrVsyxZs2aPLfduXOnz77L33++At7777/f2d66des6Ro8ebV7b2nb9opeSkuLsu1WrVnl9vK1btzanPXv2dL6v9bXt+vrQL0b57dixw/ma1T5+/PHHTYD9008/medHv7jddNNNjvLlyxPwwlYIeIEwB7z6h9L6g9KhQ4eIB7y6DR06tMA+R44ccd5XhQoVTMD20ksvFdhPR4lKlSpl9rvsssvctsX1vs466yzHoUOHCuzzwQcfOPe56qqrClyvf3St69955x2Po5sXXXSR83FrYOYp4PV2HH/t2rXLjABaAY+7QF0DBau/a9So4cjMzCxUXxXG22+/bY6jgZGnLx/79u1zfjG44IILChXIuguMJ0yYUOD6P//802s79YuKdXv9whOpgFffB+76w7JlyxbTZ3p7HS11pzB95y3g/eWXX5xf+k4//XTH/v373T7v1j6tWrXy+nh1e+KJJ9x+KdJfl6zReX0Nu9Ivov6M4B49etRsgF2QwwuEmea+ar6qlWepW6Rzi5977rkCl2vep+aAqr1798q5554rd999d4H9NC+zV69e5vx3333n8/40f1NzOvPTnMWuXbs6K1ns2LEjz/XPPPOMOe3du7cMHDjQ7bE13/G1115z5lR6e24vuugij8fxl+apau6reuGFF8xzmZ/mXj788MPmvOYoT58+XUJBY8Rnn33WOUHykksucbtfuXLl5Pnnnzfnv//+e1m3bp3zuuTkZOfiKLNnzzb97s5HH31kTrUfL7/88gLXax6zNzfeeKPJBVWhej78oTmy3iYK1qxZ0+Q8qxkzZhQqT72w3nzzTZNTrN555x2Tt5uf9qnmzyqdA6CLlHhy9tlny7/+9a8Cl2t+77Bhw8z5kydPmlxsV9b7Tl8nmr/rieYD6wbYBQEvEAH6R1QngqjHHnssom254oorPP7R14lrFm+rxFn76WSlAwcOeNxPJ03pH2JPrD/m+ofYdZLRwYMHnf+/8sorvT6exo0bO0vA5f9j7sqfiVn+1s/V4ESfR09uvvnmArcJtjVr1sj69ev9eo7atm3rPJ//ObKeF52sqBOe8jt27JgzSNVlj/WLkTcaJGoQpZOgfv31V+dWo0YNc/3PP/8s0UJfZxs2bJDffvvN2U7r8VnXhYr1utCJjvrl0pNbbrmlwG3c6du3r8dJfa7vwb///jvPdTqR1Hovf/bZZ4V4BEB0I+AFIqBChQpmGVlrlO3rr7+OWFsaNGjg8TrXUSZ/9/O2LO4555zjtS2tWrVynnddkU7rFlujX7oEr7vZ8K7bnj17zL75R4ldnXnmmRIoDYiUVqrwNlKo9XWtahnWbYJt+fLlzvPnn3++1+fHdYQ9/3Okwdapp56aZyTXlY50Hj582OeXhpkzZ8qll14qZcqUMUGUVgfQLzzWptcrq68iRX8J0GoE2j/aVq1qoSObVjutyiqhbKtWO7BG2r0Fu9YvBtZrzdtrqVGjRh6vK1++vMf3q1ZPsd7P+suN/hLy4osvyooVKyQ7O9vPRwREHwJeIEL0Z0XrD4uuvhYp3kboEhMTC72ftz+Kms7hjQaGFteySbt27ZKisNIN3NGfbANltdHX47JSP1xvE2zBfI6sQFaXPM5fUs0KgvUxX3zxxW5HdHVEW4NdDWq9fQGyRowjZdasWaZsmqbBaODrS6jaqqOpFl+vJQ129Quzr9dSUd+vemz9UqMj8NqXmhakn1UtW7Y0gbL+kqFlFQG7YWlhIEI02NU/JLoIxdKlS80fEQ0SYllR68q6/lF+6623pHXr1n7dzltQq8v4Bksg9XKDxfU5+vzzz93WX3bHXYClAe/jjz9uAp6PP/7YmYOsAZb1a4SmuGjOb37vvfeevPvuu+a85unqLxk6aqkBlAZh1vN+ww03yIcffhjSvFhvdLRWf/bXgF9HvLXmrtYI1tFtHenVurNK6/RqHVsVjrZGw2upTZs28tdff8knn3wiX375pSxcuFD++ecfk9ah+fW66XOltbt9pbQA0YKAF4ggDQZefvllMzlIR3n9CXit0RnrJ35Pjhw5ItFm586dfl/v+rOrNaKl9A+st8k04aRt3L59u8/H5Zo64Pq4gsn1OdIvU4E8R5q+oiN6miahC41YAe/UqVOdC0Z4SmcYM2aMOa1fv74ZIfY0sSmQkW7XEUp9H7j+39/3gD4WK99cAzh3o9WBttNfrl/MfL2WNL/dmkwYqteSNQFU+9jqZ81f1hF7XYxG87H1i88jjzxi0h0AOyClAYggnbhmzQLX1cP0D68/t8n/M6g73lYcixRvs8rzX+8asOlIoTXypTnP0cJqo/adBiLe0g2sn8xDFaxrbqclGM+RFehonugvv/ySJ51BR0E95ZrqhC8rF9RTsKsjpfqcFZX1HvD1PvD2HrDaqUGjp2A3f250qEZkdclxq7KF/trjjeazW6sfhvOLX926dU11GX2PavUK5W5SIxCtCHiBCNM/ItbPyjrK6+tnU/3DozRg8LSv/jG3gpRoohPR9A+2J/pzuNKfvV2XX9VlUXX5X6Ujjt6WVw0nK1DSkUL9edcT/Ynf6itvwVUgdOKcFYho6bfjx48HdLxrrrnGmX6gga7+pG2VnfM2Wc0K/L2Nrursfx0ZLyrrPeArIJ04caLPdurz5OnXEk130LQLXyOhKtBldq3Xhb53vS07riXL8t8mnHSJamvyaaQnHAKFQcALRFiJEiXkwQcfdAaEmjPnTbt27czptm3bTH5lfjpJKND6sqGks97dBUMayFqPXctdWeWRLI8++qg51TxCLbvlrfyZBh+vv/56wEGfL1pP1sphvPfee02d3fy07NZTTz1lzmseqz62UNCf9a26q1pqSnNkvQVh+jxaNYs9TbLTGfpKX2faP1bQ7i3gtUYqNY/YXTqAlk4bMmSIBEJzuK38Yf1J3d0XP6017C1wtNqpQa27kUrNidbJd/o+88Z6neoovq8Jet7cfvvtztQMfY9o/+SntZGt/GitaOKr6klRaKqCty8jGRkZzufV9YsHEPUivfIFEG8rrbmjKxbpEqf516p3R1dG0uV3rSVPR40a5ViyZIlj6dKljjfeeMNRv359c3mLFi38WmnNW7t8rVTlbgUzPbavpYV1OWK9zfLlyx1z58513H777c4VpHTVNnfHUHfffbfzWFWrVjVL9+pKXStXrjRL+Y4bN84xcOBAR7ly5cw++Vd089XOonBdWrhKlSqOF1980fSFLsOqfWMtT+tuaeFgr7Smq2j16tXL2Z5TTz3V8dxzz5nll/U5WrBggeOtt95yXHvttWb1N11Bzxt9Pq1jlS1b1tmH3jz//PPO2zRo0MCs3KXPh963rpBWpkwZ8/rUFfe8PWZvK60pfQzWPpdeeqlZhUxXtdNlgXv37p1neV13r19dRS0tLc35PnrwwQfNa0mXQdbHffbZZztXo/P2HpgzZ47zel12W5dwXrdunXMr6tLC2ne6cp62R/vv3nvvzbO0sPZnUd+v3p5ffS3q/ehS47qyoj4n+rxq/+lrvXHjxs7b6msdsAsCXiAKAl716quv+hXwqsmTJzuSkpIK7K9b8eLFHVOmTPF7aeFwBrz6x9V1Wdj8mwby+sfdW0CnQaQuierpGNamAV3+pU9DEfCqJ5980hmwu9s0sHr//fc93j5YAa/SpXL1C4QG2L6eo7p163o91sGDB83ryfU2voIcvX9r6VpPr099/fp6zL4C3h07djhOO+00j/dzzTXXmGDN2+tXlzj21m99+vTxeYzs7GzHeeed5/EYhQl49ViDBw/22mf6heHrr792e/tgBby+Xje6DRo0yLQXsAtSGoAooSsouVua1p2rrrrKzIDXwvCa36ollPS2uhSwTirxtdJWJI0cOVK++uor6d69u6m7q23XElqDBw82+YtWyoanCUJaxk0nIz3wwAPO2qCaa6oTmbSmqv7c/v7775ufZcO19KmmEmhusvahTujS+9VUFV31TZdj/uOPP0yKQThondY33njDpFLoggq6eIKW2dLnSE91AqCmvGiVgt9//93rsfQ57dGjh/P/egzN7fV1/zqb/5VXXjH9oykf+nxo1YZBgwaZ3HN9/QZKXzs6wUvTgTQ9QSd+6WtBV5EbP368ScPwVXpOU1I0L1nTTPR9pG3XFAVdwnfSpEkmB9jXMTQNQVMNNOVGVxzUEmdFncimx9JUHC0Dpq/j2rVrm8elebPab/o60wUqOnfuLKGiKSL6/Omqh9p/moaj71HtQ63eoZ8x+pzpUsieqmMA0ShBo95INwIAAAAIFb6eAQAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAACCmEfACAAAgphHwAgAAIKYR8AIAAEBi2f8BrJ0GirgU1KkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "Y_np = Y.cpu().numpy()\n",
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "ax.plot(np.minimum.accumulate(Y_np), color=\"b\", label=\"SAASBO\")\n",
+    "ax.plot([0, len(Y_np)], [0.398, 0.398], \"--\", c=\"g\", lw=3, label=\"Optimal value\")\n",
+    "ax.grid(True)\n",
+    "ax.set_title(f\"Branin, D = {DIM}\", fontsize=20)\n",
+    "ax.set_xlabel(\"Number of evaluations\", fontsize=20)\n",
+    "ax.set_xlim([0, len(Y_np)])\n",
+    "ax.set_ylabel(\"Best value found\", fontsize=20)\n",
+    "ax.set_ylim([0, 8])\n",
+    "ax.legend(fontsize=18)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8883d412",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "d81134ff-cec6-45cb-92bf-4170f428af40",
+    "papermill": {
+     "duration": 0.017598,
+     "end_time": "2026-01-08T16:46:55.013068",
+     "exception": false,
+     "start_time": "2026-01-08T16:46:54.995470",
+     "status": "completed"
+    },
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "## Predict on some test points\n",
+    "We fit a model using the 50 datapoints collected by SAASBO and predict on 50 test \n",
+    "points in order to see how well the SAAS model predicts out-of-sample.\n",
+    "The plot shows the mean and a 95% confidence interval for each test point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c00275a9",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:46:55.036424Z",
+     "iopub.status.busy": "2026-01-08T16:46:55.036246Z",
+     "iopub.status.idle": "2026-01-08T16:47:17.790284Z",
+     "shell.execute_reply": "2026-01-08T16:47:17.789927Z"
+    },
+    "executionStartTime": 1668655622271,
+    "executionStopTime": 1668655822584,
+    "hidden_ranges": [],
+    "originalKey": "970977ea-ee5e-46eb-b500-683673ce723e",
+    "papermill": {
+     "duration": 22.769638,
+     "end_time": "2026-01-08T16:47:17.791324",
+     "exception": false,
+     "start_time": "2026-01-08T16:46:55.021686",
+     "status": "completed"
+    },
+    "requestMsgId": "2ae0c053-022f-4902-8bc5-b904bd85f90d",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "n_train_pred = 10 if SMOKE_TEST else 50\n",
+    "n_test_pred = 10 if SMOKE_TEST else 50\n",
+    "train_X = SobolEngine(dimension=DIM, scramble=True, seed=0).draw(n_train_pred).to(**tkwargs)\n",
+    "test_X = SobolEngine(dimension=DIM, scramble=True, seed=1).draw(n_test_pred).to(**tkwargs)\n",
+    "train_Y = branin_emb(train_X).unsqueeze(-1)\n",
+    "test_Y = branin_emb(test_X).unsqueeze(-1)\n",
+    "\n",
+    "gp = SaasFullyBayesianSingleTaskGP(\n",
+    "    train_X=train_X,\n",
+    "    train_Y=train_Y,\n",
+    "    train_Yvar=torch.full_like(train_Y, 1e-6),\n",
+    "    outcome_transform=Standardize(m=1),\n",
+    ")\n",
+    "fit_fully_bayesian_model_nuts(\n",
+    "    gp,\n",
+    "    warmup_steps=WARMUP_STEPS,\n",
+    "    num_samples=NUM_SAMPLES,\n",
+    "    thinning=THINNING,\n",
+    "    disable_progbar=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cb3b298f",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:47:17.835298Z",
+     "iopub.status.busy": "2026-01-08T16:47:17.835154Z",
+     "iopub.status.idle": "2026-01-08T16:47:17.843981Z",
+     "shell.execute_reply": "2026-01-08T16:47:17.843603Z"
+    },
+    "executionStartTime": 1668655921184,
+    "executionStopTime": 1668655921625,
+    "hidden_ranges": [],
+    "originalKey": "25139c91-a34c-4fa8-808f-70c1cf6952fd",
+    "papermill": {
+     "duration": 0.026117,
+     "end_time": "2026-01-08T16:47:17.844955",
+     "exception": false,
+     "start_time": "2026-01-08T16:47:17.818838",
+     "status": "completed"
+    },
+    "requestMsgId": "ad9413e7-09aa-47f5-b435-bf37cf0180d1",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    posterior = gp.posterior(test_X)\n",
+    "median = posterior.quantile(value=torch.tensor([0.5], **tkwargs))\n",
+    "q1 = posterior.quantile(value=torch.tensor([0.025], **tkwargs))\n",
+    "q2 = posterior.quantile(value=torch.tensor([0.975], **tkwargs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f21ff6c5",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:47:17.874960Z",
+     "iopub.status.busy": "2026-01-08T16:47:17.874777Z",
+     "iopub.status.idle": "2026-01-08T16:47:17.930961Z",
+     "shell.execute_reply": "2026-01-08T16:47:17.930629Z"
+    },
+    "executionStartTime": 1668655923525,
+    "executionStopTime": 1668655923743,
+    "hidden_ranges": [],
+    "originalKey": "39163b27-e252-4244-9712-f52503e00f74",
+    "papermill": {
+     "duration": 0.070137,
+     "end_time": "2026-01-08T16:47:17.931765",
+     "exception": false,
+     "start_time": "2026-01-08T16:47:17.861628",
+     "status": "completed"
+    },
+    "requestMsgId": "7c819fcc-5f74-48b1-9fd4-286839fdd0b6",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAicAAAIgCAYAAABeVcllAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbyFJREFUeJzt3Qd4U2X7BvCnLWWPAmUqG5RpQZQlewqIIqhQoCLg+BRQhvKJIoKKIP5VUBEcDG0pSxEoU6AM2XspskRAdhkFiqyS/3W//U5M0jRJm7TJOef+XVdMm5w2OZamd973eZ83yGKxWISIiIgoQAT7+wkQERER2WI4ISIiooDCcEJEREQBheGEiIiIAgrDCREREQUUhhMiIiIKKAwnREREFFAYToiIiCigMJwQERFRQGE4ISIiooCiy3CSnJws77zzjpQrV05y5colFSpUkPfff19sO/Hj4+HDh0uJEiXUMS1btpRDhw759XkTERGRQcPJRx99JBMnTpQvv/xS9u/frz4fO3asfPHFF9Zj8Pnnn38ukyZNks2bN0uePHmkTZs2cuPGDb8+dyIiInItSI8b/z322GNSrFgxmTx5svW2zp07qxGSmJgYNWpSsmRJGTx4sLz++uvq/sTERPU106ZNk65du/rx2RMREZEr2USHGjRoIN98840cPHhQ7rvvPtm9e7esW7dOPv30U3X/0aNH5cyZM2oqR1OgQAGpW7eubNy40Wk4uXnzprpo7t69KxcvXpTChQtLUFBQFp0ZERGRPmFg4OrVq2pwIDg42Hzh5M0335QrV65I5cqVJSQkRNWgjBo1Srp3767uRzABjJTYwufafY5Gjx4tI0eOzIJnT0REZFwnTpyQe++913zhZPbs2TJ9+nSJjY2VatWqya5du2TAgAEqrfXs2TND33Po0KEyaNAg6+eYBipdurQanSlUqJAY1e3bt2XVqlXSrFkzCQ0NFSMywzkCz9NYzHCeZjhHI5/nlSsiTz0VIjt2pIySFCyYKJculZZ8+fJ5/b11GU7eeOMNNXqiTc/UqFFDjh07pkY/EE6KFy+ubj979qxaraPB5zVr1nT6PXPkyKEujhBMMLVj5F+a3Llzq3M00i+N2c4ReJ7GYobzNMM5GvU8LRYEE5EdO1I+Dw8X+emn29KkifikFEKXq3WuX7+eaj4L0zuoEwEsMUZAWblypfV+TANh1U79+vWz/PkSEREZSVCQyLBhIjlzpgST+HiRatV89/11OXLSoUMHVWOCaRdM6+zcuVMVw/bu3Vvdj9SGaZ4PPvhAKlWqpMIK+qJg2qdjx47+fvpERES616KFyKJFIkWKYAZD5MIFk4cT9DNB2HjllVfk3LlzKnS89NJLqumaZsiQIZKUlCQvvviiXL58WRo2bChLly6VnIh5RERElC5Y0OpY/dC8uWQKXYYTFNuMGzdOXdKC0ZP33ntPXYiIiCjjEhNFWrcWad9exGYcINPoMpwQERFR1gaTLVtSLnnyiAwenLmPqcuCWCIiIsraYAIofsXnmY3hhIiIiDwKJliVg+LXzMZwQkRERAETTIDhhIiIiAImmADDCREREQVMMAGGEyIiIlLOn8fGff4NJsBwQkRERErFiiKrV4tERPgvmAD7nBAREZHVffelbOjnsIVdluLICRERkYlrTEaMELlzx/52fwYT4MgJERGRyYtf//hDJCZGJFuApAKOnBAREZl8Vc7KlSLHj0vAYDghIiIykcQ0lguXLy8Bg+GEiIjIJBIDpI+JOwwnREREJpCok2ACDCdEREQGl6ijYAIMJ0RERAb3xhv6CSYQIIuGiIiICK5fv64unsqdO7e6uPLRRyLbt6esyAn0YAIMJ0RERAFk//79sh1JwsY///wjFotFgoKCJFeuXHb31a5dW11cKVhQZMUKkdOnRapWlYDHcEJERBRAqlSpImXKlLG7LS4uTgUUBJMOHTrY3eds1AQ1JhaLSFiYfUDBRQ8YToiIiAJIbifTNNmzZ5fbt2+r63AUjXhQ/Ipw8ssv9gFFL1gQS0REZMBVOVu3inTvLrrEcEJERGTQ5cJjxoguMZwQERHpXKLO+pi4w3BCRESkY4kGCybAcEJERBTg7t69Kzdv3lTXRg8mwNU6REREAWr37t0ybtw4iYmJkTt37ki2bNkkPj5eBgwYIOXKRRgymABHToiIiALQjBkzVHM1LZgArvE5bp8/f4aULm28YAIcOSEiIgrAEZOoqChJTk5OdZ8WVHr1ipJNm6pKoUIR0q+fcYIJMJwQEREFmHHjxqlW9a7g/gkTxsnUqVPFaDitQ0REFEDu3r2rpnS0EZK04H4chz13jIbhhIiIKID8888/amWOJ3AcjjcahhMiIqIAkitXLsmRI4dHx+I4x12KjYA1J0RERF64fv26uqQFG/bduHFDEhISJDQ01OnGfraCg4MlMjLSbpWOM1hWjOPc1aboEcMJERGRF/bv3y/bt2+3uw1TLagFQXDImTOnJCYmyoIFC9TnWAaMiysDBgyQ6Ohol8fg++M4I2I4ISIi8kKVKlWkTJkydrfFxcWpgIIpl0cffVTWrl0rjRs3to6cuFO2bISULRstR45EYV0Oyl/tRkwQTBBeIiIixIgYToiIiLzgbJome/bsajoH1+Hh4Wr0BNcIJ+4k/q8l/ZEjkSJSVXLkGCfJyf92iO3Ro4caMTFqMAGGEyIiIh/XnNy6dUuFCVyj1iQ9NSezZ9u2pI+Q+PipsmtXc7l8+bIULFhQhROjYzghIiLycc3J+fPnrTUnqDVJT83J88+L/P23yFdf/duSfs+eYLUyx4jFr84wnBAREfm45mTy5MnWaZjHH388XTUnQUEiI0aIvPKKSLFiYkoMJ0RERF5wNk2D5cAY5cC1u5oT1Jjs3y9Sr559QClm0mACbMJGRETkJ1rxa/PmIqtX+/vZBA6OnBAREWXC/jgohg0JCXEbTLTi1+eeEzl4EHvmuC+wteWuwFaPGE6IiIh8ZPfu3WpHYa27K2pOfv/9d6lVq5bLYBIejt4oWIIssndv2k3dsDx57ty5dvd50tRNbxhOiIiIfAA7BEdFRalaE63tPK5jY2NVWClcuLC631kw0VblpFVg64rRRk2A4YSIiMiLvXNg3759KngkJyenuk8LKr169ZJy5R6QwYMj0gwmRp2mSS+GEyIiIi/2zkGL+mnTpqnPXQuSJ58cJwkJU9MMJqTj1Tply5ZV/yAcL3379lX3oxMfPsYQWt68eaVz585y9uxZfz9tIiLSIUyzdOrUye6SP39+1Zoe1x07dlThBUWwriQn35GEhBnYso/BxIgjJ1u3brUbOsNwWqtWreTpp59Wnw8cOFAWLVokc+bMkQIFCki/fv3UP6b169f78VkTEZER987JkyePWkXjmZtSuPA/Eh+fm8HEaOGkSJEidp+PGTNGKlSoIE2aNFEtgtGZDwVIzbFwXESmTp2qku+mTZuknm2XGxs3b95UF82VK1fUNf7x4WJU2rnxHPWP52ksZjhPPZ8jpnC0C1bkoNmau5ETCAoKlmXLsknlyvjbIoZy24cnFGRxP0kW0JBWS5YsKYMGDZK33npL4uPjpUWLFnLp0iUJCwuzHofKZ+ziiFEVZ0aMGCEjR45MdTtCjtkLk4iIyN6RI0esS4XLlSunygc8+XOKEgQsBTbiHjnXr1+Xbt26qUECTHeZbuTE1rx589ROjc+he42InDlzRg2z2QYTKFasmLovLUOHDlUBx3bkpFSpUtKsWTNVu2JUSLrLly9X02KebOWtR2Y4R+B5GosZzlPP5zhr1ixJSkpSUzr4O+Hp+3wch+ON+Kb3woULPvteug8nmMJp27atGj3xBnZ7xMURfmH09kuTEWY4TzOcI/A8jcUM56nHc7RdjIFRAvz9sC0NSAuOw/FGHDkJ9eHPUJerdTTHjh2TFStWyPPYX/p/ihcvrqZ6MJpiC6t1cB8REZEvod4kMjJSTfG4gvtxnBGDia/pOpyg0LVo0aLSvn17621o4Yv0tnLlSuttBw4ckOPHj0v9+vX99EyJiMjIUNPobmoH9+M4MvC0DqqiEU569uxpl1axdLhPnz6qfqRQoUJq+Kx///4qmKS1UoeIiMgbZctGSNmy0XLkSJRqtiaS0hUW8DdK+5sVERHh1+epF7oNJ5jOwWhI7969U9332WefqWE2VE9jDrBNmzby1Vdf+eV5EhGR8SBs4O8LusNqe+UcORIpIlUlR45xcudOjGq6hmDSvXt3qVmzpnTt2tXfT1s3dBtOWrduneYQWs6cOWXChAnqQkRElJm7DoeFxUtCAqZrIiQ8PELi46fK4sWVVYt7rMpBC4vFixf7+6nriq5rToiIiLJy12HUNWrBBHCdkBCDikfJl2+GtSU9Ru/R1oLFrxnDcEJEROTBiIm267AWTP6Fz5MlKSlK7t7d7adnaCwMJ0RERG5gKsfdKEhwcJA6jrzHcEJEROSm+BVTOqlHTOzhfhyn811hAoJuC2KJiIiyAgpbPen+CjjuxIkTKtAgpOA6ISFBbty4oa7Rh8vZLsdkj+GEiIjIBSwX9rQ9PVbvxMXFqX2DEE5wjY3+rl69qsIJpoZq1arFpqBucFqHiIjIhatXgyVfvki37+exQuehhx5SAUQbHdFGSLhqJ304ckJERJQGrcFaSh+TaJfHIoCMHj1aqlevbnc7Rk/Wrl0rjRs3tk7rkGsMJ0RERC6CyZYt+CxC8uWLVsuFsSrHtjgWUzmYwomOjpamTZum+j4IJ2gOGh4errvdl/2F0zpEREQug4lIeLjI+vWRsmPHdunRo4d1Tzdc4/Pt27erHYfJNzhyQkRE5ODll+2Didb5FSMo2MCvefPmcvnyZSlYsKAKJ+RbHDkhIiJyMHasSIUKjsHEvvgVK3hY6Jo5OHJCRETk4N57RVavFrl8WcShvpWyAMMJERGZHmpMcuTArvb2AQUXynqc1iEiIlPTil87dhS5ccPfz4aA4YSIiEzLdlXOsmUizz/v72dEwHBCRESm5Gy58H//6+9nRcCaEyIiMh1nwcTZqhy4fv26uti6deuWasSGa+yZY4sb+3mP4YSIiEwlPcEE9u/fr5qsOe5UbLuxn63atWurC2UcwwkREZlGeoMJVKlSRcqUKePxY3DUxHsMJ0REZAoZCSbAaZqsx4JYIiIyBWyHo2UMT4MJ+QfDCRERmUKePCILF4o89RSDSaDjtA4REZkqoMyZ4+9nQe5w5ISIiAxbY/LssyJnzvj7mVB6MZwQEZFhi1+jo0WaN2dA0RuGEyIiMvSqnPPnRS5c8PezovRgOCEiIsMvF65Wzd/PjNKD4YSIiEzdx4QCD8MJERHpHoOJsTCcEBGRrjGYGA/DCRER6drXXzOYGA2bsBERka69/rrI4cMiP//MYGIUHDkhIiJdCw4WmTRJZPt2BhOjYDghIiLd1Zj89lvqgFK6tL+eEfkawwkREemu+LVxY5Hdu/39bCizMJwQEZHuVuVcvCjStatIcrK/nxVlBoYTIiLS5XLh2bNFQkL8/cwoMzCcEBFRQGMfE/NhOCEiooDFYGJODCdERBSQGEzMi+GEiIgCzu3bIm3aMJiYFTvEEhGRz12/fl1dXLl9+7bcuHFDEhISpECBApI7d27rfaGhIt26iWzezGBiRgwnRETkc/v375ftaNlq459//hGLxSJBQUGSK1cu9XFiYqIsWLBAHnroIaldu7bd8a++KpIjh0iDBgwmZsNwQkREPlelShUpU6aM3W1xcXEqoCCYdOjQQY2crF27Vho3bqxGTiwWkaAg++/z0ktZ+7wpMLDmhIiIfA5TNOHh4XaX7NmzS7Zs2dS1dlvOnDnV9e3buVXX1/nz/f3MKRDoNpycPHlSevToIYULF1YpvEaNGrJt2zbr/RguHD58uJQoUULd37JlSzl06JBfnzMREaW9KmfdOpGnnsIIi7+fEfmbLsPJpUuX5JFHHpHQ0FBZsmSJ/P777/LJJ59IwYIFrceMHTtWPv/8c5k0aZJs3rxZ8uTJI23atFHFV0REFBiSkrJJu3Yh1lU5YWEiZcv6+1mRv+my5uSjjz6SUqVKydSpU623lStXzm7UZNy4cTJs2DB54okn1G0//PCDFCtWTObNmyddsSEDERFlqbt378rNmzfVaLY2YjJiRAM5dCjlfTJX5ZCuwwkquzEK8vTTT8uaNWvknnvukVdeeUVeeOEFdf/Ro0flzJkzaipHg2KrunXrysaNG52GE/zC4KK5cuWKukbBFi5GpZ0bz1H/eJ7GYqTz3L17t3zxxRcSGxsrd+7cUXUnixevkD17XpNDhx5Ux4SHW2TZsjtSuXJKjxMjMdLP0hVfnl+QBcMMOoMCKhg0aJAKKFu3bpXXXntNTeH07NlTNmzYoKZ9Tp06pWpONM8884xawjZr1qxU33PEiBEycuTIVLfjl8l27T0REXkOq3Ewkq2NnNi/N8afn2jJn7+TvPfeeilb9qrfnid5D31tunXrppaH58+f33zhBJXeWBOPEKJ59dVXVUjByEhGwomzkRNMHZ0+fVoV3Ro56S5fvlxatWqlaniMyAznCDxPYzHCeWLEpF69epKcnOziqBCJjl4vXbqkjKAYkRF+lp64cOGC+pvri3Ciy2kdnHzVqlVTran/6aef1MfFixdX12fPnrULJ/i8Zs2aTr9njhw51MUR/iEZ+R+Tmc7TDOcIPE9j0fN5TpgwQb0hdCU4WGTFionSo8c0MTo9/yw94ctz0+VqHYyKHDhwwO62gwcPWhv+oDgWAWXlypV2IyFYtVO/fv0sf75ERGaDKZwZM2aoGhPXxyXLzJkz1UIGIl2PnAwcOFAaNGggH374oZqq2bJli3zzzTfqAkjqAwYMkA8++EAqVaqkwso777wjJUuWlI4dO/r76RMRGR46wdpOlbuC43A86/tI1+Hk4Ycflp9//lmGDh0q7733ngofKLjq3r279ZghQ4ZIUlKSvPjii3L58mVp2LChLF261FpMS0REmQfLhTFV7klAwXHa8mIi3YYTeOyxx9QlLRg9QXDBhYiIslZwcLB07hwpsbExIpL21E5ISIhq7+CuNoXMRZc1J0REFNjQYG3PngH/Wy6cNtSa9OvXL8ueF+kDwwkREWXKXjn79kWoPiZYLhwSYj9Qj0ZsGDVBfWBEBI4j+hfDCRER+TyYaHvlhIdHypw52yUqqocKJIBrbNy6adMmaYytiImMUnNCRESBHky0vXIi5Kmnpkrz5s3VAgVs0opwguZk2GGeKFPDCZaCbd++Xe1rgza2WLbrbZc4IiLSczCxL5LFyhwWv1KWhJMTJ07IW2+9JXPmzLHb+Act5m07uU6ePFm+/vprtQnfL7/8wn+gREQG8eyzroMJUZaGE3Rdbd++vVy6dMmuw5+z4NGhQwfp27evCjAIJ9hZmIiI9G/0aPw9EME2OggmFSpcl4SE63bH3Lp1S3WMxXVCQoL6W3Djxg31Md60sgkb+SScYO7wiSeekIsXL6o9bNCFtVGjRlIjjbhctGhRadu2rSxYsEAWLVrEcEJEZBAYJEcoQTjBn4Dt2/eraX7HqX+8iUUomTt3rvoYm8ThbwJG2mvXru23508GCieff/65nDt3TsLDw9VuwKVLl3b7NS1btpT58+erlvNERKRPV6+KYKAjJOTf22z3Y8VmrNp+Z2lBSFm7dq1asYOREyKfhJO4uDg1fTNo0CCPgglUq1ZNXR85csSbhyYiIj8Xv953n8i0afYBRYMpGnfTNAgn2FIEb3CNvFsvZXE4OXz4sLpOzzp1LCHTdgkmIiL9rsrBBS/pn3/u72dFRuNVEzYUMkF6Ei824wNu8kREpP/lwi+84O9nRUbk1cgJClz//vtvOXr0qNop2BO7du1S1yVLlvTmoYmIKAPQgwoXT2nTM570MSEKiHBSt25dFU6WLFkizzzzjNvjUZn97bffqjoVrOohIqKstX9/2qto8NrsOKqNFTQVK9ZmMCH9hJPu3bvLjz/+KNOnT5fXXntNatas6fL4wYMHy+7du9UvQM+ePb15aCIiygBnq2iwuAEBBcEE/ahs3bmTm8GE9BVO0OOkWbNmsmrVKmnRooV88MEH0rlzZ+v9aLZz6tQpWb9+vVp2vGHDBhVMOnXqJA0aNPDF8ycionRwtoome/bsauUMrrFyRoOpnPbtGUxIhx1if/rpJxVMdu7cKf369VMXrTtsrVq17I7FsGG9evVkGtaeERFRQMNuJDdvpnzMYEK6Wa0DYWFhqgHb0KFD1SZ/CCDOLhguHDJkiKxevVry5Mnjm2dPRESZBoFkxQo0z2QwIR1u/IehwFGjRqnN/9asWSPbtm1TnWOTk5OlcOHCagQFnWHZAZCISH8BZflyfz8LMhufhBMNRkTatWunLkREpC937oj07ZuyiV/+/P5+NmRmXk/rEBGRvt29e1euX78pmzffla++Enn0UXTx9vezIjPz6cgJERHpp7EaWjuMGzdOYmJi1OrK4GD8SYiX/fsHyMmTERw9IX2Gkx9++MGrB3/22We9+noiIqMGCSztxRYhONZdvV5GGqsdPHhQoqKi1P0IJnD3Lq5j5MqVaNm1K1qqVInM0DkS+TWcPPfcc9Zlw+mFr2M4ISKz8TRI4PPExEQ5cOCA1KlTx6eN1bBpK4IJFi2kdkfu3hV1f9WqVSUiIiLD50rkt2kd/AIREZFnPA0SGDlZu3at3H///T5trAZvvPGG2zeWuB9TPlOnTk3H2REFQDjBhn+e7EKM4cPY2FjV6v6RRx6Rb775JtUvEhGRGXgaJPB5zpw5ff5aieLXGTNmWKdy0oL7cdyUKVMyPEJO5Jdw4pj+04KhwY4dO8rs2bOlW7du0r9/f1nOhfNERFkOIzQ3tbavbuA4HM83k2TopcTYuRgb/mEvnq+//jorH5qIiETU1FGOHDk8OhbHORbTEhmyzwkCCupUuL8OEVHmwfQNRj5wbSs4OFgiIyMlWzbXA+e4H8dxSodM0eekWLFi6hoV6ERE5FuOvUsQMpYujZcePQZI27YpK28GDBgg0dHRLr8P3kTiOCJTjJwcP37cWuxFRES+gwJW9DDRggngOjY2Rtq1qy3jx89Qt2F5MMJJSEhIqhEUfI7bcT+XEZMpwgkCydixY9XHFStWzMqHJiIy/IiJ1rsk9UocfJ4sAwZEya5du9UtmLJBv5UePXpYAwqu8Tlux/1EupzW0UZBXMF856VLl9ROxV9++aXs27dPzWF27drVm4cmIiIbmMpxVx8SEhIk48f/27sEIyP4uHnz5nL58mUpWLCgCidEug4n5cqVS/fXYB6zfv36MnDgQG8emojI0NC2Hu3rExISJDQ01Ce9S5KTnfcuQZEsVuaw+JUMEU7S2x22UKFC8tJLL8mwYcM8XspGRGRGWDRw7NgxWbBggTU0pLVfDlblsHcJGYlX4cSTtsZI5Pny5VOjLNWrV1eFVkRE5Bra1qMLd+PGja0jJ2ntl4ORE7Sk9ySgsHcJGT6coKEaERH5HkY20L4e7ey1cOJqv5ynn45Uq3RSil+dY+8S0ossX0pMRES+N3jwAAkKcj3Vzt4lpBcMJ0REBlCzZoTExERLUFCIhISwdwnpG8MJEZFOOa5J6NYtUnbu3C5RUWn3LsEqIKwAsr3cunVLrfTBteN9OJ4oIGtOevfu7fMHxpzn5MmTff59iYjMIDFRpHNnkREjRBo2/Pd2d71L9u/fr4KKLW0VEOpZ5s6da3cfOs7iQhRw4QSb9PmygEpbCsdwQkSU/s38QkNzSevWIlu2iGzaJLJ0qX1AcdW7pEqVKlKmTBmPH5NLjilgw0np0qVZ3U1EFCCb+aGmJDk5Hlv4Sa5cEVKggKQrbDBwkCHCyV9//ZX5z4SIiFKZOXOm9OrVS71B1DrAotOrCJYNR8vrr0dLjRrcB4eMxas+J0RElHnQhO31119Xm/mllhJU3n47Spo0KZdqM1XHIldbHD2hQMdwQkQUoNAR1t2UOu7/8MMP5bHHHrO7nUWupGcMJ0REAVLoattWHrf9+uuvbjfzw/2//PKLWmDgaW0gR00o0OkynIwYMUJGjhyZah+KP/74Q32MnTwHDx6s5mrxC9+mTRv56quvpFixYn56xkRE7gtd0ZMkPj5edXHFihqMengCr3N58uRh6CDD8Ek4wZzm9OnTZd68eeqXDfObGFJ0xba4KyOqVasmK1assH6uNRyCgQMHyqJFi2TOnDlSoEAB6devn3Tq1EnWr1+f4ccjInIGTcrS06hMq/eYMWOGREVF2b0W4hpBBZ1cMRKCPXU8CSjczI+MxutwcvDgQenYsaPa3hvzm1kFYaR48eKpbk9MTFS/1LGxsaoJEaAhEdb2b9q0SerVq5dlz5GIjM9VUzMED8fQgFoPvH4hmDgrdNWCSp8+feTBBx+UnTt3unwjx838yIi8CidJSUnStm1bVVGOhj9PPPGEFClSRL799lv1izJs2DC5ePGibNu2TTZv3qxuq1+/vrRq1crrJ37o0CEpWbKk2rUT33P06NGqHwteJPBOo2XLltZjK1eurO7buHFjmuEEw6K2241fuXJFXeN7eTq0qkfaufEc9Y/n6R9YJYPXIltLlixRAQXBBK+RtjBq8uqrr3pU6Aru3vTh/r59+wbM/w89/ywzi9nO0xeCLF4Md3zyySfyxhtvqA2lli1bpkYqfvvtN6lRo4b6xbJ9V4D0j3cKqAvBHCumWjIKv/jXrl1TdSanT59W9ScnT56Uffv2qep29ASwDRpQp04dadasmXz00Uce17EARmA4j0tE6XHkyBFrDUmFChXs7kOha5cuXTx6Ice0Tv/+/dVrpuNrKl53tV2GGzdunCnnQZQemN7s1q2bmsHInz+/+C2cNG3aVFWTd+3aVdWcQFrhBM6fP6/2fUBNCkYxfLWUDftHoHjs008/Ve9UMhJOnI2clCpVSoWfwoULi1HhBXL58uVqNAsvhEZkhnMEnmfgmDVrlhpZRpEqgogt3I79bjyF1000wvzyyy/V66wWerp3767e5Ol5l2E9/Cx9wSzneeHCBSlRooRPwolX0zq///67un7yySed3o93CJju0WDKZ9CgQTJkyBD1i4ZaEF8ICwuT++67Tw4fPqx++CjQRWDB7ZqzZ886rVGxLSjDxRH+IRn5H5OZztMM5wg8T//DmzPt4vgc8aKN1xrHN1DO4Gtx/EMPPaT2OGvRooXTzfz0LpB/lr5k9PMM9eG5/ZscMgC/JGC7iZTtH3i8Q3D0yCOPqOs1a9aIr2CKB8OoSGwYjcH/oJUrV1rvR7Hu8ePHVW0KEZE/4Q0bClhtVxg6g/sbNWpkV5uS1mZ+REbjVTjRajFsf1FsRysQCNJy5syZDD8u2jkj3GCoc8OGDWrkBvOv+IXH0mFUuWOEZtWqVapAFtM8CCZcqUNEgQB1Ip4Uunbo0CHLnhORYcJJuXLl1PWpU6est4WHh0uhQoXUx876imhL7rJnz57hx/37779VEEFB7DPPPKNqQrBMGNNG8Nlnn6lWzp07d1aFYpjOcWzfTETkL6gT+frraJS1pppdx4gJ3mxh2lt7jSUyG6/CCeZBAUuFbWFeFKn/448/VkuJNX/++aeMGTNGjbTUrFkzw4+Lzq8IRJizRVDB57YV8VhePGHCBPXYmFpCMHFVb0JElJUwaDJzJnYSxpu1HhIcnM0aTFBLgjdxWGhAZFZeFcSi+BQNzxYsWCDvvfee9Xas4Ud3VoQRFKpilQxCwrp161R9CMLJiy++6IvnT0SkO5gJR+eCzZsjJEeOqTJyZHNJTrYvdMWKB2zFgdWNWqEhdxoms/AqnGDqBNMmWDKMglRt9AJFr8OHD1eBBaMX2pSKNseKGhCshSYiMqsGDUSWLRPJm1dkz55gSUqyL3RFIf+xY8fUmz/tdu40TGbhVThBSl+9enWaTc1Qaf7dd9+p3idI+5UqVZJnn31W1YIQEZlpl2Fsv4NPbRfaaAsI9+xJ/T1QU4fu23gD6MkSTY6akJFk6q7EqD3BhYjIzLsM9+kzQAYPjhA0ch071j6guAobqJ/DIgMj98YgyvJwQkRkFq52GZ42DStzomXLlkjJl09k+HB/P1siA6/WefPNN9V+NkREZh8x0XYZdtxBOOVzbOURJWFhuyWNhtpE5KtwMnbsWLVe/4EHHlAfnzhxwptvR0SkS9rGfK4FSZMm46RGjSx6UkRmDSf4ZUTlOEZPhg4dqhoGNWnSRL799lu5dOmS754lEVEAF79iSsdxxCS1O7J06Qy3nWGJyMtwgpESNFqrVauW+oXDLyl6mfznP/9R+9x07NhR9TvxZIMrIiI9wvJeT1/jcByOJ6JMDCclS5aUwYMHq26G+/fvl2HDhkn58uVVUEGToLi4ONXlsFixYtK7d29ZsWIF3zUQkaFgubCzHc2dwXG2y4uJKBPCieOafDRdO3TokNrnpn///lK0aFEVRq5cuSLff/+9tGnTRu655x5roCEiMtMuwziOOwoTZWE4sVWnTh0ZP368nDx5UpYtW6aq2PPmzauCCnYjRvFY3bp1M+OhiYgCdpdhHEdEfgon1m8eHKz238Goyblz59Q+PGFhYeqXlNM7RGQUWLUYHR2tdhN2HEHRdhnG/TiOiPwcTgDr/hcuXCjPPfecmurBZlZEREaAl7M330Shq6gpG0xXY+M+LaDY7jKM+4nIzx1if/31V4mNjZUff/xRbf4H2mhJqVKl+ItKRLoPJq1bi2zZIvLbbyI//pgygjJ16lRp3ry5XL5sv8swEfkpnOzdu1cFEqz51xqyaYEEv6RPPfWUdO/eXW1kRURkhGACmzahtYJIxYr/TmljZQ6LX4n8FE6OHz+uAgku2H3YNpBg06rHHntMBZJ27dpx8yoiMlwwCQ8XiY//N5gQkZ/DSaNGjWTjxo12Ba54x4AhTQSSzp07Sz7sckVEZOBgwpb0RAEUTtavX2/9+MEHH1SBBE3X0B2WiMhIGEyIdBJO0A22W7duKpSgCRsRkdmCyfXr19XFFjpkY68dXCckJNjdlzt3bnUhokwKJ4cPH/bmy4mIdGHYsLRHTLB1h2PHa+yfg6nu27dvy9y5c+3uq127troQkR+WEhMRGcWHH4rs2iXyxx+pp3KqVKkiZcqUSdf3cxxNcTbSgmBz48YNNSpToEAB35wIkU4wnBARuYG6/sWLRU6eFKlcWbyapsEoiycjLfgcTSsPHDigtgQhMhOGEyIiJzUmt26JFCliH1Acg0lGeDrSgqCydu1a1vORKTGcEBE5KX5FjSumcGwDii94OtKCcIJeUSyeJTPK9L11iIj0uCpn3z6Rrl39/YyIzInhhIgojeXC48b5+1kRmRPDCRGZHhusEQUWhhMiMjUGE6LAw3BCRKbFYEIUmLhah4j8wlnbd1d83fb92jUGE6JAxXBCRH7hqu17UFCQ5MqVK1PbvuPbV62aEk4YTIh0GE6aN2/u8wfGi8/KlSt9/n2JSB+cNSOLi4tTAQXBpEOHDnb3+brfR0iIyHffiYSFifTuzWBCpLtwsnr1ahUm8I4mLbjflnasp7cTkbk4m6bJnj27aj6G63AMZ2QyBJTPPsv0hyGizAgnjRs3dhkmTp06JYcOHVIf47iyZctKsWLF1Odnz56Vv/76yzpUW6lSJSlZsmR6nycRkdfFrz16iIweLVK9ur+fDRH5ZOQkLUuWLJHu3btL/vz55e2335ZevXqleseDXTanTp0qH374oZw/f17GjRsnbdu29eShiYh8uipn8+aU+hIGFCKDLiU+ePCgPPPMM2pUZP369fLGG284HYrFbbgPx+DYLl26qK8lIsrq5cKYWXYxQ01Eeg8nn3zyiSQlJcmQIUOkWrVqbo+vWrWqOvbatWvyf//3f948NBGRW+xjQmTCpcTLly9XdSTpWc3TrFkzdb1ixQpvHpqITNoLBQWzN27cUNPFoaGhaRbZMpgQmTScnD59Ot1foxXWnjlzxpuHJiKT9kLRAgtefxxX+2i9UBhMiEwcTsLCwuTcuXOyZs0aqVu3rqSnuLZAgQLePDQRmbQXyoIFC9TICYrwH3/8cbv7EFYYTIhMXnPSqFEjVeA6ZswYjwpcccxHH32kRk8aNmzozUMTkQkgbKCg3vaCHijBwcHWXii2FxwfF8dgQmTqcDJo0CD1IpGYmCj16tVTS4QvXryY6rhLly7J+PHjpUGDBnL58mUVTgYPHuzNQxMROYVeJh9/zGBCZNppHQSSjz/+WAUNBBRcv/7661KuXDkpWrSoCiFownb06FE1wqJ1hx07dqz6WiKizPD66yK9eokULuzvZ0JEftn4b+DAgaojbP/+/VWnWASQI0eOyJ9//qnut215X6JECfniiy+kU6dO3j4sEZnU3bt35datW+oaUGOya5dIkyb2xzGYEJl8V+Inn3xSHnvsMZk/f75aIrx3717r9E7BggWlRo0a0rJlS+nYsWOqpX9ERIAVOAgdd+7cUddYKmxr37598vXXX8uPP/6ojsmWLZssW7ZK9uwZIAcPRsjcuSLt2/vt6RNRoIUTQOh46qmn1IWIKCPLhjENjBGRK1euyNy5c9UOxRh93bFjh0yfPl0dp42YIKDExsaISLS6vPRSpBw+LJIzp59PhIj8WxAbCLBSCLUtAwYMsN6GZYZ9+/aVwoULS968eaVz587qRY+IAnvZMDYMRYsCXGP6F8uF0a4AwQShRAsm/7ojIskiEiXjxu1mMCEyCJ+HE7x4YDj2+PHjkpyMF43Ms3XrVjXM+8ADD6Sqg4mLi5M5c+aoHiyohWGdC1FgwzJgLA/GdI22TBjXrjYe1YSEBMmiReOy5HkSkU7CCULI5MmTVd8TvMDgXU/58uXlwIEDdsctXLhQ7a0zatQorx8T+/NgN+Rvv/1W1bVosGoIz+XTTz9VbfXRLRI7Im/YsEE2bdrk9eMSUdbBmx28CUk9YmIvOfmOzJgxw64An4hMXHOCIVcUum7evNntCwNW9aCjI6Zh2rdvLzVr1szw42LaBt8DhbYffPCB9Xa0usbeG7hdU7lyZSldurRs3LgxzSXMN2/eVBcN5rwB3wsXo9LOjeeof0Y4T63lAC44D/xOorbEEzgWv7eOLe31ygg/T3fMcI5mPE+/hxOMmHTo0EG9s0EztqeffloaN24s/fr1c3p89erVVZv7LVu2yM8//5zhcDJz5kxVIIfHdYQ9ezAUjHlrWxjNcbWfz+jRo2XkyJGpbl+1apVhXuzcbeJodGY4R72fJ97sIIxgt/PFixerVX8hISEeTRGjKB+/r9r+XUah55+np8xwjmY4z+sOm3T6LZx8//33KiDgRQH7XbRp00bdnlY4AYycYJRl3bp1GXrMEydOyGuvvaZ+yDl9WP02dOhQ1fFWg3dgpUqVUrsoo7DWyEkX/y9btWpl2GXeZjhHo5znrFmzVDBB3RpW68TGxnoUTFCn0q1bNzWaahRG+Hm6Y4ZzNNN5XrhwITDCCeZ48S7lpZdesgYTd2rVqqWuHetRPIVpG7y7evDBB6234cVr7dq18uWXX8qyZctUjwS0ybcdPcFqneLFi6f5fXPkyKEujvAPycj/mMx0nmY4R72fJ15P8IYHdWIYjfV0SgfTQCiE1+t5G/Xn6SkznKMZzjPUh+fmVTjZs2ePunbcGdQVtLX3JmG1aNFCNXmz1atXL1VX8t///leNduB/0MqVK9USYi0IYfVQ/fr1M/SYRJQ1/vrrL5kyZYoKG+6KYLURExwbHR0tERERWfIciSjzeRVOMDoB6Zn20IZoMY+cEfny5VO1K7by5MmjnoN2e58+fdQUTaFChVSfBLTWRzDhfj5EgWn37t1q41BMFXu64gbBpEePHqrHEYMJkbF4FU7wxx9TLKgD0aZr3Dl06JC6LlKkiGSWzz77TA0JY+QEFfyYcvrqq68y7fGIyLvp4aioKPWxp8EEb27QMuDZZ5/N5GdHRLoLJ9WqVVPhBHPEnk7toOAN88oPP/yw+IpjkyYUyk6YMEFdiCjrKvXTU62PVXB4s4Jgkt6GjTje6MsyiczMq3CC/ibx8fGqEBXTKLbN0JzBhl3o3IpwotWDEJFx9sZBwbotbW8c/M7nypXL7j40SMRrR0aW/mpdZInImLwKJy+88IL83//9n5rWad26tZovrlq1aqrjMLoyfvx4+fjjj9ULEWpDnnnmGW8emogCcG+cMmXK2N2GNyMIKAgm6InkOMKJKR1PV+RoMGWLGhOj9TMhIh+FEyy9nT9/vjRt2lS9Y6pRo4bcf//91vtRrIY283/++ae16yMKV3/66Se+sBAZDKZpHBsWYnQD0y/aXjm20M/EtitzejRs2NCr50pEBt9bB+9gUHOC1TAIH3/88YddBf7hw4fVkkDcV6dOHdWArWLFit4+LBHpHEZTnPUWclUEi8vzzz+vehahnxGatdlefNmhkoh0vLcOIGysX79edX1Fp9ht27apqRwUrWGkBCt5UDCL7nhERNr0TNu2kTJvXoyIuJ7awUgrtr7AZp54TUEIQRdndJF1rGPBhYj0zSfhxHaolcOtROSpESMGyIIF0eKu39rw4cOt22JgmggdobGPl2NHSjPsg0VkBj4NJ0RE6Z0WjomJVsuJMTpiWxyLFTmYEkYH6EqVKllrVhBOUEyLz43cCpzIzIK9HZbFC8jvv//u8dccOXLE+nVEZC6JiSJjxojdSElkZKQqqEcBvfa6oHV/ff/991WtGhGZi9cJwdOOjr76OiLSD4x8YEUOil8RTFq3FtmyReTgQZHvvsMbnH9HULDZH2pKsC0GeiYhnEyfPl2t6iEic/Hb8AWXEhMZf6+cmJgYNVWDkZCwsHhJSBiAKCJxcSInTog4tEVRo6pYwcPXByJzy/JwguV+2mZ9RGSsdvS4aHvl2NaQ4DohAatyoiVfvmiJj49MFUzwWFgejGO1ZcKOn2s1Jzdu3FDHFyhQwLcnTUTGCSeevsvB8OwXX3yhPq5QoYIvHpqIAqgdPUZI0t4rJyWoJCVFyd276CQdkerxzp49q6aCtGXC2uMhkGjLhvF5YmKiHDhwgPUoRAaVrnBSvnx5p7ejdb27qnnMO6P3CV548MLm2MqaiPTdjh6jJn379nX7ZiU4OEhN+aDGxPHx9uzZk+b312hLiW27URORicPJX3/9leo2vIs5efJkuh60Xr16MmTIkHR9DREFdjt6vPHwZK8c3I/jpkyZYhdk8Fiuvr9GW0rMniZExpWucNKzZ0+7z7HRH15c0P01LCwsza/DMXgxKVGihDRo0EBV5LPgjUh/NSa2NSA41jYgYMTD071ycByOZ8AgIq/DieMwLMIJjBo1yuluxERkrBqTixcvWmtCcLxtq3htrxxPAgqOc6xZISLySUHsu+++q66LFi3qzbchIp3UmNh+juMdlwGjoZq2fDgtKJrFcRw9JaJMDSdEZI4aE9vPbY9Fg7WQEJEBAwZIdHS0y8fBSAyOIyLKlPb1RERa59d27dAiIEKFk5CQkFRbVOBz3I770RGWiChTwsmGDRvUiw2GeD1ZsYNjUBiLFynHuW0i0k87elyDbUv6X39F0bzrvXJwO+4nIsq0aZ2ZM2eqIdrHHntM7rnnHrfH4xjMW//0008SGxtrV0xHRIHr2LFjandg23b0S5fGy549A2TfvpRREKz8HTHC9V45RESZHk7WrVunitratm3r8de0b99ehRM0USKiwLdlyxYVNFDwatuOPjY2pR09LuHhkRIfL1Kjhv3Xcq8cIsrycHLkyBF1nZ5lxJUrV1bXhw8f9uahiSgLepvg9xTN0jBCqk3l/EtbkRMlEydWlRo1WEdCRAEQTrD5FqCOxFN4FwXcBp3I/wHkt99+UxdbqCnBSAcu8+fPV9cIJ2kJCQmSRYvGyVNP2fdBIiLySzgpVKiQ2i/n+PHjUrNmTY++5u+//1bXrjrKElHWNFfDRXvDoEE9yenTp2XNmjWyc+dOt98/Odl5O3oiIr+EE0znIJwsWLBAtbD3xLx589Q1N+0iCswN/N555x355ptvXI6WOGI7eiIKmKXE7dq1Uy9gP/zwg/yKdYRuoAgWPQ7w7gorfIgosOzbt08FE9SXpCecsB09EQXMyMlLL70kH330kVy4cEEFldGjR8vzzz+fqgYFtSl4wXv77bdVlT+mg15++WVvnzsRZXBa5/z589Y9c+bOnWu9fdq0aen+/mxHT0QBFU7y5s2r+pUgmKDg7rXXXpO33npL9S/BDsSAuett27ap+/FiiBcyzE/nz5/fV+dAROmc1pk8ebK1X0mnTp3UbXv27JHNmzc7WZUjHrWjd1Z4a7uLcUJCgtvv5ep4Z+31iciYvAon0LJlS1m2bJlERUXJqVOn5Nq1a6l6mGjDw2jChmmdpk2bevuwROQhZ3/U0X8EIx24xp45eMOAJmnpCSYINvjd1trRY3QmrcJb7MdjO0IDeFzHAOLqeLzpYeNGInPwOpxAs2bNVM8T1J4sXLhQVfhrLzp4AXrwwQdV0R1e/BxXBhCRf+3evVu9uUjviAl+nzFiou2T42yExpc4akJkHj4JJ4DQ8cILL6gLEenHuHHj0lUvgmMbNmyousba4rQLEfkKdyUmMjGMlmBKR2tL72k4efTRRzP1eRGRufls5ISI9BVKUHSKXcXRo8RTqFHBBoCZOX1DRMRwQmSy+hJM46CINTk5WYUNXDypN8Fx7733nhQpUiRLnisRmZdH4aR8+fLW4Vxtsz/b2zPC8XsRUebSVuRobevB0yJY/L4+++yzUrZsWe6LRUSBEU7++usvde1YNKfdnhFs2ESUtSMm3bt3T1fXV8ffV6zMQQdZIqKACCc9e/ZM1+1EFFiGDx+eoWCCqRz4z3/+o5YMM5wQUcCEE8clg+5uJ6LAgakb9B/yFIpkUY+CJmt169aVxo0bS6VKlVTvInZwJaKswIJYIoNDjUh6GqxNnDhR7YeFUZOrV6+qrz179qzq2MoOrkSUFRhOiMgOQgmaKmIDT4yEIJBgx2F0eXaFoyZE5CsMJ0QGlydPnnQtF0bxK6ZuMLXjiFM3RBQw4cRxIz9fwVw2EWWuq1eDJX/+x+Ty5QVuj61evbqaytGmbjBqglBz5coVNY3DqRsiCphwgl2Efb30V3t3RkSZJzFRpHVrkcuX3xMRFMXedfk7+f7776sN/DSrVq1S9SeY4sEGn7jWCmE5ikJEfp/WyWh/BCLybzDZsgWfRUi+fDGSlGTfhE0LJbig++uZM2fURaMVwOIaQcUWR1GIyK/hxPFFyRaWFA4bNky2bt2q2lo/88wzUqdOHSlWrJi6H1X+uG/27Nly7tw5efjhh2XUqFESGhrqu7MgIjsoF8HefCnBRCQ8XCQ+PlLu3q1q174ey4XRNRYN1rBc+Pr16x4/BkdNiMiv4aRJkyZOb8c7qnbt2sm2bdukT58+6kUPxXeOoqKiZMyYMeoF8LvvvpNPP/1UFi9e7P2zJyKnQkJEXnhBZPNmkcKFEUxEatTAPRGqP1HlypXVaAgCxpAhQ6xfx8BBRIEgpf1jBk2ePFmWLVsmLVu2lG+//dZpMLF90fvmm2+kVatW6mvwcUahD8MDDzwg+fPnV5f69evLkiVLrPdjjrxv375SuHBhyZs3r3Tu3FmN4BAFMoxaoJ7D04u7UY7evUW+/942mNivysmePTu3kSAi4y0lnjZtmnpxe+WVVzz+GoSG5cuXy/fffy8vvvhihh733nvvVSMxGIbG6A2+1xNPPCE7d+6UatWqycCBA2XRokUyZ84cKVCggPTr1086deok69evz9DjEWWF/fv3y/bt2+1u02o+8HuGXiOuaj6crPyVqKjMe75ERAEZTv744w91Xbp0aY+/plSpUnZfmxGOzaBQw4LRlE2bNqngghGd2NhYad68ubofw9hYgYD769Wr5/R73rx5U100WDoJWE6Ji1Fp58Zz9L+KFStKyZIl7W7DiKDWBK1t27apRiO1c0Lxa4cOwVK//r3SqpVn56kVxQb6/xe9/jy9ZYbzNMM5mvE8/R5OMH0CJ06ckFq1ann0NTgWbIOAN1DUhxEStOjG9A7eeeJ/EKaaNJhfR4DauHFjmuFk9OjRMnLkSKfFwGaYh8doltHp8RwvX76sltzj92WLVt3qICkpm4wY0UAOHSooW7Y8KCEh26Rhw1Muvy++H/qX4Fqv9V96/HlmhBnO0wznaIbzvJ6OgvpMDSd4p7d3716ZNGmSPP744x59DY6FChUqePPQ6nERRhCQUFfy888/S9WqVWXXrl1qLj0sLMzueKwesl0i6Wjo0KEyaNAgu5ETjPKgtwNqV4wKQQ6/MKgFMuoKqkA4R/zSpnclDC6zZs1SwRv1XCg+d4QRk3btQuTQoZTysbx5b8nTT1eXWrVquvz+Bw8eVCvt8Lvi7PsGskD4eWYFM5ynGc7RTOd54cKFwAgnWDa8Z88eVeCKuhOswkGTJmfwDm3w4MGydOlSNX/etWtXbx5a7r//fhVEEhMT5ccff5SePXvKmjVrMvz9sJcILo7wD8nI/5jMdJ7+PMfDhw9nqJ5E60GCi+NzRzBp315k69aUz8PDLTJs2HqpVauR3bHOgpHWyh7X+B2ypZfmamb4N2uW8zTDOZrhPEN9eG5ehROMNMTExKj6ka+//lrmzZunAgt6mRQtWlS9oGp9TjD1oo1cIFjYjlJkBN7xYeQG8CKOxxg/frx06dJFvSPEcLjt6AmeR/Hixb16TKKMQs1TmTJl7G6Li4tLc1M9d+HAvsFaSh+TZcvuyIkTV1Mdu3v3blUs7vhOTmtRjx5EtjBFi1FJIiJ/8SqcYJQENRnt27eXHTt2qPDxxRdfuCy+wwvfwoULnY5SeEObP0dQQXpbuXKlWkIMBw4ckOPHj/MFl/zG2WgEAjbCAa7DkS485CyYYLlw5cqo6fL8+WijNkREhtuVGLUcmzdvVrUkWDHz+++/p/nO8eWXX1aXEHSI8gLqQ7ByAUWu2KQMK3NWr16tppewdBgN4TAyU6hQIdUHpX///iqYpFUMS6QXaQUT9DFJq1A+IiJCLbv3lB6mdIjI2LwOJ4Cwgf4luGD0BMWqFy9eVPcVLFhQatSoISVKlBBfQRv8Z599Vk6fPq3CCBqyIZig2Ag+++wz1WQKIycYTWnTpo189dVXPnt8oqyijQhqNSkHDoj89lvqYOKKXmpIiIh8Gk5soa4js2s70MfE3XTThAkT1IVIj1Angu0gUNOFpcTYAyc+Pl5tAbF4cYT07CmyYIH7YEJEZLr29UTkezNmzFC1U1owAVzjc9x+8uQMNYLCYEJERpXNl8PPKI5FozNM7WDpIjq32k7nYBUNXmQxDeTrglgio4yYYKNMNBd0pAUV3I+ePqglISIyIp+MnGD1DZb1tm7dWt59911VGIv9bi5dumR3HHYkzpcvn1pmjMZSRGQPUznuVtDgfhxHRGRUXocT7EaMTff++usvtTQR3VS1ZcOOnn/+eVXAeu3aNdXRlYjsRx8xpaONkKQF9+O4tH7PiIhMHU4OHTqkVugANtnDMmKspEkL+jlgBQ1eVH/55RdvHprIcNCQzdM9p3AcjiciMiKvwgmW7OJdXLVq1dTmYdhgz51GjRqpa8eOlURmh+XCntZi4TjHlvdEREbhVTjB0kbMf2N5I0ZFPKG1nNd2JyaiFFevBku+fJFu69SxrDgyMpLdXYnIsLwKJ3///be6Ts+qAeyu6uutlYmM0vk1IWEANntweSymRfGGgIjIqLwKJ9o7t/QEDW1LZRTGElGKPn20lvQRki9ftAQHh6gRElv4HMvwo6OjuYyYiAzNq3Byzz33qOs///zT469Zt26dui5fvrw3D01kKGPHipQqldKSfv36SNmxY7v06NHDGlBwjc+3b9+upnSIiIzMqyZsTZs2lYMHD6qeJj3RT9uNxMREtUEgRlywuofIzGz3zUFWX71aBO1/Ujq/RsjUqVPV78nly5fVHlUIJ0REZuDVyMlLL72kgsaaNWtk2rRpbqdzOnbsqLrH4l3gf/7zH28emkjXXWC7d+8lvXv3lldffVVd9+rVS65e3Z2qJT02sMTKHBa/EpGZeBVOatWqJa+99poq0OvTp4906dJFZs+ebb1/w4YNEhsbq3qhYJXO2rVr1YvsO++8I2XKlPHF8yfS5b45sbHO983B/UREZuf13jqffPKJGppGy/off/xRXbR3eRhZ0WjdLLHKYNiwYd4+LFGWQcF3eoq+c+fOrS6OuG8OEVEWhRMEkQkTJqgpmzFjxqgpHsylOx5Tv359FUratm3r7UMSZan9+/erQlRb6M6KwI1/247N0DACgoujsWPHSXKyZ/vmoN6EiMisfLYrcatWrdTl6tWrqvsr2tjjHSL22qlZs6aEYxkCkQ5VqVIl1TRkXFycCigIJh06dLC7z9moyaVLKfvmiHi2b86UKVNYZ0JEpuVVOEEhH2A05Omnn1YfY9fhxo0b++bZEQUAZ9M06Ih8+/Ztde0ueKPBWqtWGGlJ3745zkIOEZEZeBVOsIQYUAhLRGl3ft2+HVM/2DfHfUDhvjlEZHZehZMiRYrI+fPnpVixYr57RkQGCyYpnV+xJDhS7tyJkeTktKd20AG2U6dO1k7Kt27dUlM9uE5ISPCo8JaIyNThBKsKUAB77NgxVVdCRPaC/7dYHzM/EycOkK5do10ejyLbChUqyNy5c+0KbzGFpN3mrvCWiMjU4QQdK1evXq2md5544gnfPSsiA8D2UUuXYnmwyKhR6PwaofbFwXJhFLtqy4cBjQkRQr766is1cuIJjpoQkVF51YQNXS1btGgh8+fPlxEjRlh7mRDRvwFlwQKtJb2ofXGwLDmtfXNefPFFVWDryYXhhIiMyquRk19//VVef/11VXfy/vvvy6xZs1Rx7AMPPKD2AsH8uStc1UNGqzEZPFjko49EChdO+zg0WOO+OUREmbjxn20vBmwCiJDiCcdhbSKjFL+iX9uKFa4DCnDfHCKiTGrCxqkcMjv7VTkif/8tcvas+3BCRESZEE5WrVrlzZcT6Ra2aECztNDQXHbBBKty4uOxks3fz5CIyKThpEmTJr57JkQ6gM37sPcNdhHGtGRISDZJTo7HlpYSHh6hgolW/EpERH7eW4fI6LDnjeMy4JSGajEiEi2vvx4tNWpE+vtpEhGZM5wsWrRIli5dqpqvYXO/kiVLquLYZ555RkJDQ33/LIkCYMQEwQT/3lNLCSpvvx0ljz5aVa3GISKiLAonZ8+elY4dO8oWbYLdBnZRHT58uMybN09qcFybAtj169fVxVPoJ4KpHHeranA/jsMyYSIiyoJwgneMjz/+uGzdujXNY44ePSpt2rSRPXv2uN2plchf9u/frxqe2dLaxCNgOG66V6tWLTWl427pO+7HcQjqXB5MRJQF4WT27NkqmOBFF3t/DB06VOrUqaOmcfbu3SuffPKJbNq0SY2u4OPRo0d78bSIvIOREWyed+PGDRUaEhMT5fDhw6oba/bs2eXBBx+0Ox7/thHA8+TJIx06dLC7D6EFK3M8geMQdNi9lYgoi8IJlC1bVk3rhIWFWe+777771HRPy5Yt1UaAc+bMYTghv4+OoIMxQgrCBYLH8ePH1RJgrQEaLhocg2CC4OI46nfp0l3Jnj2H3LrlPqCgqZrjyAsREWVSONm5c6caNRk8eLBdMNGgVf3IkSNVYSymd65evSr58uVL59Mh8o0qVapI0aJFrSMnGBnBiEZCQoK6v0iRItKsWTPr8QjVzqZt0GDt0UcRZCIlJCTmf6tznMOoDPbO4ZQOEVEWhRPsnwMPPfRQmsfY3oc/Agwn5C/atApGTm7fvq1GNBA+tOCA6UjsaWMbrh3DiX3n1wFqubArGH0ZMADHERFRloQTvOvEC3vevHnTPMZ2nh3vWIkCofAVoQE1J5jSQVCBU6dOydy5c63HXrx4UXLmzGkN1I4t6dFgDX1MsFzYcV8ojJjgMaKjo7mMmIgokJuwcc8dCoSpnTJlyqhAsnbtWklKSpK///5b/dtEoOjUqZP12Pnz58u1a9dUgEkdTFJa0qPBGvqY2HaIxffBjsIYMWEwISLyDXaIJcPCSB4uCCcYFcG1Nq2DYlgUvjq2o0fYCAuLl4QETM9E2ASTlO+JAII+Js2bN5fLly+rqSGEEyIi8mM4+eqrr1ShoS+OQ9M2okBqR4/rhISUdvT58kVLfHyk071yEG5Qx+Jp8auzxm+3bt1Sj4drrVDXMVgREZlRusPJxIkTXd6vvVi7Ow4YTshfUHOCXj2u2tEnJUXJ3bvYXjgiUxu/YUTHtv4FateurS5ERGaUzV91JFxuSf6EHiju/g0GB/uuHb1W/+IpjpoQkZl5HE5WrVqVuc+EKJP2y8HIBFaP4YIOrpiSQa1JVraj5zQNEVEmhJMmTZqk49sSZS1X0yYnT55U4XrXrl1qGgfhROsU6w7b0RMRZT2u1iFD7ByMKRPHaZO4uDg1ffP999+rz7VA4mkwAbajJyLKegwnZIidg50VkJ4+fVoFk/SEEVtsR09E5B8MJxSQbAtIEUpQL4KpGVyjZ4ntvjiA27TluFp9x9KlS716DmxHT0TkH7oMJ9jxGEsv//jjD/UOukGDBvLRRx/J/fffbz0Gf8SwSeHMmTNV3UCbNm1U75VixYr59blT+gtIMYKCC1rMYxQE0z2LFy92OYpSq1Yt2bhxY4ZGTdiOnojIv3QZTrCDbN++feXhhx9WKyreeustad26tfz+++9q23sYOHCgLFq0SObMmSMFChSQfv36qXbl69ev9/fTpwyOoqCGBKMoWhjRPu7QoYPd8Qg1uM/dahxbCDlaW3u2oyci8i9dhhPH4fpp06apbrR4d924cWO1ydvkyZMlNjZWtRkH9KrAH7lNmzZJvXr1/PTMyZtRlOzZs6tlwbgG7WO0obeFZcKfffZZuh4DwWT8+PFSqFAhtqMnIvIzXYYTRwgjgD8sgJCCP1wtW7a0HlO5cmUpXbq0Gup3Fk4w9YOL5sqVK+oa30fbydaItHPTwzkiQGgX289tnzum8Xr16uVVEasn/y9sn0ug/L/T08/SGzxP4zDDOZrxPH1B9+EENQUYgn/kkUekevXq6rYzZ86od9RhYWF2x6LeBPelVccycuTIVLejCNMMPS6WL18uge7cuXNqqga7C4P2MepP4OjRo6rOKKOrcxBy8T217+fpc/Hk+Kykh5+lL/A8jcMM52iG87yejvYPhg8nqD3Zt2+frFu3zqvvg31WBg0aZDdyUqpUKbUqpHDhwmLkpItfmFatWkloaKgEslmzZqkwoNUVaR+3a9dOff7888+nq8GaLYy0FClSRPLmzWv9fq56rly4cMFa81KnTp2A6Aarp5+lN3iexmGGczTTeV64cMFn30vX4QRFrgsXLpS1a9fKvffea729ePHiaqdXbGlvO3py9uxZdV9azbZwcYR/SEb+x6Sn80SA0C62n+N5I5AgvKSnCNYWVvcg2Gjfz9bhw4fT7LmCx0OhbiBt2qeHn6Uv8DyNwwznaIbzDPXhuekynOCPQv/+/eXnn3+W1atXS7ly5ezuxx8G/E9auXKldO7cWd124MABOX78uNSvX99Pz5oyE8KCbc1QeiCQaP9OnOGmfUREWSubXqdysBJn/vz5ki9fPmsdCZYMY5gd13369FHTNCiSzZ8/vwozCCZcqWNM+Llj5Cu9AQWjJRMnTlRhFgEHI25aMzfbsOG4IoiIiDKPLsMJ/phA06ZN7W7HcuHnnntOfYylpPjDg3fEtk3YyBgwjYOfq9bz5OrVYMmXL1Ju3oxBqazbr8e/DQRVbak5aoy0lTdo8BdI0zRERGajy3CiLSV1Be3MJ0yYoC5knEDy559/qkZ66FeDeg80TVu6NF727BkgCQloNR/tdgqnd+/eUrFiRVVA6wlO0xARZS1dhhMyFzRVGzdunPzwww+pVuIgoMTGxvwvlERLvnzRkpQUJcHBQXbFsSEhISrUoksw+t3gc07VEBEFJoYTCmgzZsyQqKgo9XHaS4S1EBIlU6Zsl0qVtqswExMTYx1dQedgTOHge3gy8kZERP7DcEIBPWKCYJKcnOzR8SEhQbJo0ThVe4QLwoi2nBxF0VevXlWN2oiIKLAF+/sJEKUFox/paUOfnHxHjbRgZARN0zBqgukbFLlil2qsxNFazmMEBatytIsvOxsSEZF3OHJCAQnhAUEjvU3VsIIHS4L379+vmu7h+2BlDi7ahoGAoGK7KocrcoiIAgfDCRmqqRp6nWB5MRqn7dmzR30frNxCm3vUnaCoVqtDQXGshityiIgCB8MJGaapGgJHZGSkmgpC2MBICaZ0cI2AgtU5Wot6XHO1DhFRYGLNCQUkhAcEDQQOT6GWBDtUExGRvnHkhDKVsx19XbHd0RdBIzradVM1QNEroAPwPffcY20/jykdFMJqBbDYwA9TOvgYK4Cctann9A4Rkf8xnFCmQmFqWjv6YnpFaz/vrDC1bNkIKVs2Wo4cQZ8TrNq54zSYYLlx69at1VJh2yJXLCNG4SsgkJw4ccJaYIvHZ5t6IqLAxHBCmTpKUrRoUWnWrJndbatWrVIjGhil6Nixo9192shFYqJI69YiR45EikhVyZFjnCQn/9tUDZs44lKjRg3p0aOH08e+dOmSJCYmqlGSvXv3qmMRlLQ9eRyfV8GCBX38f4SIiDKC4YSyfJTk4sWLaiQDIcNZUaoWTLZsSfk8PDxC4uOnyq5dKU3VECLw/ZKSkqx9UJxNyRw7dkx27NihHh8hZdeuXapAFl+DgIKQZAujJiySJSLyP4YT8hks3y1TpozdbXFxcSqgIJh06NDB7ra8efN6EExE4uNFatQQ2bMnWK3g8bQxm/Z8EEjWrl2rlhKHhoameTzrTYiIAgPDCfmMs9EL2+W82qiEdptWyOpJMPHm+eCxtKXErsIJEREFBi4lpoDxzz8iV674JpgQEZF+MZxQwChePCWQNGrEYEJEZGac1qEsh2JYbcWMoxIlRNasEUnHfn9ERGQwDCeUZXbv3q12Go6J+XdJ8OjR8TJlygCpVy/CehyDCRGRuXFah7LEhg0b1FJdLZgArvfvj5H69WvLtGkz/P0UiYgoQHDkhDIdOrNOmjRJTeeklhJU+vSJklq1qkpExL8jKBqtwRq6vSLQaF1ftY/Zhp6IyFgYTijTrVy50u0xwcFBaspn6tSpaTZ305q3XblyRdWroLkalgmzDT0RkbEwnFCmQpjYunVrGqMm/8IoyIwZM2TKlCmpmqxpzdScNXRzhqMmRET6xnBCmQp76Gg1Ju5gBQ/CB8KFN7sZExGRvjGcUKavzPEUWtNry4td7dPDqRwiImNjOCGfw/RMVFSUmp7xdNQEy4ojIyOtUzrO9ulxhaMmRETGwXBCPh8xQTBJTk5O19dhRGTAgAHWzzlNQ0RkXgwn5FRGaz4wlePprsHaiAmCSXR0tNNlxEREZD4MJ+SUq5oPhA/H1vOo96hVq5aa0vF0Kge7Evfo0UONmDCYEBGRhuGEnHJW8+FqKS9GTXAfVtx46uuvv5Y+ffr47DkTEZExMJyQU85qPrJnz65WyuA6PDw81ddcunRXgoJyiMVy06PpHKzOISIicsS9dcgnEhNFHn00WCyWSLeZNzg4WOrUqZOu2hQiIjIPjpyYvNAVIyFolIb9aUJDQ1Md78mqGQST1q1FtmzBZ1hxE+32eTRv3jxjJ0BERIbHcGLyQlcUuGLPmlOnTqkRDWeFrq6am9kHE5Hw8Ah5/fVoefvt1H1OtJU5L730kpQqVSozTo+IiAyA4cRkHAtdMXKCLq6oI8EIibNCVw32x0HBqxZgUgcTkfh4kRo1IuXRR6taO8QioCCYaCtz9u3bJ0lJSVl1ykREpDMMJybjOE2DcIIlvQgPaRW62rai14LGsmXxsns3gkaEQzBJ+RosDcYOw02aNJFLly5JgQIF5PHHH1f37dixQ32fW7duqekkV8+PiIjMh+GE0t2KHtezZsVIcjJqS6IlPDzSLpjYQn2LtsRY2w+He+QQEZErDCeUoVb0WlAJCoqSiROrSo0azpuo5c2bV107643iDEdNiIiI4YTS5Ekr+pCQIFm0aJw89dTUNO53PWVERETkiH1OyCkUv3rSih734zhM0xAREfkCwwk5lZ5W9DgOxxMREfkCwwk5hRoRT9vL4zjH/ihEREQZxZoTcgoN2Tp3jpTY2BhM3qR5HOpJIiMjVW2KY/dZwHJhLhsmIqL0YDgha3M126CABmt79rhvRY9aEzRWc9Z9FrhsmIiI0ovhxORLhT/99FOJjY21NleLj4+XPn0GyODBEf9rsIZwEqVW5SQnp25FHx0drRquOes+6w5HTYiIyBmGE5NKq7kausBOm5bSXE0kUjVYQx8TLBd21opeCybAaRoiIvIFhhMT8qS5GkZLwsKqSnx8hGqwhj4m2En48uXLUrBgQRVOiIiIMgNX65iQJ83VRIKkSZNxdi3pUSSLlTnuv5aIiMhk4WTt2rWqFXrJkiXVH8p58+bZ3Y9aiOHDh0uJEiXUEteWLVvKoUOH/PZ89dhcDSt0li5lczUiIsp6ugwnSUlJqtZhwoQJTu8fO3asfP755zJp0iTZvHmz5MmTR9q0aSM3btwQf8NSWyyp9fTiuDTXW2yuRkREgU6XNSdt27ZVF2fwTh/TFsOGDZMnnnhC3fbDDz9IsWLF1AhL165dxZ9cLbfFKJBjMzNfL7fVmqt5ElDYXI2IiPxBl+HElaNHj8qZM2fUVI6mQIECUrduXdm4cWOa4QR/rG3/YF+5ckVdoz8HLr5SsWJFNR1la8mSJSqgIAg4hi6sfvHl40OXLl1k+vRYu6XBjrAiB/+vbKd/EKC0i6+fU2bSnquennNG8DyNxQznaYZzNON5+oLhwgmCCWCkxBY+1+5zZvTo0TJy5MhUt69atSrTl8diBQxCAMLRli1bJLNVrvyQJCdPd1ubUrVqVbvGaadPn1YrfBDcHBuqIczgEsiWL18uZsDzNBYznKcZztEM53ndh2UIgf3XJAsNHTpUBg0aZP0cf4BLlSolzZo1k8KFC2fqY8+aNUvV0aA2pl27dpn6WOj8OmpUiIiEq+XCWJVj255ea6727rvvqhEnBCdNaGiouh/TT7a3Q61atdQlUNM8XhRatWqlzsGoeJ7GYobzNMM5muk8L1y44LPvZbhwUrx4cXV99uxZtVpHg89r1qzpsr7C2UZ3+IeU2f+Y8Mdeu2TmYyGYtG8vsnUrPotUfUwaNfpMliyZnqq5WqVKldKVgjG6FOi/dFnxswwEPE9jMcN5muEczXCeoT48N8OFk3LlyqmAsnLlSmsYwSgIVu28/PLLYlYIJq1bi2izRuHhohqsVa78rYwfX12yZ88uhQoVsmuuxm6vRETkD7oMJ9euXZPDhw/bFcHu2rVL/XEtXbq0euf/wQcfqHf/CCvvvPOOKkLt2LGjmBFalTz5pGMwEdVgDfVLbK5GRESBRJfhZNu2baoWRKPVivTs2VOmTZsmQ4YMUTUcL774oqqNaNiwoSxdulRy5swpZoTMMWyYyKZNInny/BtMiIiIApEuw0nTpk1ddi7FCMB7772nLnqGmo/01n2kNRXTvLnIokUpoyYMJkREFMh0GU7MwpuGbWiG6zhQZDPYREREFLAYTgJYlSpVpEyZMna3xcXFWRu2YX8hW9qoiVb8in5uI0Zk6VMmIiLyGsNJAHM2TYNVNVgzj+twzNG4WJWDC2pM3ngjC580ERGRGTf+I8+XCz/6qL+fFRERUfpw5MTQfUxSF786FtliFAYt6dGE7datW2onZE+LbImIiDIDw4mJgomzIlsU12rBBNeOe+b4eldkIiIidxhOdAYb8mGDQG2lTnqCibMiW4ycrF27Vho3buy09TBHTYiIKKsxnOjE7t27Zdy4cRITE2PdB2fp0njZs2eA7NsX4VEwcTZNg3CC5nQorjXyng9ERKQfDCc6MGPGDImKilK9TRBMANezZsVIcnK0iERLeHgkO78SEZEhcLWODkZMEEy0olVbycn4PFlEomTixN0MJkREZAgMJwEOUznuNuTLli1IFi0al2XPiYiIKDMxnAR48SumdBxHTBzhfhznar8hIiIivWA4CWBoU4+VOZ7AcTieiIhI7xhOAhiWC+fIkcOjY3Gc40aAREREesTVOm5cuHDB7XRJZnVRDQ4Ols6dIyU2NgaTN2keh2XFkZGRbmtTiIiI9IDhxI3Fixer4IEpE4QUBADHEQpvu6g6NlbToMEa+phgqbAreF4DBuA4IiIi/WM4caNdu3ZSqFAhiYuLUwEFAaJDhw52x2R01MRZY7X4+HgVNMqWjVCdX1MarCGcRElISND/lg+nwPEIJtHR0RIRkdKIjYiISO8YTtwoXLiwumTPnl11U8U1uqk647ipnivYw+aVV15J1VgNQQVho2zZaDlyJFLdjgZrEydWVcuFbYNMjx49VJBhMCEiIiNhOPEhx031wNl00IkTJ+TDDz9U0zmOtKBy5EiUiFSV8PCI/3V+jZCnnpoqzZs3l8uXL0vBggVVOCEiIjIahhMfctxUD5xNB/Xv39+D4tUgyZFjnMTHT7Xr/IoiWazMYfErEREZFcOJDzlbteM4HYTRkp9//lm1o3ftjlgsM6R69SkqqBAREZkF+5wEcGO1W7fYWI2IiMyHIycZkJ7C11u3btnVlmiN1TwJKGysRkREZsRwkomFr3Dx4kXJmTOn5MuXz1ozgoZp2qqbtLCxGhERmRXDSSYWvmq3O46SYPkvlgu7wsZqRERkVgwnmVT46ni7LTRYS+ljguXCGBlhYzUiIiINw0kWQ0t6dH5NabBWVS0XTk523ljNWW0LalhwLK4TEhKyZI8fIiKirMRw4odgsmVLyucpDdamyq5dzhuruaptwWgMusz6co8fIiKiQMBwkkVQ+2ofTOR/nV+xuZ/zxmrOaltc4agJEREZAcNJJtN2HM6ZM5cgZyCc2AYTVzhNQ0REZsRw4saFCxfUNIqrWg9n/Uyc7TjcrVu8PPXUABk+PMJtMCEiIjIrhhM3Fi9erEYv0K8E4ePSpUsqcLjqZzJjxgyJiopKteNwbGyMWCzR0qlTtNSokbLjMBEREdljOHGjXbt2UqhQIWsfk6tXr6rlwY79TObPny/Xrl2To0ePyogRI5zunaMFFQSXqlWrcqkwERGREwwnbhQuXFhdtH4l6PCKKRqtn4nj9I0nHV1xDL5m6tSpWXIOREREesKN/7yA6Rss3bVtRY/6FFxcwbH4WnfHERERmRHDSQYdO3ZMTc9g+sbVHjlpwQoe7jhMRESUGsNJBi1dutSrTfm44zAREZFzDCcZgFU7GzduzNCICXDHYSIiorQxnGQACmMzGkyAOw4TERGljeEknZ1eEUrwcUhISIZGTPB13HGYiIgobVxK7MbevXvl+++/V4HCsXcJpmVcrbjRpm1wjOOOw0REROQcw4kbLVq0UNe2rek17pYCoyfKyJEjJX/+/Kl2HCYiIiLnGE7ccBZK3MEoCYILRlvw9UlJSSx+JSIi8hBrTnwAwUMLH9r0zfbt29WKHCIiIkofjpz4gFZT8sknn6h9eDh9Q0RElHEcOfERrOJBjQmnb4iIiLzDcOIjGDkJDQ3199MgIiLSPUOHkwkTJkjZsmUlZ86cUrduXdmyZUumBZMGDRpw1ISIiMgHDBtOZs2aJYMGDZJ3331XduzYoXqLtGnTRs6dO5cpNSf43kREROQ9w4aTTz/9VF544QXp1auXVK1aVSZNmiS5c+eWKVOmZOB/kfP/Tagx0Tq+lilTxifPm4iIyOwMuVrn1q1bainv0KFD7YJEy5Yt1YZ9zqA1PS6axMREdZ0//2Jp0OB7+eWXWXY9T/D9unTpIi+++KLUqFFD5s6dK9evX1dTOxcuXLAeh9tsb8fH//zzj91jX758Wd2GPXsOHjxodx92Lkaoyix4TDwnPDej1syY4RyB52ksZjhPM5yjmc7z4sWLHjUo9YjFgE6ePIn/M5YNGzbY3f7GG29Y6tSp4/Rr3n33XfU1vPDCCy+88MKLZPhy5MgRr/+OG3LkJCMwyoIaFdvRDEzVHD9+XAoUKCBGdeXKFSlVqpScOHFCtdk3IjOcI/A8jcUM52mGczTTeSYmJkrp0qVVvy9vGTKchIeHq1qQs2fP2t2Oz4sXL+70a3LkyKEujhBMjPyPSYNzNPp5muEcgedpLGY4TzOco5nOMzjY+3JWQxbEZs+eXWrXri0rV6603oZ6EXxev359vz43IiIiMuHICWCKpmfPnvLQQw9JnTp1ZNy4cWoDPqzeISIiosBl2HCClTTnz5+X4cOHy5kzZ6RmzZqydOlSKVasmEdfjyke9EhxNtVjJGY4TzOcI/A8jcUM52mGcwSeZ/oFoSo2A19HRERElCkMWXNCRERE+sVwQkRERAGF4YSIiIgCCsMJERERBRSGEycmTJggZcuWlZw5c0rdunVly5Ytomdr166VDh06SMmSJdUeP/PmzbO7HzXRWNVUokQJtZcP9iA6dOiQ6M3o0aPl4Ycflnz58knRokWlY8eOcuDAAbtjbty4IX379pXChQtL3rx5pXPnzqma9QWyiRMnygMPPGBt5oS+PUuWLDHM+aVlzJgx6t/ugAEDDHWuI0aMUOdle6lcubKhzlFz8uRJ6dGjhzoXvM5gT7Jt27YZ6nUIfzccf5644GdolJ9ncnKyvPPOO1KuXDn1c6pQoYK8//77dvvp+ORn6XUDfIOZOXOmJXv27JYpU6ZYfvvtN8sLL7xgCQsLs5w9e9aiV4sXL7a8/fbblrlz56p9D37++We7+8eMGWMpUKCAZd68eZbdu3dbHn/8cUu5cuUs//zzj0VP2rRpY5k6dapl3759ll27dlnatWtnKV26tOXatWvWY/7zn/9YSpUqZVm5cqVl27Ztlnr16lkaNGhg0YsFCxZYFi1aZDl48KDlwIEDlrfeessSGhqqztkI5+fMli1bLGXLlrU88MADltdee816uxHOFXt6VatWzXL69Gnr5fz584Y6R7h48aKlTJkylueee86yefNmy59//mlZtmyZ5fDhw4Z6HTp37pzdz3L58uXqNXfVqlWG+XmOGjXKUrhwYcvChQstR48etcyZM8eSN29ey/jx4336s2Q4cYCNAfv27Wv9PDk52VKyZEnL6NGjLUbgGE7u3r1rKV68uOXjjz+23nb58mVLjhw5LDNmzPDTs/TdCwXOd82aNdbzwh9y/DJp9u/fr47ZuHGjRa8KFixo+e677wx5flevXrVUqlRJvcg3adLEGk6Mcq4IJxEREU7vM8o5wn//+19Lw4YN07zfqK9D+PdaoUIFdX5G+Xm2b9/e0rt3b7vbOnXqZOnevbtPf5ac1rFx69Yt2b59uxqCst0jAJ9v3LhRjOjo0aOqSZ3tOWM/IUxn6f2csQkVaJtQ4WeLrcttzxVD6NioSo/niuHVmTNnqs7HmN4x2vkBhsDbt29vd05gpHPFcDemXMuXLy/du3dXm40a7RwXLFigunU//fTTasq1Vq1a8u233xr6dQh/T2JiYqR3795qascoP88GDRqorWAOHjyoPt+9e7esW7dO2rZt69OfpWE7xGZEQkKCesF37CKLz//44w8xIvwjAmfnrN2nR9hLCfUJjzzyiFSvXl3dhvPBvkthYWG6Pte9e/eqMIL5a8xb//zzz1K1alXZtWuXIc5Pg+C1Y8cO2bp1a6r7jPKzxAv2tGnT5P7775fTp0/LyJEjpVGjRrJv3z7DnCP8+eefql4K24q89dZb6mf66quvqvPDNiNGfB1CbR92t3/uuefU50b5eb755ptql2UEK2ywi7+Zo0aNUsEafPWzZDghQ8I7brzAI9EbDf6QIYhgZOjHH39UL+5r1qwRI8HW8q+99posX75cFaYblfZuE1DojLBSpkwZmT17tiokNAq8WcDIyYcffqg+x8gJfj8nTZqk/v0a0eTJk9XPF6NiRjJ79myZPn26xMbGSrVq1dRrEd4I4jx9+bPktI6N8PBwlQQdq6fxefHixcWItPMy0jn369dPFi5cKKtWrZJ7773XejvOB0OteDej53PFu6+KFSuqnbexQikiIkLGjx9vmPMDDIGfO3dOHnzwQcmWLZu6IIB9/vnn6mO8CzPKudrCu+r77rtPDh8+bKifJ1ZtYHTPVpUqVaxTWEZ7HTp27JisWLFCnn/+eettRvl5vvHGG2r0pGvXrmrFVVRUlAwcOFC9FvnyZ8lw4vCijxd8zKfZJn58jmF0I8JyMPyDsT1nDNlt3rxZd+eMel8EE0xzxMfHq3OzhZ9taGio3bliqTFeIPV2rrbwb/TmzZuGOr8WLVqo6Su8K9MueOeNoWPtY6Ocq61r167JkSNH1B9zI/08Mb3quKwfNQsYJTLa6xBMnTpV1dagXkpjlJ/n9evXVS2mLbypx+uQT3+WPiziNcxSYlQVT5s2zfL7779bXnzxRbWU+MyZMxa9woqHnTt3qgt+5J9++qn6+NixY9ZlXzjH+fPnW/bs2WN54okndLeED15++WW1fG316tV2y/muX79uPQZL+bC8OD4+Xi3lq1+/vrroxZtvvqlWH2EJH35W+DwoKMjyyy+/GOL8XLFdrWOUcx08eLD694qf5/r16y0tW7a0hIeHq5VmRjlHbTl4tmzZ1DLUQ4cOWaZPn27JnTu3JSYmxnqMUV6HsMITPzOsUHJkhJ9nz549Lffcc491KTFaVODf7JAhQ3z6s2Q4ceKLL75Q/4DQ7wRLizdt2mTRM6yxRyhxvOAfmbb065133rEUK1ZMBbMWLVqoHhp64+wccUHvEw1+OV555RW1/BYvjk8++aQKMHqBJXzoF4F/m0WKFFE/Ky2YGOH80hNOjHCuXbp0sZQoUUL9PPGCj89te38Y4Rw1cXFxlurVq6vXmMqVK1u++eYbu/uN8jqE/i143XH23I3w87xy5Yr6PcTfyJw5c1rKly+v+mjdvHnTpz/LIPzHdwM+RERERN5hzQkREREFFIYTIiIiCigMJ0RERBRQGE6IiIgooDCcEBERUUBhOCEiIqKAwnBCREREAYXhhIiIiAIKwwkRUTqsXr1agoKC1AUfE5HvMZwQBaC//vrL+gfQmwsRkR4xnBAREVFAyebvJ0BEqd1zzz2yd+/eNO+vUaOGun7ooYfU9uxEREbCcEIUgEJDQ6V69epuj8uTJ49HxxER6QmndYiIiCigMJwQGUzTpk1VMSyu4dChQ9KvXz+pVKmS5M6dW92HgluYNm2atXhWu81dgS6+xpV58+bJ008/LaVLl5acOXNKWFiYmn4aOXKkXLp0KUPntHbtWuvjf/vtt26PHz16tPX433//3e6+P//8Uz755BPp0KGDlC1bVnLlyqUuZcqUkS5dusjSpUvFl///0zJixAiPCpcTExPV+TzyyCNSpEgRyZ49u5QoUUI9/x9//FEsFotXz5coEHFah8jA5s+fL927d5ekpKRMfywEj6eeekri4+Ptbr9586Zs375dXb766iv1nOrVq5eu792oUSMVdo4fPy6xsbHywgsvuDwex0DNmjWlatWq1tuPHj0qFSpUcPo1+N64zJ49W3r06KFqebJl8+9L5MqVK1VgunDhgt3tZ86ckYULF6pLu3btZNasWZI3b16/PU8iX2M4ITIo/KHFH1mMlrzzzjvqD3xISIhs3brV53/IEEBatmwpO3bsUI/RrVs39UezXLlycvv2bTXy8emnn8q5c+fU7Tt37lQjFZ7C6EJkZKR89NFH6nudPHlSFQ07s2fPHtm3b5/6GMHMVnJyshp5aNOmjbRq1UoFl0KFCsnFixfl4MGDMmHCBPntt98kJiZGypcvr0Z7/GX9+vXStm1b9f+vWLFi0r9/f4mIiJCSJUvKqVOnVCDB81y8eLH07NlTfvrpJ789VyKfsxCR7uBXF5cmTZqkug+3afeXLFnScuzYsTS/z9SpU63HHj16NM3jcJ92HL7G0VtvvaXuCwsLs2zbts3p9/jrr78sJUqUUMd169bNkl579uyxPoePP/44zeP++9//qmOCg4Mtf//9t919165ds5w6dSrNr717967lueeeU1+fJ08ey+XLl1Mds2rVKuvzwMdp/f939rOx9e6771q/j6Nbt25ZypYtq+579NFHLUlJSU6/xzfffGP9Hr/88ovLxyPSE9acEBnYmDFj1HRIZrp27ZoacYD3339fateu7fQ4jJRgBAfmzJmT7qkmLJ/WllBPnz7d6THIbTNmzFAfN2nSJNXoClY3oV7D1QgN6lEw+oPnt2LFCvGHmTNnqjof1Oz88MMPavTLGUxv1alTR33srhaISE8YTogMCtMXKEzNbGvWrFFFm4CaE1caN26srjFVgRqU9NKmaXbt2iX79+9Pdf+6devUdJbtsa7gefz999/qe2EqCBdMmRQuXFjdv3v3bvGHBQsWWAMWimA9+X+6cePGLHluRFmBNSdEBoXVOXjnndm2bdtm/djVqIQjFHWmF+pOhg4dqkZIMHrywQcfOC2EzZEjh3Tu3DnNQPLNN99IdHS0qn25detWmo+XkJAg/qD9P122bJnH2xBk5P8nUaDiyAmRQRUsWDBLHgdFrhlx/fr1dH8NpqhQ2GsbRGxDB6aLoH379moJsyMUvtavX18trd68ebPLYAL//POP+ENG/p/667kSZQaOnBAZFOomsgJWwGiwWgfdbT1x7733ZujxMF2DFTtYFoypDIQNbZRBW3Kb1pTOa6+9Zp1O6tixo/Tu3VseeOABKVq0qBpl0kYpEIJOnDjhtx4i2v9TrNYZO3asX54DkT8xnBCZWHDwv4Ond+/eTfM4V8WrWn0GoD4io6HDU6ijwbJajHpgakcLJ9pISoECBdTIiaMrV66o5bdaeMEy3LRktFmc7f9TV/8/Pfl/itoXnCO3JyAz4rQOkYnly5fPoz/I6AGSllq1atn15siK6SqMKAAapt25c0f9oUdzN60oFzUnjtApF1M/gMZmafnjjz/UCiRv/5+6Czie/D9F7Ym7qSciI2I4ITIxNElzVtjqSFue6wyar2lLXT///PMsmQrRpm3Onz8vy5cvVy3ztRqWtKZ0EGI8GbWYNGmST/6fInxcvXo1zUJbPO+0PP744+oaq6C46zSZEcMJkYlhygAdUuHLL79UnV4dYXRCKzR1BoWnKDCFDRs2yMCBA11OaZw9e1a+++47r5439pXJnz+/+hhTO9qUDvqaYPmtMxUrVrTWlHz//fdOQ1RcXJz6/+AN7fEx4vHFF1+kuh+jN88//7zLAlZ0fC1VqpT6+PXXX1c1Nq5gCTWWdBMZBcMJkYlh75iXXnpJfYweH82bN1fTI1hiiw3w+vTpo5bvNmjQwOX3ee+996Ru3brq4/Hjx8uDDz6oGrNhmgc9SVatWqX+6KMIFcWm3o5OoHi1U6dO6mOMmmijEHiutnU0jnUcaJ0POLfWrVvL3LlzVYHskiVLVGB48sknVdt6d71FXEG9i9aaH03nBg0apMIDRqYQirCvEPqYuNpfCNNSCIW4xhQTfi7YigAb/eH5YgsCfI93331XFfRiBdPevXsz/JyJAo6/W9QSUea0r3fXPl2D1uj16tWzfk/HS9OmTS379u1z2b4erly5YunUqVOa38f20qxZM6//HyxfvjzV9925c6fLrzl+/LildOnSaT4v3Pfbb79ZypQpoz7v2bNnutvXw6+//qra3zt7jJCQEMv48eNdtq/XbNy40VKqVCmP/p9+//33Gfi/SBSYOHJCZHKoF8FOwqNGjVLt4XPlyqWmTB5++GE12oEW7mj77kkhKDaf+/XXX9UoxP33369uw+gMpo7w/fr27as2qnNVb+EpjCbYNn3DJn7YhdgVTJVgufMbb7wh9913nxqZwOoebKiHUQiM8tjuYpxRDRs2VCMcUVFRaqM+LK/Gc0VjOEzRvPrqqx59H4yuoJAXI00YkcH3QudfjBzhXDD6g58binifffZZr583UaAIQkLx95MgIiIi0nDkhIiIiAIKwwkREREFFIYTIiIiCigMJ0RERBRQGE6IiIgooDCcEBERUUBhOCEiIqKAwnBCREREAYXhhIiIiAIKwwkREREFFIYTIiIiCigMJ0RERBRQGE6IiIgooDCcEBERkQSS/weeOH9M701DSQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(1, 1, figsize=(8, 6))\n",
+    "ax.plot([0, 80], [0, 80], \"b--\", lw=2)\n",
+    "\n",
+    "yerr1, yerr2 = median - q1, q2 - median\n",
+    "yerr = torch.cat((yerr1.unsqueeze(0), yerr2.unsqueeze(0)), dim=0).squeeze(-1)\n",
+    "markers, caps, bars = ax.errorbar(\n",
+    "    test_Y.squeeze(-1).cpu().numpy(),\n",
+    "    median.squeeze(-1).cpu().numpy(),\n",
+    "    yerr=yerr.cpu().numpy(),\n",
+    "    fmt=\".\",\n",
+    "    capsize=4,\n",
+    "    elinewidth=2.0,\n",
+    "    ms=14,\n",
+    "    c=\"k\",\n",
+    "    ecolor=\"gray\",\n",
+    ")\n",
+    "ax.set_xlim([0, 80])\n",
+    "ax.set_ylim([0, 80])\n",
+    "[bar.set_alpha(0.8) for bar in bars]\n",
+    "[cap.set_alpha(0.8) for cap in caps]\n",
+    "ax.set_xlabel(\"True value\", fontsize=20)\n",
+    "ax.set_ylabel(\"Predicted value\", fontsize=20)\n",
+    "ax.set_aspect(\"equal\")\n",
+    "ax.grid(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19284b99",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "hidden_ranges": [],
+    "originalKey": "34e976cd-7d09-40d2-8987-aecdefa7c0fd",
+    "papermill": {
+     "duration": 0.019776,
+     "end_time": "2026-01-08T16:47:17.978761",
+     "exception": false,
+     "start_time": "2026-01-08T16:47:17.958985",
+     "status": "completed"
+    },
+    "requestMsgId": "34e976cd-7d09-40d2-8987-aecdefa7c0fd",
+    "showInput": false,
+    "tags": []
+   },
+   "source": [
+    "## Look a the lengthscales from the final model\n",
+    "\n",
+    "As SAASBO places strong priors on the inverse lengthscales, we only expect parameters \n",
+    "0 and 1 to be identified as important by the model since the other parameters have no effect.\n",
+    "We can confirm that this is the case below as the lengthscales of parameters 0 and 1 are \n",
+    "small with all other lengthscales being large."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e8e561a9",
+   "metadata": {
+    "code_folding": [],
+    "customInput": null,
+    "customOutput": null,
+    "execution": {
+     "iopub.execute_input": "2026-01-08T16:47:18.003809Z",
+     "iopub.status.busy": "2026-01-08T16:47:18.003647Z",
+     "iopub.status.idle": "2026-01-08T16:47:18.006614Z",
+     "shell.execute_reply": "2026-01-08T16:47:18.006277Z"
+    },
+    "executionStartTime": 1668655927129,
+    "executionStopTime": 1668655927142,
+    "hidden_ranges": [],
+    "originalKey": "33147b57-ea6b-4c67-9c7d-796bb54d5c84",
+    "papermill": {
+     "duration": 0.01625,
+     "end_time": "2026-01-08T16:47:18.007452",
+     "exception": false,
+     "start_time": "2026-01-08T16:47:17.991202",
+     "status": "completed"
+    },
+    "requestMsgId": "b32e63df-16ee-45f1-af94-7f6f4bb78173",
+    "showInput": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parameter  0) Median lengthscale = 7.48e-01\n",
+      "Parameter  1) Median lengthscale = 2.20e+00\n",
+      "Parameter 27) Median lengthscale = 4.60e+02\n",
+      "Parameter 16) Median lengthscale = 5.25e+02\n",
+      "Parameter 26) Median lengthscale = 5.91e+02\n",
+      "Parameter  4) Median lengthscale = 6.43e+02\n",
+      "Parameter  2) Median lengthscale = 6.53e+02\n",
+      "Parameter 18) Median lengthscale = 6.71e+02\n",
+      "Parameter 29) Median lengthscale = 7.05e+02\n",
+      "Parameter 10) Median lengthscale = 7.09e+02\n"
+     ]
+    }
+   ],
+   "source": [
+    "median_lengthscales = gp.median_lengthscale\n",
+    "for i in median_lengthscales.argsort()[:10]:\n",
+    "    print(f\"Parameter {i:2}) Median lengthscale = {median_lengthscales[i].item():.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e0890ef",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012113,
+     "end_time": "2026-01-08T16:47:18.031271",
+     "exception": false,
+     "start_time": "2026-01-08T16:47:18.019158",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "fileHeader": "",
+  "fileUid": "d9b695e8-72dd-408b-b482-b264b8b50ba8",
+  "isAdHoc": false,
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 243.894431,
+   "end_time": "2026-01-08T16:47:20.664782",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "/Users/saitcakmak/botorch/tutorials/saasbo/saasbo.ipynb",
+   "output_path": "/Users/saitcakmak/botorch/tutorials/saasbo/saasbo.ipynb",
+   "parameters": {},
+   "start_time": "2026-01-08T16:43:16.770351",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Summary:

`botorch.models.fully_bayesian` and `botorch.models.fully_bayesian_multitask` eagerly import JAX and numpyro at module level. When JAX requires NumPy >= 2.0 but the environment has an older NumPy (e.g., pyper Bento kernel with NumPy 1.24), this causes an `ImportError` even for callers that never use fully Bayesian models.

This diff wraps the JAX/numpyro imports in a `try/except` block, deferring the failure to when `AbstractFullyBayesianSingleTaskGP` or `SaasFullyBayesianMultiTaskGP` is actually instantiated. The error message is preserved and clearly states the NumPy >= 2.0 requirement. Since `from __future__ import annotations` is already present, type annotations referencing `jax.Array` remain valid as strings.

Reviewed By: saitcakmak

Differential Revision: D102367287


