### PR TITLE
Pin numpy<2 in test_stable min-req job for torch <2.4

### DIFF
--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -43,7 +43,7 @@ jobs:
         min_gpytorch_version=$(grep '"gpytorch>=' pyproject.toml | sed 's/.*"gpytorch>=\([^"]*\)".*/\1/')
         min_linear_operator_version=$(grep '"linear_operator>=' pyproject.toml | sed 's/.*"linear_operator>=\([^"]*\)".*/\1/')
         uv pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" ${numpy_constraint}
-        uv pip install .[test]
+        uv pip install .[test] ${numpy_constraint}
     - name: Unit tests and coverage -- BoTorch
       run: |
         pytest -ra test/ --cov botorch/ --cov-report term-missing --cov-report xml:botorch_cov.xml

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -38,9 +38,11 @@ jobs:
         min_torch_version=$(grep '"torch>=' pyproject.toml | sed 's/.*"torch>=\([^"]*\)".*/\1/')
         # The earliest PyTorch version on Python 3.14 available for all OS is 2.9.0.
         min_torch_version="$(if ${{ matrix.python-version == '3.14' }}; then echo "2.9.0"; else echo "${min_torch_version}"; fi)"
+        # Torch <2.4 was built against numpy 1.x and is ABI-incompatible with numpy 2.x.
+        numpy_constraint="$(if ${{ matrix.python-version == '3.14' }}; then echo ""; else echo "numpy<2"; fi)"
         min_gpytorch_version=$(grep '"gpytorch>=' pyproject.toml | sed 's/.*"gpytorch>=\([^"]*\)".*/\1/')
         min_linear_operator_version=$(grep '"linear_operator>=' pyproject.toml | sed 's/.*"linear_operator>=\([^"]*\)".*/\1/')
-        uv pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}"
+        uv pip install "torch==${min_torch_version}" "gpytorch==${min_gpytorch_version}" "linear_operator==${min_linear_operator_version}" ${numpy_constraint}
         uv pip install .[test]
     - name: Unit tests and coverage -- BoTorch
       run: |


### PR DESCRIPTION
The min-req job pins torch to the floor declared in pyproject.toml (2.2), but lets pip resolve numpy unconstrained, which picks up numpy 2.x. Torch <2.4 was built against the numpy 1.x C ABI and fails at import time with "numpy not available" when paired with numpy 2.x. Constrain numpy<2 on the Python 3.11 leg, matching the existing pattern used to override the torch floor on the Python 3.14 leg (which uses torch 2.9 and supports numpy 2.x).

Before: 
https://github.com/meta-pytorch/botorch/actions/runs/26538884146/job/78174986399 fails with Numpy not available.

After:
https://github.com/meta-pytorch/botorch/actions/runs/26543116588