### PR TITLE
Bump codecov-action to v5 (Node.js 24 support)

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -51,7 +51,7 @@ jobs:
         pytest -ra test_community/ --cov botorch_community/ --cov-report term-missing --cov-report xml:botorch_community_cov.xml
     - name: Upload coverage
       if: ${{ inputs.upload_coverage && runner.os == 'Linux' && matrix.python-version == 3.11 }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
`codecov/codecov-action@v4` runs on the deprecated Node.js 20 runtime, which triggers a CI warning:

> Node.js 20 actions are deprecated. ... Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

This bumps the action to `v5`, which runs on Node.js 24.

## Details
- Only change is `.github/workflows/reusable_test.yml`: `codecov/codecov-action@v4` → `@v5`.
- The inputs used (`token`, `files`, `fail_ci_if_error`) remain valid in v5, so no other changes are required.

## Test plan
- Coverage upload step runs on the next CI run (Linux, Python 3.11) and should no longer emit the Node.js 20 deprecation warning.