### PR TITLE
Bump minimum torch to 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pyre_extensions",
     "gpytorch>=1.15.2",
     "linear_operator>=0.6.1",
-    "torch>=2.2",
+    "torch>=2.4",
     "jax>=0.4.35,<0.10",
     "jaxlib>=0.4.35,<0.10",
     "numpyro>=0.18.0",


### PR DESCRIPTION
Torch <2.4 was built against the numpy 1.x C ABI and fails at import time when paired with numpy 2.x ('numpy not available'). With modern scipy, jax, and scikit-learn all requiring numpy>=2, capping numpy in the min-req CI job is no longer feasible. Torch 2.4 (Jul 2024) is the first release with stable numpy 2.x ABI support, so bump the floor there.

Before: https://github.com/meta-pytorch/botorch/actions/runs/26538884146/job/78174986399 fails with Numpy not available.

After: https://github.com/meta-pytorch/botorch/actions/runs/26543456932/job/78190062048 the previously failing tests are passing