### PR TITLE
Add missing copyright header to test_latent_information_gain.py

### DIFF
--- a/test_community/acquisition/test_latent_information_gain.py
+++ b/test_community/acquisition/test_latent_information_gain.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import torch


### PR DESCRIPTION
Summary: The first 16 lines of `test_community/acquisition/test_latent_information_gain.py` were missing the standard BoTorch copyright/license header. This adds the standard MIT license header matching the source of truth in `//pytorch/botorch` and other files in `test_community/`.

Differential Revision: D107668165


