### PR TITLE
Extend projection to nonlinear inequality constraints

### DIFF
--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -551,7 +551,7 @@ def _optimize_acqf_batch(
         nonlinear_inequality_constraints=nonlinear_inequality_constraints,
     )
     infeasible = ~is_feasible
-    if nonlinear_inequality_constraints is None and infeasible.any():
+    if infeasible.any():
         # Filter tensor-valued fixed features to match the infeasible subset.
         # This is needed because fixed_features may contain per-element tensor
         # values (e.g., from continuous_step in mixed optimization), and we
@@ -567,6 +567,7 @@ def _optimize_acqf_batch(
             bounds=opt_inputs.bounds,
             equality_constraints=equality_constraints,
             inequality_constraints=inequality_constraints,
+            nonlinear_inequality_constraints=nonlinear_inequality_constraints,
             fixed_features=fixed_features,
         )
         if opt_inputs.post_processing_func is not None:

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -632,11 +632,35 @@ def nonlinear_constraint_is_feasible(
     return is_feasible.view(x.shape[:-2])
 
 
+def _get_f_np_wrapper_for_projection(
+    shapeX: torch.Size, device: torch.device, dtype: torch.dtype
+) -> Callable:
+    """Numpy wrapper for evaluating nonlinear constraints during projection."""
+
+    def f_np_wrapper(
+        x: npt.NDArray,
+        f: Callable,
+    ) -> tuple[float, np.ndarray]:
+        X = (
+            torch.from_numpy(x)
+            .to(device=device, dtype=dtype)
+            .view(shapeX)
+            .contiguous()
+            .requires_grad_(True)
+        )
+        loss = f(X).sum()
+        gradf = _arrayify(torch.autograd.grad(loss, X)[0].contiguous().view(-1))
+        return loss.item(), gradf
+
+    return f_np_wrapper
+
+
 def make_scipy_nonlinear_inequality_constraints(
     nonlinear_inequality_constraints: list[tuple[Callable, bool]],
     f_np_wrapper: Callable,
     x0: Tensor,
     shapeX: torch.Size,
+    validate_feasibility: bool = True,
 ) -> list[dict]:
     r"""Generate Scipy nonlinear inequality constraints from callables.
 
@@ -660,6 +684,9 @@ def make_scipy_nonlinear_inequality_constraints(
         x0: The starting point for SLSQP. We return this starting point in (rare)
             cases where SLSQP fails and thus require it to be feasible.
         shapeX: Shape of the three-dimensional batch X, that should be optimized.
+        validate_feasibility: If True, require that ``x0`` satisfies all nonlinear
+            inequality constraints. Set to False when ``x0`` may be infeasible, e.g.
+            during projection onto the feasible set.
 
     Returns:
         A list of dictionaries containing callables for constraint function
@@ -679,7 +706,7 @@ def make_scipy_nonlinear_inequality_constraints(
                 f"got length {len(constraint)}."
             )
         nlc, is_intrapoint = constraint
-        if not nonlinear_constraint_is_feasible(
+        if validate_feasibility and not nonlinear_constraint_is_feasible(
             nlc, is_intrapoint=is_intrapoint, x=x0.reshape(shapeX)
         ).all():
             raise ValueError(
@@ -789,6 +816,7 @@ def project_to_feasible_space_via_slsqp(
     bounds: Tensor,
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
+    nonlinear_inequality_constraints: list[tuple[Callable, bool]] | None = None,
     fixed_features: dict[int, float | Tensor] | None = None,
 ) -> Tensor:
     """Project X onto the feasible space by solving a quadratic program.
@@ -809,6 +837,9 @@ def project_to_feasible_space_via_slsqp(
             ``coefficients`` should be torch tensors. See the docstring of
             ``make_scipy_linear_constraints`` for an example.
         equality_constraints: A list of tuples (indices, coefficients, rhs).
+        nonlinear_inequality_constraints: A list of tuples representing the nonlinear
+            inequality constraints. See ``make_scipy_nonlinear_inequality_constraints``
+            for the expected format (``callable(x) >= 0``).
         fixed_features: A dictionary mapping feature indices to their fixed values.
             These dimensions will not be modified during projection. Values can be
             scalars (applied to all elements) or 1D tensors matching the batch size
@@ -817,7 +848,11 @@ def project_to_feasible_space_via_slsqp(
     Returns:
         A ``(batch_shape x) n x d``-dim tensor of projected values.
     """
-    if inequality_constraints is None and equality_constraints is None:
+    if (
+        inequality_constraints is None
+        and equality_constraints is None
+        and nonlinear_inequality_constraints is None
+    ):
         return X
 
     d = X.shape[-1]
@@ -841,8 +876,9 @@ def project_to_feasible_space_via_slsqp(
                 ub[flat_idx] = X_fixed_flat[flat_idx]
 
     bounds_scipy = Bounds(lb=lb, ub=ub, keep_feasible=True)
+    shapeX = _validate_linear_constraints_shape_input(X.shape)
     constraints = make_scipy_linear_constraints(
-        shapeX=X.shape,
+        shapeX=shapeX,
         inequality_constraints=inequality_constraints,
         equality_constraints=equality_constraints,
     )
@@ -862,6 +898,18 @@ def project_to_feasible_space_via_slsqp(
         .numpy()
         .flatten()
     )
+    if nonlinear_inequality_constraints:
+        f_np_wrapper = _get_f_np_wrapper_for_projection(
+            shapeX=shapeX, device=X.device, dtype=X.dtype
+        )
+        x0_tensor = torch.from_numpy(x0).to(device=X.device, dtype=X.dtype)
+        constraints += make_scipy_nonlinear_inequality_constraints(
+            nonlinear_inequality_constraints=nonlinear_inequality_constraints,
+            f_np_wrapper=f_np_wrapper,
+            x0=x0_tensor,
+            shapeX=shapeX,
+            validate_feasibility=False,
+        )
     # NOTE: A proper specialized QP solver would be a better choice here,
     # but we'd like to avoid adding dependency on additional packages.
     # SLSQP should be able to solve this reliably and quickly since the

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -706,9 +706,12 @@ def make_scipy_nonlinear_inequality_constraints(
                 f"got length {len(constraint)}."
             )
         nlc, is_intrapoint = constraint
-        if validate_feasibility and not nonlinear_constraint_is_feasible(
-            nlc, is_intrapoint=is_intrapoint, x=x0.reshape(shapeX)
-        ).all():
+        if (
+            validate_feasibility
+            and not nonlinear_constraint_is_feasible(
+                nlc, is_intrapoint=is_intrapoint, x=x0.reshape(shapeX)
+            ).all()
+        ):
             raise ValueError(
                 "`batch_initial_conditions` must satisfy the non-linear inequality "
                 "constraints."

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -1652,13 +1652,14 @@ class TestOptimizeAcqf(BotorchTestCase):
             )
 
     @mock.patch(
-        "botorch.optim.parameter_constraints.project_to_feasible_space_via_slsqp"
+        "botorch.optim.optimize.project_to_feasible_space_via_slsqp",
+        wraps=project_to_feasible_space_via_slsqp,
     )
     @mock.patch("botorch.generation.gen.minimize_with_timeout")
-    def test_optimize_acqf_projection_not_applied_with_nonlinear_constraints(
+    def test_optimize_acqf_projection_applied_with_nonlinear_constraints(
         self, mock_minimize: mock.Mock, mock_project_slsqp: mock.Mock
     ) -> None:
-        """Test that projection is not applied when nonlinear constraints exist."""
+        """Test that projection repairs infeasible candidates with nonlinear constraints."""
         for dtype in (torch.float, torch.double):
             mock_project_slsqp.reset_mock()
             infeasible_candidates = torch.tensor(
@@ -1667,7 +1668,6 @@ class TestOptimizeAcqf(BotorchTestCase):
 
             mock_acq_function, bounds = self._setup_projection_test(d=2, dtype=dtype)
 
-            # Define both linear and nonlinear constraints
             inequality_constraints = [
                 (
                     torch.tensor([0, 1], dtype=torch.long, device=self.device),
@@ -1681,9 +1681,7 @@ class TestOptimizeAcqf(BotorchTestCase):
 
             nonlinear_inequality_constraints = [(callable_constraint, True)]
 
-            # Test that optimization should raise error due to infeasible candidates
-            # when nonlinear constraints are present (projection not applied)
-            self._run_optimize_acqf_with_projection(
+            candidates = self._run_optimize_acqf_with_projection(
                 mock_minimize,
                 mock_acq_function,
                 bounds,
@@ -1691,12 +1689,19 @@ class TestOptimizeAcqf(BotorchTestCase):
                 q=1,
                 inequality_constraints=inequality_constraints,
                 nonlinear_inequality_constraints=nonlinear_inequality_constraints,
-                should_raise_error=True,
-                error_regex="infeasible candidates",
             )
 
-            # Verify that project_to_feasible_space_via_slsqp was NOT called
-            mock_project_slsqp.assert_not_called()
+            def check_inequality_constraint(candidates):
+                for i in range(candidates.shape[0]):
+                    constraint_value = candidates[i, 0] + candidates[i, 1]
+                    self.assertGreaterEqual(constraint_value, 1.5 - 1e-6)
+
+            self._verify_projection_called_and_constraints_satisfied(
+                mock_project_slsqp=mock_project_slsqp,
+                candidates=candidates,
+                bounds=bounds,
+                constraint_checks=[check_inequality_constraint],
+            )
 
     @mock.patch(
         "botorch.optim.optimize.project_to_feasible_space_via_slsqp",

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -1659,7 +1659,7 @@ class TestOptimizeAcqf(BotorchTestCase):
     def test_optimize_acqf_projection_applied_with_nonlinear_constraints(
         self, mock_minimize: mock.Mock, mock_project_slsqp: mock.Mock
     ) -> None:
-        """Test that projection repairs infeasible candidates with nonlinear constraints."""
+        """Test projection repairs infeasible candidates with nonlinear constraints."""
         for dtype in (torch.float, torch.double):
             mock_project_slsqp.reset_mock()
             infeasible_candidates = torch.tensor(

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -1090,6 +1090,63 @@ class TestProjectToFeasibleSpace(BotorchTestCase):
                 self.assertTrue(torch.all(projected[i] >= bounds[0]))
                 self.assertTrue(torch.all(projected[i] <= bounds[1]))
 
+    def test_project_to_feasible_space_via_slsqp_nonlinear(self) -> None:
+        """Project slightly infeasible points onto nonlinear inequality constraints."""
+        for dtype in (torch.float, torch.double):
+            tol = get_constraint_tolerance(dtype=dtype)
+            bounds = torch.tensor(
+                [[0.0, 0.0], [1.0, 1.0]], dtype=dtype, device=self.device
+            )
+
+            def disk(x):
+                return 1 - x.pow(2).sum(dim=-1)
+
+            def half_plane(x):
+                return x[..., 0] + x[..., 1] - 0.5
+
+            nonlinear_inequality_constraints = [(disk, True), (half_plane, True)]
+
+            # Outside the unit disk but within box bounds.
+            X = torch.tensor([[0.85, 0.85]], dtype=dtype, device=self.device)
+            projected = project_to_feasible_space_via_slsqp(
+                X=X,
+                bounds=bounds,
+                nonlinear_inequality_constraints=nonlinear_inequality_constraints,
+            )
+            for nlc, is_intrapoint in nonlinear_inequality_constraints:
+                self.assertTrue(
+                    nonlinear_constraint_is_feasible(
+                        nlc,
+                        is_intrapoint=is_intrapoint,
+                        x=projected.unsqueeze(0),
+                        tolerance=tol,
+                    ).all()
+                )
+            self.assertTrue(torch.all(projected >= bounds[0] - tol))
+            self.assertTrue(torch.all(projected <= bounds[1] + tol))
+
+            # Nonlinear constraints together with linear inequalities.
+            inequality_constraints = [
+                (
+                    torch.tensor([0], dtype=torch.long, device=self.device),
+                    torch.tensor([1.0], dtype=dtype, device=self.device),
+                    0.2,
+                )
+            ]
+            X = torch.tensor([[0.85, 0.85]], dtype=dtype, device=self.device)
+            projected = project_to_feasible_space_via_slsqp(
+                X=X,
+                bounds=bounds,
+                inequality_constraints=inequality_constraints,
+                nonlinear_inequality_constraints=[(disk, True)],
+            )
+            self.assertGreaterEqual(projected[0, 0].item(), 0.2 - tol)
+            self.assertTrue(
+                nonlinear_constraint_is_feasible(
+                    disk, is_intrapoint=True, x=projected.unsqueeze(0), tolerance=tol
+                ).all()
+            )
+
     @mock.patch(
         "botorch.optim.parameter_constraints.minimize",
         return_value=mock.Mock(success=False, message="failed reason"),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Related to #3280.

`gen_candidates_scipy` already supports `nonlinear_inequality_constraints` via `make_scipy_nonlinear_inequality_constraints`, but `project_to_feasible_space_via_slsqp` only handled linear constraints. After optimization, `_optimize_acqf_batch` checks feasibility (including nonlinear inequalities) but previously skipped projection whenever nonlinear constraints were present, so slightly infeasible candidates could remain infeasible or trigger errors.

This PR extends projection to nonlinear inequality constraints using the same SciPy path as `gen_candidates_scipy`, as suggested in the #3280 discussion. 

**Changes:**

### `botorch/optim/parameter_constraints.py`

- Add `nonlinear_inequality_constraints` argument to `project_to_feasible_space_via_slsqp`.
- Build SciPy constraints with `make_scipy_nonlinear_inequality_constraints` (same helper as `gen_candidates_scipy`).
- Add `_get_f_np_wrapper_for_projection` so projection can evaluate constraint values/Jacobians without importing `gen.py` (avoids circular imports).
- Add `validate_feasibility: bool = True` to `make_scipy_nonlinear_inequality_constraints` (default unchanged). Projection passes `validate_feasibility=False` because repair starts from infeasible points; IC validation behavior is unchanged.
- Normalize `shapeX` with `_validate_linear_constraints_shape_input` for consistent `(b, q, d)` handling.

### `botorch/optim/optimize.py`

- Remove the guard that skipped projection when `nonlinear_inequality_constraints is not None`.
- Pass `nonlinear_inequality_constraints` into `project_to_feasible_space_via_slsqp` for infeasible batches.

### Tests

- `test_project_to_feasible_space_via_slsqp_nonlinear`: unit disk + half-plane; slightly infeasible point projected to feasibility; linear + nonlinear combo.
- Update `test_optimize_acqf_projection_applied_with_nonlinear_constraints` to expect projection is applied and linear constraints are repaired.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. First BoTorch contribution — happy to adjust based on review.

## Test Plan

- `pytest test/optim/test_parameter_constraints.py::TestProjectToFeasibleSpace::test_project_to_feasible_space_via_slsqp_nonlinear -v`  
  Unit disk + half-plane; slightly infeasible point projected to feasibility; linear + nonlinear combo.

- `pytest test/optim/test_parameter_constraints.py test/optim/test_optimize.py -v`  
  Broader regression (75 passed locally).

- `test_optimize_acqf_projection_applied_with_nonlinear_constraints`: projection runs when nonlinear constraints are present; linear inequalities repaired.

- Compared pytest warnings with/without this diff on the above test files: **117 warnings, unchanged** (no new warnings from these changes; existing RuntimeWarnings from retry/IC mocks, etc.).

## Notes for reviewers

- Convention unchanged: nonlinear inequalities are `callable(x) >= 0`, with the same `(callable, is_intrapoint)` tuple format as `optimize_acqf`.
- Projection objective remains minimum-distance (`½‖x - x₀‖²`) with SLSQP, consistent with existing linear repair.


## Related PRs

N/A

----
/cc @esantorella @jduerholt FYI for the discussion in #3280 