### PR TITLE
Make JAX/jaxlib/NumPyro optional dependencies (#3319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The release log for BoTorch.
 
+## [0.18.1] -- Jun 8, 2026
+
+* Make JAX/jaxlib/NumPyro optional dependencies, only required for fitting
+  fully Bayesian models via the `botorch[fully_bayesian]` extra (#3319).
+
+
 ## [0.18.0] -- Jun 3, 2026
 
 #### Compatibility

--- a/botorch/models/fully_bayesian.py
+++ b/botorch/models/fully_bayesian.py
@@ -90,10 +90,9 @@ _sqrt5 = math.sqrt(5)
 def _check_jax_available() -> None:
     if not _HAS_JAX:
         raise ImportError(
-            "BoTorch's fully Bayesian models require JAX, numpyro, and "
-            "NumPy >= 2.0 (python-scientific-stack version 3). "
-            "Please update your PACKAGE file to set "
-            '"python-scientific-stack": "3".'
+            "BoTorch's fully Bayesian models require JAX, jaxlib, and NumPyro, "
+            "which are optional dependencies. Please install them with "
+            '`pip install "botorch[fully_bayesian]"`.'
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ dependencies = [
     "gpytorch>=1.15.2",
     "linear_operator>=0.6.1",
     "torch>=2.4",
-    "jax>=0.4.35,<0.10",
-    "jaxlib>=0.4.35,<0.10",
-    "numpyro>=0.18.0",
     "scipy",
     "multipledispatch",
     "threadpoolctl",
@@ -40,7 +37,16 @@ pymoo = [
     "pymoo",
 ]
 
+# JAX/NumPyro are only needed to fit fully Bayesian models (e.g.
+# ``SaasFullyBayesianSingleTaskGP``), which run NUTS via NumPyro.
+fully_bayesian = [
+    "jax>=0.4.35,<0.10",
+    "jaxlib>=0.4.35,<0.10",
+    "numpyro>=0.18.0",
+]
+
 test = [
+    "botorch[fully_bayesian]",
     "pytest",
     "pytest-cov",
     "requests",
@@ -58,6 +64,7 @@ dev = [
 ]
 
 tutorials = [
+    "botorch[fully_bayesian]",
     "cma",
     "jupyter",
     "matplotlib",

--- a/test/models/test_fully_bayesian.py
+++ b/test/models/test_fully_bayesian.py
@@ -6,6 +6,9 @@
 
 
 import itertools
+import subprocess
+import sys
+import textwrap
 from unittest import mock
 from unittest.mock import patch
 
@@ -1297,3 +1300,87 @@ class TestNumpyVersionCheck(BotorchTestCase):
                     train_X=torch.rand(10, 2),
                     train_Y=torch.rand(10, 1),
                 )
+
+    def test_core_workflow_without_jax(self) -> None:
+        """Core BoTorch works when JAX/jaxlib/NumPyro are not installed.
+
+        JAX, jaxlib, and NumPyro are optional dependencies that are only needed
+        to fit fully Bayesian models. We run this in a subprocess that blocks
+        those imports (the parent process has them installed and has already
+        imported the gated modules with ``_HAS_JAX=True``), and assert that the
+        standard fit + acquisition-optimization loop works end to end while
+        constructing a fully Bayesian model raises a clear ``ImportError``.
+        """
+        script = textwrap.dedent(
+            """
+            import sys
+
+            # ``python -c`` puts the current working directory on ``sys.path``;
+            # drop it so the subprocess only sees installed packages, matching a
+            # real install rather than whatever happens to live next to the cwd.
+            sys.path = [p for p in sys.path if p not in ("", ".")]
+
+            import builtins
+
+            _real_import = builtins.__import__
+
+            def _blocked_import(name, *args, **kwargs):
+                if name.split(".")[0] in {"jax", "jaxlib", "numpyro"}:
+                    raise ImportError(f"blocked {name}")
+                return _real_import(name, *args, **kwargs)
+
+            builtins.__import__ = _blocked_import
+
+            import torch
+            import botorch  # noqa: F401
+            import botorch.fit  # noqa: F401
+            import botorch.models.fully_bayesian_multitask  # noqa: F401
+            from botorch.acquisition.analytic import LogExpectedImprovement
+            from botorch.fit import fit_gpytorch_mll
+            from botorch.models import SingleTaskGP
+            from botorch.models.fully_bayesian import (
+                _HAS_JAX,
+                SaasFullyBayesianSingleTaskGP,
+            )
+            from botorch.optim import optimize_acqf
+            from botorch.test_utils.mock import mock_optimize_context_manager
+            from gpytorch.mlls import ExactMarginalLogLikelihood
+
+            assert _HAS_JAX is False, "_HAS_JAX should be False with JAX blocked"
+
+            # Standard (non-fully-Bayesian) BO loop must work without JAX.
+            train_X = torch.rand(8, 2, dtype=torch.double)
+            train_Y = train_X.sum(dim=-1, keepdim=True)
+            model = SingleTaskGP(train_X=train_X, train_Y=train_Y)
+            mll = ExactMarginalLogLikelihood(model.likelihood, model)
+            with mock_optimize_context_manager():
+                fit_gpytorch_mll(mll)
+                acqf = LogExpectedImprovement(model=model, best_f=train_Y.max())
+                candidate, _ = optimize_acqf(
+                    acq_function=acqf,
+                    bounds=torch.tensor(
+                        [[0.0, 0.0], [1.0, 1.0]], dtype=torch.double
+                    ),
+                    q=1,
+                    num_restarts=2,
+                    raw_samples=4,
+                )
+            assert candidate.shape == (1, 2), candidate.shape
+
+            # Fully Bayesian models still require JAX -> clear ImportError.
+            try:
+                SaasFullyBayesianSingleTaskGP(train_X=train_X, train_Y=train_Y)
+            except ImportError:
+                pass
+            else:
+                raise AssertionError(
+                    "expected ImportError when constructing SAAS without JAX"
+                )
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/botorch/issues/3318. JAX, jaxlib, and NumPyro were added as **required** dependencies in 0.18.0, but they are only needed to fit fully Bayesian models (`SaasFullyBayesianSingleTaskGP` / `SaasFullyBayesianMultiTaskGP`), which run NUTS via NumPyro. As the issue notes, a Torch project shouldn't pull in JAX for everyone.

The code is already written for these to be optional:
- `botorch/models/fully_bayesian.py` guards `import jax/numpyro` behind `try/except` (`_HAS_JAX`) and raises via `_check_jax_available()` only at model construction.
- `botorch/models/fully_bayesian_multitask.py` guards its imports behind `if _HAS_JAX:`.
- `fit_fully_bayesian_model_nuts` uses a **local** import (not module-level).

I verified empirically (with `jax`/`jaxlib`/`numpyro` blocked at import) that `import botorch`, `import botorch.fit`, importing the fully-Bayesian modules, and building/using `SingleTaskGP` all work; only constructing a fully Bayesian model raises a clear `ImportError`.

## Changes
- Move `jax`, `jaxlib`, `numpyro` from core `dependencies` into a new `fully_bayesian` optional extra in `pyproject.toml`.
- Add `botorch[fully_bayesian]` to the `test` extra so CI still exercises the fully Bayesian path.
- Update the `_check_jax_available` error message to point at `pip install "botorch[fully_bayesian]"` instead of the Meta-internal `PACKAGE` / `python-scientific-stack` instructions (which are meaningless to OSS users).

Note: `botorch/utils/jax_utils.py` still imports JAX at module level, but it is not imported by any production code (only its own test), so it does not affect `import botorch`.


Test Plan:
- `pytest test/models/test_fully_bayesian.py test/models/test_fully_bayesian_multitask.py` → 98 passed.
- Confirmed `import botorch` and core model usage work with JAX/jaxlib/numpyro blocked.
- ufmt + flake8 clean on changed files.

Reviewed By: dme65

Differential Revision: D107686465

Pulled By: saitcakmak


