### PR TITLE
Handle JAX circular import AttributeError in fully_bayesian.py

### DIFF
--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -47,7 +47,7 @@ try:
     import numpyro.distributions as numpyro_dist
 
     _HAS_JAX = True
-except ImportError:  # pragma: no cover
+except (ImportError, AttributeError):  # pragma: no cover
     _HAS_JAX = False
 import torch
 from botorch.acquisition.objective import PosteriorTransform


### PR DESCRIPTION
Summary: JAX 0.5.3 has a circular import between `pxla.py` and `dispatch.py` that raises `AttributeError` instead of `ImportError` on Python 3.12. The existing `try/except ImportError` guard around JAX imports in `fully_bayesian.py` does not catch this.

Differential Revision: D102690643


