### PR TITLE
Linear constraints as sparse constraints

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -342,11 +342,12 @@ def gen_candidates_scipy(
 
             x0 = candidates_.flatten()
 
-            constraints = make_scipy_linear_constraints(
+            linear_lc = make_scipy_linear_constraints(
                 shapeX=candidates_.shape,
                 inequality_constraints=_no_fixed_features.inequality_constraints,
                 equality_constraints=_no_fixed_features.equality_constraints,
             )
+            constraints = [linear_lc] if linear_lc is not None else []
             if _no_fixed_features.nonlinear_inequality_constraints:
                 # Make sure ``batch_limit`` is 1 for now.
                 if not (len(candidates_.shape) == 3 and candidates_.shape[0] == 1):

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -342,12 +342,13 @@ def gen_candidates_scipy(
 
             x0 = candidates_.flatten()
 
-            linear_lc = make_scipy_linear_constraints(
-                shapeX=candidates_.shape,
-                inequality_constraints=_no_fixed_features.inequality_constraints,
-                equality_constraints=_no_fixed_features.equality_constraints,
+            constraints = list(
+                make_scipy_linear_constraints(
+                    shapeX=candidates_.shape,
+                    inequality_constraints=_no_fixed_features.inequality_constraints,
+                    equality_constraints=_no_fixed_features.equality_constraints,
+                )
             )
-            constraints = [linear_lc] if linear_lc is not None else []
             if _no_fixed_features.nonlinear_inequality_constraints:
                 # Make sure ``batch_limit`` is 1 for now.
                 if not (len(candidates_.shape) == 3 and candidates_.shape[0] == 1):

--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -342,13 +342,12 @@ def gen_candidates_scipy(
 
             x0 = candidates_.flatten()
 
-            constraints = list(
-                make_scipy_linear_constraints(
-                    shapeX=candidates_.shape,
-                    inequality_constraints=_no_fixed_features.inequality_constraints,
-                    equality_constraints=_no_fixed_features.equality_constraints,
-                )
+            constraints = make_scipy_linear_constraints(
+                shapeX=candidates_.shape,
+                inequality_constraints=_no_fixed_features.inequality_constraints,
+                equality_constraints=_no_fixed_features.equality_constraints,
             )
+
             if _no_fixed_features.nonlinear_inequality_constraints:
                 # Make sure ``batch_limit`` is 1 for now.
                 if not (len(candidates_.shape) == 3 and candidates_.shape[0] == 1):

--- a/botorch/optim/optimize.py
+++ b/botorch/optim/optimize.py
@@ -1019,6 +1019,7 @@ def optimize_acqf_list(
     ic_generator: TGenInitialConditions | None = None,
     ic_gen_kwargs: dict | None = None,
     return_acq_values: bool = True,
+    retry_on_optimization_warning: bool = True,
 ) -> tuple[Tensor, Tensor | None]:
     r"""Generate a list of candidates from a list of acquisition functions.
 
@@ -1073,6 +1074,10 @@ def optimize_acqf_list(
         ic_gen_kwargs: Additional keyword arguments passed to function specified by
             ``ic_generator``
         return_acq_values: Return acquisition values.
+        retry_on_optimization_warning: Whether to retry candidate generation with a new
+            set of initial conditions if it fails with an `OptimizationWarning`.
+            Forwarded to each per-acquisition-function `optimize_acqf` /
+            `optimize_acqf_mixed` call.
 
     Returns:
         A two-element tuple containing
@@ -1115,6 +1120,7 @@ def optimize_acqf_list(
                 ic_generator=ic_generator,
                 ic_gen_kwargs=ic_gen_kwargs,
                 return_acq_values=return_acq_values,
+                retry_on_optimization_warning=retry_on_optimization_warning,
             )
         else:
             ic_gen_kwargs = ic_gen_kwargs or {}
@@ -1134,6 +1140,7 @@ def optimize_acqf_list(
                 return_acq_values=return_acq_values,
                 sequential=False,
                 ic_generator=ic_generator,
+                retry_on_optimization_warning=retry_on_optimization_warning,
                 **ic_gen_kwargs,
             )
         candidate_list.append(candidate)

--- a/botorch/optim/optimize_mixed.py
+++ b/botorch/optim/optimize_mixed.py
@@ -920,6 +920,7 @@ def optimize_acqf_mixed_alternating(
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     return_acq_values: bool = True,
+    retry_on_optimization_warning: bool = True,
 ) -> tuple[Tensor, Tensor | None]:
     r"""
     Optimizes acquisition function over mixed integer, categorical, and continuous
@@ -989,6 +990,9 @@ def optimize_acqf_mixed_alternating(
             ``[(torch.tensor([1, 3]), torch.tensor([1.0, 0.5]), -0.1)]`` Equality
             constraints can only be used with continuous degrees of freedom.
         return_acq_values: Return acquisition values.
+        retry_on_optimization_warning: Whether to retry candidate generation with a new
+            set of initial conditions if it fails with an `OptimizationWarning`.
+            Applies to the continuous optimization sub-steps.
 
     Returns:
         A tuple of two tensors: a (q x d)-dim tensor of optimized points
@@ -1079,6 +1083,7 @@ def optimize_acqf_mixed_alternating(
         gen_candidates=gen_candidates_scipy,
         sequential=sequential,  # only relevant if all dims are cont.
         return_acq_values=True,  # Internal functions need acq values for logic
+        retry_on_optimization_warning=retry_on_optimization_warning,
     )
     if sequential:
         # Sequential optimization requires return_best_only to be True

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -193,6 +193,9 @@ def make_scipy_linear_constraints(
                 )
             )
 
+    if not ineq_blocks and not eq_blocks:
+        return []
+
     # n = total flat variable count = b*q*d after shape validation.
     n_total = int(_validate_linear_constraints_shape_input(shapeX).numel())
 

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -11,20 +11,39 @@ Utility functions for constrained optimization.
 from __future__ import annotations
 
 from collections.abc import Callable
-from functools import partial
+from dataclasses import dataclass
 
 import numpy as np
 import numpy.typing as npt
 import torch
 from botorch.exceptions.errors import CandidateGenerationError, UnsupportedError
 from botorch.optim.utils import columnwise_clamp, fix_features as apply_fix_features
-from scipy.optimize import Bounds, minimize
+from scipy import sparse
+from scipy.optimize import Bounds, LinearConstraint, minimize
 from torch import Tensor
 
 
 ScipyConstraintDict = dict[
     str, str | Callable[[np.ndarray], float] | Callable[[np.ndarray], np.ndarray]
 ]
+
+
+@dataclass
+class _LinearConstraintBlock:
+    """COO-style block of linear constraints produced by ``_make_linear_constraints``.
+
+    ``rows`` are 0-indexed within the block; the caller offsets them when stacking
+    multiple blocks into a single ``A`` matrix. ``cols`` are absolute column
+    indices into the flat ``(b*q*d,)`` decision vector. The semantics are
+    ``lb[i] <= sum_j A[i, j] * x[j] <= ub[i]`` per row.
+    """
+
+    rows: np.ndarray  # int64, length nnz
+    cols: np.ndarray  # int64, length nnz
+    vals: np.ndarray  # float64, length nnz
+    lb: np.ndarray  # length n_rows
+    ub: np.ndarray  # length n_rows
+    n_rows: int
 
 
 def get_constraint_tolerance(dtype: torch.dtype) -> float:
@@ -88,63 +107,107 @@ def make_scipy_linear_constraints(
     shapeX: torch.Size,
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
-) -> list[ScipyConstraintDict]:
-    r"""Generate scipy constraints from torch representation.
+) -> LinearConstraint | None:
+    r"""Generate a scipy ``LinearConstraint`` from torch constraint tuples.
+
+    Stacks every inequality and equality constraint into a single sparse
+    constraint matrix ``A`` of shape ``(m_total, b*q*d)`` together with bound
+    vectors ``lb`` / ``ub``: equality rows have ``lb == ub == rhs``; inequality
+    rows have ``lb == rhs, ub == +inf`` (BoTorch's convention is ``A @ x >= rhs``).
 
     Args:
         shapeX: The shape of the torch.Tensor to optimize over (i.e. ``(b) x q x d``)
-        inequality constraints: A list of tuples (indices, coefficients, rhs),
+        inequality_constraints: A list of tuples (indices, coefficients, rhs),
             with each tuple encoding an inequality constraint of the form
             ``\sum_i (X[indices[i]] * coefficients[i]) >= rhs``, where
             ``indices`` is a single-dimensional index tensor (long dtype) containing
             indices into the last dimension of ``X``, ``coefficients`` is a
             single-dimensional tensor of coefficients of the same length, and
             rhs is a scalar.
-        equality constraints: A list of tuples (indices, coefficients, rhs),
-            with each tuple encoding an inequality constraint of the form
+        equality_constraints: A list of tuples (indices, coefficients, rhs),
+            with each tuple encoding an equality constraint of the form
             ``\sum_i (X[indices[i]] * coefficients[i]) == rhs`` (with ``indices``
             and ``coefficients`` of the same form as in ``inequality_constraints``).
 
     Returns:
-        A list of dictionaries containing callables for constraint function
-        values and Jacobians and a string indicating the associated constraint
-        type ("eq", "ineq"), as expected by ``scipy.optimize.minimize``.
+        A :class:`scipy.optimize.LinearConstraint` whose ``A`` is a
+        :class:`scipy.sparse.coo_array`, or ``None`` if no constraints were
+        supplied. Solvers that don't consume ``LinearConstraint`` natively
+        (SLSQP, COBYLA, …) round-trip it to per-row dicts via scipy's
+        ``standardize_constraints``; solvers that do (trust-constr, custom
+        callable methods such as pounce) read the sparse pattern directly.
 
     This function assumes that constraints are the same for each input batch,
-    and broadcasts the constraints accordingly to the input batch shape. This
-    function does support constraints across elements of a q-batch if the
-    indices are a 2-d Tensor.
+    and broadcasts the constraints accordingly to the input batch shape. It
+    does support constraints across elements of a q-batch if the indices
+    are a 2-d Tensor.
 
     Example:
-        The following will enforce that ``x[1] + 0.5 x[3] >= -0.1`` for each ``x``
+        The following enforces ``x[1] + 0.5 x[3] >= -0.1`` for each ``x``
         in both elements of the q-batch, and each of the 3 t-batches:
 
-        >>> constraints = make_scipy_linear_constraints(
+        >>> lc = make_scipy_linear_constraints(
         >>>     torch.Size([3, 2, 4]),
         >>>     [(torch.tensor([1, 3]), torch.tensor([1.0, 0.5]), -0.1)],
         >>> )
 
-        The following will enforce that ``x[0, 1] + 0.5 x[1, 3] >= -0.1`` where
+        The following enforces ``x[0, 1] + 0.5 x[1, 3] >= -0.1`` where
         x[0, :] is the first element of the q-batch and x[1, :] is the second
         element of the q-batch, for each of the 3 t-batches:
 
-        >>> constraints = make_scipy_linear_constraints(
-        >>>     torch.size([3, 2, 4])
-        >>>     [(torch.tensor([[0, 1], [1, 3]), torch.tensor([1.0, 0.5]), -0.1)],
+        >>> lc = make_scipy_linear_constraints(
+        >>>     torch.Size([3, 2, 4]),
+        >>>     [(torch.tensor([[0, 1], [1, 3]]), torch.tensor([1.0, 0.5]), -0.1)],
         >>> )
     """
-    constraints = []
+    blocks: list[_LinearConstraintBlock] = []
     if inequality_constraints is not None:
         for indcs, coeffs, rhs in inequality_constraints:
-            constraints += _make_linear_constraints(
-                indices=indcs, coefficients=coeffs, rhs=rhs, shapeX=shapeX, eq=False
+            blocks.append(
+                _make_linear_constraints(
+                    indices=indcs,
+                    coefficients=coeffs,
+                    rhs=rhs,
+                    shapeX=shapeX,
+                    eq=False,
+                )
             )
     if equality_constraints is not None:
         for indcs, coeffs, rhs in equality_constraints:
-            constraints += _make_linear_constraints(
-                indices=indcs, coefficients=coeffs, rhs=rhs, shapeX=shapeX, eq=True
+            blocks.append(
+                _make_linear_constraints(
+                    indices=indcs,
+                    coefficients=coeffs,
+                    rhs=rhs,
+                    shapeX=shapeX,
+                    eq=True,
+                )
             )
-    return constraints
+
+    if not blocks:
+        return None
+
+    # Stack blocks with a running row offset; columns/values/bounds concat directly.
+    row_offset = 0
+    row_parts, col_parts, val_parts, lb_parts, ub_parts = [], [], [], [], []
+    for blk in blocks:
+        row_parts.append(blk.rows + row_offset)
+        col_parts.append(blk.cols)
+        val_parts.append(blk.vals)
+        lb_parts.append(blk.lb)
+        ub_parts.append(blk.ub)
+        row_offset += blk.n_rows
+
+    rows = np.concatenate(row_parts)
+    cols = np.concatenate(col_parts)
+    vals = np.concatenate(val_parts)
+    lb = np.concatenate(lb_parts)
+    ub = np.concatenate(ub_parts)
+
+    # n = total flat variable count = b*q*d after shape validation.
+    n_total = int(_validate_linear_constraints_shape_input(shapeX).numel())
+    A = sparse.coo_array((vals, (rows, cols)), shape=(row_offset, n_total))
+    return LinearConstraint(A, lb=lb, ub=ub)
 
 
 def eval_lin_constraint(
@@ -238,97 +301,76 @@ def _make_linear_constraints(
     rhs: float,
     shapeX: torch.Size,
     eq: bool = False,
-) -> list[ScipyConstraintDict]:
-    r"""Create linear constraints to be used by ``scipy.optimize.minimize``.
+) -> _LinearConstraintBlock:
+    r"""Build a COO block for a linear constraint over a flattened ``(b)xqxd`` X.
 
     Encodes constraints of the form
     ``\sum_i (coefficients[i] * X[..., indices[i]]) ? rhs``
-    where ``?`` can be designated either as ``>=`` by setting ``eq=False``, or as
-    ``=`` by setting ``eq=True``.
+    where ``?`` is ``=`` when ``eq=True`` and ``>=`` otherwise.
 
-    If indices is one-dimensional, the constraints are broadcasted across
-    all elements of the q-batch. If indices is two-dimensional, then
-    constraints are applied across elements of a q-batch. In either case,
-    constraints are created for all t-batches.
+    If ``indices`` is one-dimensional, the constraint is broadcast over each
+    ``(t-batch, q-batch)`` pair (intra-point). If two-dimensional, it is applied
+    once per t-batch across elements of the q-batch (inter-point).
 
     Args:
-        indices: A tensor of shape ``c`` or ``c x 2``, where c is the number of terms
-            in the constraint. If single-dimensional, contains the indices of
-            the dimensions of the feature space that occur in the linear
-            constraint. If two-dimensional, contains pairs of indices of the
-            q-batch (0) and the feature space (1) that occur in the linear
-            constraint.
-        coefficients: A single-dimensional tensor of coefficients with the same
-            number of elements as ``indices``.
-        rhs: The right hand side of the constraint.
-        shapeX: The shape of the torch tensor to construct the constraints for
-            (i.e. ``(b) x q x d``). Must have two or three dimensions.
-        eq: If True, return an equality constraint, o/w return an inequality
-            constraint (indicated by "eq" / "ineq" value of the ``type`` key).
+        indices: ``c`` or ``c x 2`` long tensor. 1D → intra-point feature indices.
+            2D → ``(q-row, feature)`` pairs for inter-point constraints.
+        coefficients: 1D tensor of constraint coefficients, length ``c``.
+        rhs: Right-hand side of the constraint.
+        shapeX: Shape of the torch tensor (``(b) x q x d``). 2 or 3 dimensions.
+        eq: If True, equality (``lb = ub = rhs``); otherwise inequality
+            (``lb = rhs, ub = +inf``).
 
     Returns:
-        A list of constraint dictionaries with the following keys
-
-        - "type": Indicates the type of the constraint ("eq" if ``eq=True``, "ineq" o/w)
-        - "fun": A callable evaluating the constraint value on ``x``, a flattened
-            version of the input tensor ``X``, returning a scalar.
-        - "jac": A callable evaluating the constraint's Jacobian on ``x``, a flattened
-            version of the input tensor ``X``, returning a numpy array.
-
-    >>> shapeX = torch.Size([3, 5, 4])
-    >>> constraints = _make_linear_constraints(
-    ...     indices=torch.tensor([1., 2.]),
-    ...     coefficients=torch.tensor([-0.5, 1.3]),
-    ...     rhs=0.49,
-    ...     shapeX=shapeX,
-    ...     eq=True
-    ... )
-    >>> len(constraints)
-    15
-    >>> constraints[0].keys()
-    dict_keys(['type', 'fun', 'jac'])
-    >>> x = np.arange(60).reshape(shapeX)
-    >>> constraints[0]["fun"](x)
-    1.61  # 1 * -0.5 + 2 * 1.3 - 0.49
-    >>> constraints[0]["jac"](x)
-    [0., -0.5, 1.3, 0., 0., ...]
-    >>> constraints[1]["fun"](x)  #
-    4.81
+        A :class:`_LinearConstraintBlock` containing the sparse triplet for this
+        block of rows together with the ``lb`` / ``ub`` vectors. Equality rows
+        have ``lb[i] == ub[i] == rhs``; inequality rows have ``lb[i] == rhs``
+        and ``ub[i] == +inf`` (BoTorch's convention is ``A @ x >= rhs``).
     """
-
     shapeX = _validate_linear_constraints_shape_input(shapeX)
-
     b, q, d = shapeX
     _validate_linear_constraints_indices_input(indices, q, d)
-    n = shapeX.numel()
-    constraints: list[ScipyConstraintDict] = []
-    coeffs = _arrayify(coefficients)
-    ctype = "eq" if eq else "ineq"
 
+    coeffs = _arrayify(coefficients)
+    n_coeffs = int(coefficients.numel())
     offsets = [q * d, d]
+
     if indices.dim() == 2:
-        # indices has two dimensions (potential constraints across q-batch elements)
-        # rule is [i, j, k] is at
-        # i * offsets[0] + j * offsets[1] + k
+        # Inter-point: one row per t-batch element, touches len(indices) columns.
+        n_rows = int(b)
+        rows = np.repeat(np.arange(n_rows, dtype=np.int64), n_coeffs)
+        cols = np.empty(n_rows * n_coeffs, dtype=np.int64)
         for i in range(b):
-            list_ind = (idx.tolist() for idx in indices)
+            list_ind = [idx.tolist() for idx in indices]
             idxr = [i * offsets[0] + idx[0] * offsets[1] + idx[1] for idx in list_ind]
-            fun = partial(
-                eval_lin_constraint, flat_idxr=idxr, coeffs=coeffs, rhs=float(rhs)
-            )
-            jac = partial(lin_constraint_jac, flat_idxr=idxr, coeffs=coeffs, n=n)
-            constraints.append({"type": ctype, "fun": fun, "jac": jac})
-    elif indices.dim() == 1:
-        # indices is one-dim - broadcast constraints across q-batches and t-batches
+            cols[i * n_coeffs : (i + 1) * n_coeffs] = idxr
+        vals = np.tile(coeffs, n_rows)
+    else:  # indices.dim() == 1 — validator already rejected dim==0 / dim>2
+        # Intra-point: one row per (t-batch, q-batch) pair.
+        n_rows = int(b * q)
+        rows = np.repeat(np.arange(n_rows, dtype=np.int64), n_coeffs)
+        cols = np.empty(n_rows * n_coeffs, dtype=np.int64)
+        idx_np = _arrayify(indices).astype(np.int64)
+        r = 0
         for i in range(b):
             for j in range(q):
-                idxr = (i * offsets[0] + j * offsets[1] + indices).tolist()
-                fun = partial(
-                    eval_lin_constraint, flat_idxr=idxr, coeffs=coeffs, rhs=float(rhs)
+                cols[r * n_coeffs : (r + 1) * n_coeffs] = (
+                    i * offsets[0] + j * offsets[1] + idx_np
                 )
-                jac = partial(lin_constraint_jac, flat_idxr=idxr, coeffs=coeffs, n=n)
-                constraints.append({"type": ctype, "fun": fun, "jac": jac})
-    return constraints
+                r += 1
+        vals = np.tile(coeffs, n_rows)
+
+    rhs_f = float(rhs)
+    if eq:
+        lb = np.full(n_rows, rhs_f, dtype=np.float64)
+        ub = np.full(n_rows, rhs_f, dtype=np.float64)
+    else:
+        lb = np.full(n_rows, rhs_f, dtype=np.float64)
+        ub = np.full(n_rows, np.inf, dtype=np.float64)
+
+    return _LinearConstraintBlock(
+        rows=rows, cols=cols, vals=vals, lb=lb, ub=ub, n_rows=n_rows
+    )
 
 
 def _make_nonlinear_constraints(
@@ -841,11 +883,12 @@ def project_to_feasible_space_via_slsqp(
                 ub[flat_idx] = X_fixed_flat[flat_idx]
 
     bounds_scipy = Bounds(lb=lb, ub=ub, keep_feasible=True)
-    constraints = make_scipy_linear_constraints(
+    linear_lc = make_scipy_linear_constraints(
         shapeX=X.shape,
         inequality_constraints=inequality_constraints,
         equality_constraints=equality_constraints,
     )
+    constraints = [linear_lc] if linear_lc is not None else []
     # Define squared distance objective
     X_np = X.flatten().detach().cpu().numpy()
 

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -107,13 +107,19 @@ def make_scipy_linear_constraints(
     shapeX: torch.Size,
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
     equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
-) -> LinearConstraint | None:
-    r"""Generate a scipy ``LinearConstraint`` from torch constraint tuples.
+) -> list[LinearConstraint]:
+    r"""Generate scipy ``LinearConstraint`` objects from torch constraint tuples.
 
-    Stacks every inequality and equality constraint into a single sparse
-    constraint matrix ``A`` of shape ``(m_total, b*q*d)`` together with bound
-    vectors ``lb`` / ``ub``: equality rows have ``lb == ub == rhs``; inequality
-    rows have ``lb == rhs, ub == +inf`` (BoTorch's convention is ``A @ x >= rhs``).
+    Returns up to two ``LinearConstraint``s — one for all inequality rows and
+    one for all equality rows — each carrying a single sparse ``A`` of shape
+    ``(m_block, b*q*d)`` plus the corresponding ``lb`` / ``ub`` vectors.
+    Equality rows have ``lb == ub == rhs``; inequality rows have
+    ``lb == rhs, ub == +inf`` (BoTorch's convention is ``A @ x >= rhs``).
+
+    Splitting eq vs ineq into separate objects (rather than packing both into
+    one ``LinearConstraint``) silences scipy's ``OptimizeWarning`` from
+    ``new_constraint_to_old`` when SLSQP / COBYLA round-trip the constraint
+    via ``standardize_constraints``.
 
     Args:
         shapeX: The shape of the torch.Tensor to optimize over (i.e. ``(b) x q x d``)
@@ -130,12 +136,14 @@ def make_scipy_linear_constraints(
             and ``coefficients`` of the same form as in ``inequality_constraints``).
 
     Returns:
-        A :class:`scipy.optimize.LinearConstraint` whose ``A`` is a
-        :class:`scipy.sparse.coo_array`, or ``None`` if no constraints were
-        supplied. Solvers that don't consume ``LinearConstraint`` natively
-        (SLSQP, COBYLA, …) round-trip it to per-row dicts via scipy's
-        ``standardize_constraints``; solvers that do (trust-constr, custom
-        callable methods such as pounce) read the sparse pattern directly.
+        A list of :class:`scipy.optimize.LinearConstraint` objects whose ``A``
+        is a :class:`scipy.sparse.coo_array`. The list contains 0, 1, or 2
+        entries: at most one inequality block (first, when present) and at
+        most one equality block (second). Solvers that don't consume
+        ``LinearConstraint`` natively (SLSQP, COBYLA, …) round-trip them to
+        per-row dicts via scipy's ``standardize_constraints``; solvers that do
+        (trust-constr, custom callable methods such as pounce) read the
+        sparse pattern directly.
 
     This function assumes that constraints are the same for each input batch,
     and broadcasts the constraints accordingly to the input batch shape. It
@@ -146,7 +154,7 @@ def make_scipy_linear_constraints(
         The following enforces ``x[1] + 0.5 x[3] >= -0.1`` for each ``x``
         in both elements of the q-batch, and each of the 3 t-batches:
 
-        >>> lc = make_scipy_linear_constraints(
+        >>> lcs = make_scipy_linear_constraints(
         >>>     torch.Size([3, 2, 4]),
         >>>     [(torch.tensor([1, 3]), torch.tensor([1.0, 0.5]), -0.1)],
         >>> )
@@ -155,15 +163,16 @@ def make_scipy_linear_constraints(
         x[0, :] is the first element of the q-batch and x[1, :] is the second
         element of the q-batch, for each of the 3 t-batches:
 
-        >>> lc = make_scipy_linear_constraints(
+        >>> lcs = make_scipy_linear_constraints(
         >>>     torch.Size([3, 2, 4]),
         >>>     [(torch.tensor([[0, 1], [1, 3]]), torch.tensor([1.0, 0.5]), -0.1)],
         >>> )
     """
-    blocks: list[_LinearConstraintBlock] = []
+    ineq_blocks: list[_LinearConstraintBlock] = []
+    eq_blocks: list[_LinearConstraintBlock] = []
     if inequality_constraints is not None:
         for indcs, coeffs, rhs in inequality_constraints:
-            blocks.append(
+            ineq_blocks.append(
                 _make_linear_constraints(
                     indices=indcs,
                     coefficients=coeffs,
@@ -174,7 +183,7 @@ def make_scipy_linear_constraints(
             )
     if equality_constraints is not None:
         for indcs, coeffs, rhs in equality_constraints:
-            blocks.append(
+            eq_blocks.append(
                 _make_linear_constraints(
                     indices=indcs,
                     coefficients=coeffs,
@@ -184,30 +193,42 @@ def make_scipy_linear_constraints(
                 )
             )
 
-    if not blocks:
-        return None
-
-    # Stack blocks with a running row offset; columns/values/bounds concat directly.
-    row_offset = 0
-    row_parts, col_parts, val_parts, lb_parts, ub_parts = [], [], [], [], []
-    for blk in blocks:
-        row_parts.append(blk.rows + row_offset)
-        col_parts.append(blk.cols)
-        val_parts.append(blk.vals)
-        lb_parts.append(blk.lb)
-        ub_parts.append(blk.ub)
-        row_offset += blk.n_rows
-
-    rows = np.concatenate(row_parts)
-    cols = np.concatenate(col_parts)
-    vals = np.concatenate(val_parts)
-    lb = np.concatenate(lb_parts)
-    ub = np.concatenate(ub_parts)
-
     # n = total flat variable count = b*q*d after shape validation.
     n_total = int(_validate_linear_constraints_shape_input(shapeX).numel())
-    A = sparse.coo_array((vals, (rows, cols)), shape=(row_offset, n_total))
-    return LinearConstraint(A, lb=lb, ub=ub)
+
+    def _stack(blocks: list[_LinearConstraintBlock]) -> LinearConstraint | None:
+        if not blocks:
+            return None
+        row_offset = 0
+        row_parts, col_parts, val_parts, lb_parts, ub_parts = [], [], [], [], []
+        for blk in blocks:
+            row_parts.append(blk.rows + row_offset)
+            col_parts.append(blk.cols)
+            val_parts.append(blk.vals)
+            lb_parts.append(blk.lb)
+            ub_parts.append(blk.ub)
+            row_offset += blk.n_rows
+        A = sparse.coo_array(
+            (
+                np.concatenate(val_parts),
+                (np.concatenate(row_parts), np.concatenate(col_parts)),
+            ),
+            shape=(row_offset, n_total),
+        )
+        return LinearConstraint(
+            A,
+            lb=np.concatenate(lb_parts),
+            ub=np.concatenate(ub_parts),
+        )
+
+    result: list[LinearConstraint] = []
+    ineq_lc = _stack(ineq_blocks)
+    if ineq_lc is not None:
+        result.append(ineq_lc)
+    eq_lc = _stack(eq_blocks)
+    if eq_lc is not None:
+        result.append(eq_lc)
+    return result
 
 
 def eval_lin_constraint(
@@ -883,12 +904,13 @@ def project_to_feasible_space_via_slsqp(
                 ub[flat_idx] = X_fixed_flat[flat_idx]
 
     bounds_scipy = Bounds(lb=lb, ub=ub, keep_feasible=True)
-    linear_lc = make_scipy_linear_constraints(
-        shapeX=X.shape,
-        inequality_constraints=inequality_constraints,
-        equality_constraints=equality_constraints,
+    constraints = list(
+        make_scipy_linear_constraints(
+            shapeX=X.shape,
+            inequality_constraints=inequality_constraints,
+            equality_constraints=equality_constraints,
+        )
     )
-    constraints = [linear_lc] if linear_lc is not None else []
     # Define squared distance objective
     X_np = X.flatten().detach().cpu().numpy()
 

--- a/botorch/optim/parameter_constraints.py
+++ b/botorch/optim/parameter_constraints.py
@@ -234,43 +234,6 @@ def make_scipy_linear_constraints(
     return result
 
 
-def eval_lin_constraint(
-    x: npt.NDArray, flat_idxr: list[int], coeffs: npt.NDArray, rhs: float
-) -> np.float64:
-    r"""Evaluate a single linear constraint.
-
-    Args:
-        x: The input array.
-        flat_idxr: The indices in ``x`` to consider.
-        coeffs: The coefficients corresponding to the indices.
-        rhs: The right-hand-side of the constraint.
-
-    Returns:
-        The evaluted constraint: ``\sum_i (coeffs[i] * x[i]) - rhs``
-    """
-    return np.sum(x[flat_idxr] * coeffs, -1) - rhs
-
-
-def lin_constraint_jac(
-    x: npt.NDArray, flat_idxr: list[int], coeffs: npt.NDArray, n: int
-) -> npt.NDArray:
-    r"""Return the Jacobian associated with a linear constraint.
-
-    Args:
-        x: The input array.
-        flat_idxr: The indices for the elements of x that appear in the constraint.
-        coeffs: The coefficients corresponding to the indices.
-        n: number of elements
-
-    Returns:
-        The Jacobian.
-    """
-    # TODO: Use sparse representation (not sure if scipy optim supports that)
-    jac = np.zeros(n)
-    jac[flat_idxr] = coeffs
-    return jac
-
-
 def _arrayify(X: Tensor) -> npt.NDArray:
     r"""Convert a torch.Tensor (any dtype or device) to a numpy (double) array.
 

--- a/test/generation/test_gen.py
+++ b/test/generation/test_gen.py
@@ -118,6 +118,36 @@ class TestGenCandidates(TestBaseCandidateGeneration):
     def test_gen_candidates_torch(self):
         self.test_gen_candidates(gen_candidates=gen_candidates_torch)
 
+    def test_gen_candidates_scipy_custom_method_dispatch(self):
+        """Smoke-test the scipy ``_custom`` callable-method path.
+
+        Passing a callable via ``options["method"]`` should reach the user
+        function via scipy's ``_custom`` dispatch. We confirm this minimally:
+        a callable that raises a sentinel exception is passed in, and we
+        assert the exception propagates back out of ``gen_candidates_scipy``.
+
+        If any layer (gen.py extracts/forwards ``method``, minimize_with_timeout
+        forwards ``method``, scipy dispatches to the callable) breaks the chain,
+        this test catches it.
+        """
+
+        class _Reached(Exception):
+            pass
+
+        def custom_method(*args, **kwargs):
+            raise _Reached
+
+        self._setUp(double=True)
+        acqf = qExpectedImprovement(self.model, best_f=self.f_best)
+        with self.assertRaises(_Reached):
+            gen_candidates_scipy(
+                initial_conditions=self.initial_conditions,
+                acquisition_function=acqf,
+                lower_bounds=0,
+                upper_bounds=1,
+                options={"method": custom_method, "maxiter": 1},
+            )
+
     def test_gen_candidates_with_fixed_features(
         self, gen_candidates=gen_candidates_scipy, options=None, timeout_sec=None
     ):

--- a/test/optim/test_optimize.py
+++ b/test/optim/test_optimize.py
@@ -2418,6 +2418,33 @@ class TestOptimizeAcqfList(BotorchTestCase):
                         else:
                             self.assertEqual(expected_call_args[k], v)
 
+    @mock.patch("botorch.optim.optimize.optimize_acqf")
+    @mock.patch("botorch.optim.optimize.optimize_acqf_mixed")
+    def test_optimize_acqf_list_forwards_retry_flag(
+        self, mock_optimize_acqf_mixed, mock_optimize_acqf
+    ):
+        bounds = torch.stack([torch.zeros(3), 4 * torch.ones(3)])
+        rv = (torch.rand(1, 3), torch.rand(1))
+        for ffl, mocked in (
+            (None, mock_optimize_acqf),  # → optimize_acqf branch
+            ([{0: 0.5}], mock_optimize_acqf_mixed),  # → optimize_acqf_mixed branch
+        ):
+            for retry in (True, False):
+                mock_optimize_acqf.reset_mock()
+                mock_optimize_acqf_mixed.reset_mock()
+                mocked.side_effect = [rv]
+                optimize_acqf_list(
+                    acq_function_list=[MockAcquisitionFunction()],
+                    bounds=bounds,
+                    num_restarts=2,
+                    raw_samples=10,
+                    fixed_features_list=ffl,
+                    retry_on_optimization_warning=retry,
+                )
+                self.assertEqual(
+                    mocked.call_args.kwargs["retry_on_optimization_warning"], retry
+                )
+
     def test_optimize_acqf_list_empty_list(self):
         with self.assertRaises(ValueError):
             optimize_acqf_list(

--- a/test/optim/test_optimize_mixed.py
+++ b/test/optim/test_optimize_mixed.py
@@ -1032,6 +1032,44 @@ class TestOptimizeAcqfMixed(BotorchTestCase):
             call_kwargs = mock_opt.call_args.kwargs
             self.assertFalse(call_kwargs["opt_inputs"].return_acq_values)
 
+    def test_optimize_acqf_mixed_alternating_forwards_retry_flag(self) -> None:
+        """The retry-on-optimization-warning flag must reach the continuous
+        sub-step via the constructed OptimizeAcqfInputs (default True)."""
+        train_X, train_Y, binary_dims, cont_dims = self._get_data()
+        dim = len(binary_dims) + len(cont_dims)
+        bounds = self.single_bound.repeat(1, dim).to(**self.tkwargs)
+        torch.manual_seed(0)
+        model = SingleTaskGP(train_X=train_X, train_Y=train_Y)
+        acqf = LogExpectedImprovement(model=model, best_f=torch.max(train_Y))
+        options = {
+            "initialization_strategy": "random",
+            "maxiter_alternating": 1,
+            "maxiter_discrete": 4,
+            "maxiter_continuous": 8,
+            "num_spray_points": 0,
+        }
+        for retry in (True, False):
+            with mock.patch(
+                f"{OPT_MODULE}._optimize_acqf", wraps=_optimize_acqf
+            ) as mock_opt:
+                optimize_acqf_mixed_alternating(
+                    acq_function=acqf,
+                    bounds=bounds,
+                    discrete_dims=binary_dims,
+                    options=options,
+                    q=1,
+                    raw_samples=8,
+                    num_restarts=2,
+                    retry_on_optimization_warning=retry,
+                )
+                # every continuous sub-step inherits the flag from opt_inputs
+                self.assertTrue(mock_opt.call_count >= 1)
+                for call in mock_opt.call_args_list:
+                    self.assertEqual(
+                        call.kwargs["opt_inputs"].retry_on_optimization_warning,
+                        retry,
+                    )
+
     def test_optimize_acqf_mixed_integer(self) -> None:
         # Testing with integer variables.
         train_X, train_Y, binary_dims, cont_dims = self._get_data()

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from collections.abc import Callable
 from itertools import product
 from unittest import mock
@@ -31,7 +32,7 @@ from botorch.optim.parameter_constraints import (
 )
 from botorch.utils.testing import BotorchTestCase
 from scipy import sparse
-from scipy.optimize import Bounds, LinearConstraint
+from scipy.optimize import Bounds, LinearConstraint, OptimizeWarning
 from scipy.optimize._minimize import standardize_constraints
 
 
@@ -275,76 +276,84 @@ class TestParameterConstraints(BotorchTestCase):
         for shapeX in [torch.Size([2, 1, 4]), torch.Size([1, 4])]:
             b = shapeX[0] if len(shapeX) == 3 else 1
             n = shapeX.numel()
-            # None when no constraints
+            # Empty list when no constraints.
             res = make_scipy_linear_constraints(
                 shapeX=shapeX, inequality_constraints=None, equality_constraints=None
             )
-            self.assertIsNone(res)
+            self.assertEqual(res, [])
 
             indices = torch.tensor([0, 1], dtype=torch.long, device=self.device)
             coefficients = torch.tensor([1.5, -1.0], device=self.device)
 
-            # both inequality and equality constraints
-            lc = make_scipy_linear_constraints(
+            # Both inequality and equality constraints → two separate
+            # LinearConstraints (ineq first, eq second). Splitting is what
+            # silences scipy's OptimizeWarning on SLSQP conversion.
+            lcs = make_scipy_linear_constraints(
                 shapeX=shapeX,
                 inequality_constraints=[(indices, coefficients, 1.0)],
                 equality_constraints=[(indices, coefficients, 1.0)],
             )
-            self.assertIsInstance(lc, LinearConstraint)
-            # A is sparse and shape matches (m_total, n)
-            self.assertTrue(sparse.issparse(lc.A))
-            self.assertEqual(lc.A.shape, (2 * b, n))
-            # Order: inequality rows first (lb=rhs, ub=+inf), then equality rows
-            # (lb=ub=rhs). Verify per-row.
-            self.assertTrue(np.allclose(lc.lb[:b], 1.0))
-            self.assertTrue(np.all(np.isinf(lc.ub[:b])))
-            self.assertTrue(np.allclose(lc.lb[b:], 1.0))
-            self.assertTrue(np.allclose(lc.ub[b:], 1.0))
+            self.assertEqual(len(lcs), 2)
+            for lc in lcs:
+                self.assertIsInstance(lc, LinearConstraint)
+                self.assertTrue(sparse.issparse(lc.A))
+                self.assertEqual(lc.A.shape, (b, n))
+            ineq_lc, eq_lc = lcs
+            # Inequality: lb=rhs, ub=+inf. Equality: lb=ub=rhs.
+            self.assertTrue(np.allclose(ineq_lc.lb, 1.0))
+            self.assertTrue(np.all(np.isinf(ineq_lc.ub)))
+            self.assertTrue(np.allclose(eq_lc.lb, 1.0))
+            self.assertTrue(np.allclose(eq_lc.ub, 1.0))
 
-            # Round-trip via scipy's standardize_constraints → dicts. scipy
-            # emits ONE vectorized dict per category (eq / ineq), each with a
-            # ``fun`` returning a vector and ``jac`` returning a matrix.
-            # Verifying these against per-row direct math catches regressions
-            # in either layer.
+            # Round-trip via scipy's standardize_constraints → dicts. With
+            # eq and ineq in separate LCs, scipy emits one dict per LC
+            # (vectorized fun returning a length-b vector; vectorized jac
+            # returning the dense A) and the OptimizeWarning we used to get
+            # for "eq and ineq in the same constraint" no longer fires.
             x = np.random.rand(n)
-            A_dense = lc.A.toarray()
-            old = standardize_constraints([lc], x0=np.zeros(n), meth="slsqp")
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", OptimizeWarning)
+                old = standardize_constraints(lcs, x0=np.zeros(n), meth="slsqp")
             self.assertEqual({c["type"] for c in old}, {"ineq", "eq"})
-            # ineq portion is the first b rows; eq portion is the last b rows.
-            ineq_expected = A_dense[:b] @ x - lc.lb[:b]
-            eq_expected = A_dense[b:] @ x - lc.lb[b:]
+            ineq_A = ineq_lc.A.toarray()
+            eq_A = eq_lc.A.toarray()
+            ineq_expected = ineq_A @ x - ineq_lc.lb
+            eq_expected = eq_A @ x - eq_lc.lb
             for c in old:
                 val = np.atleast_1d(np.asarray(c["fun"](x), dtype=float))
                 jac = np.atleast_2d(np.asarray(c["jac"](x), dtype=float))
                 if c["type"] == "ineq":
                     np.testing.assert_allclose(val, ineq_expected, atol=1e-10)
-                    np.testing.assert_allclose(jac, A_dense[:b], atol=1e-10)
+                    np.testing.assert_allclose(jac, ineq_A, atol=1e-10)
                 else:
                     np.testing.assert_allclose(val, eq_expected, atol=1e-10)
-                    np.testing.assert_allclose(jac, A_dense[b:], atol=1e-10)
+                    np.testing.assert_allclose(jac, eq_A, atol=1e-10)
 
-            # inequality only
-            lc = make_scipy_linear_constraints(
+            # Inequality only → single LC, length-1 list.
+            lcs = make_scipy_linear_constraints(
                 shapeX=shapeX, inequality_constraints=[(indices, coefficients, 1.0)]
             )
-            self.assertEqual(lc.A.shape, (b, n))
-            self.assertTrue(np.all(np.isinf(lc.ub)))
-            # equality only
-            lc = make_scipy_linear_constraints(
+            self.assertEqual(len(lcs), 1)
+            self.assertEqual(lcs[0].A.shape, (b, n))
+            self.assertTrue(np.all(np.isinf(lcs[0].ub)))
+            # Equality only → single LC, length-1 list.
+            lcs = make_scipy_linear_constraints(
                 shapeX=shapeX, equality_constraints=[(indices, coefficients, 1.0)]
             )
-            self.assertEqual(lc.A.shape, (b, n))
-            self.assertTrue(np.allclose(lc.lb, lc.ub))
+            self.assertEqual(len(lcs), 1)
+            self.assertEqual(lcs[0].A.shape, (b, n))
+            self.assertTrue(np.allclose(lcs[0].lb, lcs[0].ub))
 
-            # 2-dim (inter-point) indices: still produces a valid LinearConstraint.
+            # 2-dim (inter-point) indices: same two-LC split, b rows each.
             indices2 = indices.unsqueeze(0)
-            lc = make_scipy_linear_constraints(
+            lcs = make_scipy_linear_constraints(
                 shapeX=shapeX,
                 inequality_constraints=[(indices2, coefficients, 1.0)],
                 equality_constraints=[(indices2, coefficients, 1.0)],
             )
-            # b rows for ineq + b rows for eq
-            self.assertEqual(lc.A.shape, (2 * b, n))
+            self.assertEqual(len(lcs), 2)
+            for lc in lcs:
+                self.assertEqual(lc.A.shape, (b, n))
 
     def test_make_scipy_linear_constraints_sparsity_intra_point(self):
         """Intra-point mixture: per-row column sets are pairwise disjoint
@@ -353,7 +362,7 @@ class TestParameterConstraints(BotorchTestCase):
         shapeX = torch.Size([b, q, d])
         indices = torch.tensor([0, 1, 2], dtype=torch.long, device=self.device)
         coefficients = torch.tensor([1.0, 1.0, 1.0], device=self.device)
-        lc = make_scipy_linear_constraints(
+        (lc,) = make_scipy_linear_constraints(
             shapeX=shapeX,
             equality_constraints=[(indices, coefficients, 1.0)],
         )
@@ -375,7 +384,7 @@ class TestParameterConstraints(BotorchTestCase):
             [[0, 0], [1, 0], [2, 0]], dtype=torch.long, device=self.device
         )
         coefficients = torch.tensor([1.0, 1.0, 1.0], device=self.device)
-        lc = make_scipy_linear_constraints(
+        (lc,) = make_scipy_linear_constraints(
             shapeX=shapeX,
             inequality_constraints=[(indices, coefficients, 0.0)],
         )
@@ -396,7 +405,7 @@ class TestParameterConstraints(BotorchTestCase):
             [[0, 2], [1, 3]], dtype=torch.long, device=self.device
         )
         coeffs = torch.tensor([1.0, -1.0], device=self.device)
-        lc = make_scipy_linear_constraints(
+        (lc,) = make_scipy_linear_constraints(
             shapeX=shapeX,
             equality_constraints=[
                 (intra_indices, coeffs, 0.5),  # broadcast → b*q = 6 rows

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -19,10 +19,8 @@ from botorch.optim.parameter_constraints import (
     _generate_unfixed_nonlin_constraints,
     _make_linear_constraints,
     _make_nonlinear_constraints,
-    eval_lin_constraint,
     evaluate_feasibility,
     get_constraint_tolerance,
-    lin_constraint_jac,
     make_scipy_bounds,
     make_scipy_linear_constraints,
     make_scipy_nonlinear_inequality_constraints,
@@ -43,22 +41,6 @@ class TestParameterConstraints(BotorchTestCase):
             t_np = _arrayify(t)
             self.assertIsInstance(t_np, np.ndarray)
             self.assertTrue(t_np.dtype == np.float64)
-
-    def test_eval_lin_constraint(self):
-        res = eval_lin_constraint(
-            flat_idxr=[0, 2],
-            coeffs=np.array([1.0, -2.0]),
-            rhs=0.5,
-            x=np.array([1.0, 2.0, 3.0]),
-        )
-        self.assertEqual(res, -5.5)
-
-    def test_lin_constraint_jac(self):
-        dummy_array = np.array([1.0])
-        res = lin_constraint_jac(
-            dummy_array, flat_idxr=[0, 2], coeffs=np.array([1.0, -2.0]), n=3
-        )
-        self.assertTrue(all(np.equal(res, np.array([1.0, 0.0, -2.0]))))
 
     def test_make_nonlinear_constraints(self):
         def nlc(x):

--- a/test/optim/test_parameter_constraints.py
+++ b/test/optim/test_parameter_constraints.py
@@ -30,7 +30,9 @@ from botorch.optim.parameter_constraints import (
     project_to_feasible_space_via_slsqp,
 )
 from botorch.utils.testing import BotorchTestCase
-from scipy.optimize import Bounds
+from scipy import sparse
+from scipy.optimize import Bounds, LinearConstraint
+from scipy.optimize._minimize import standardize_constraints
 
 
 class TestParameterConstraints(BotorchTestCase):
@@ -177,87 +179,90 @@ class TestParameterConstraints(BotorchTestCase):
         self.assertEqual(len(res), b * q + b)
 
     def test_make_linear_constraints(self):
-        # equality constraints, 1d indices
+        # equality constraints, 1d indices (intra-point) -> one row per (b, q) pair
         indices = torch.tensor([1, 2], dtype=torch.long, device=self.device)
         for dtype, shapeX in product(
             (torch.float, torch.double), (torch.Size([3, 2, 4]), torch.Size([2, 4]))
         ):
+            b = shapeX[0] if len(shapeX) == 3 else 1
+            q, d = shapeX[-2:]
+            n = shapeX.numel()
             coefficients = torch.tensor([1.0, 2.0], dtype=dtype, device=self.device)
-            constraints = _make_linear_constraints(
+            block = _make_linear_constraints(
                 indices=indices,
                 coefficients=coefficients,
                 rhs=1.0,
                 shapeX=shapeX,
                 eq=True,
             )
-            self.assertTrue(
-                all(set(c.keys()) == {"fun", "jac", "type"} for c in constraints)
-            )
-            self.assertTrue(all(c["type"] == "eq" for c in constraints))
-            self.assertEqual(len(constraints), shapeX[:-1].numel())
-            x = np.random.rand(shapeX.numel())
-            self.assertEqual(constraints[0]["fun"](x), x[1] + 2 * x[2] - 1.0)
-            jac_exp = np.zeros(shapeX.numel())
-            jac_exp[[1, 2]] = [1, 2]
-            self.assertTrue(np.allclose(constraints[0]["jac"](x), jac_exp))
-            self.assertEqual(constraints[-1]["fun"](x), x[-3] + 2 * x[-2] - 1.0)
-            jac_exp = np.zeros(shapeX.numel())
-            jac_exp[[-3, -2]] = [1, 2]
-            self.assertTrue(np.allclose(constraints[-1]["jac"](x), jac_exp))
+            # eq → lb == ub == rhs; row count = b * q
+            self.assertEqual(block.n_rows, b * q)
+            self.assertTrue(np.allclose(block.lb, 1.0))
+            self.assertTrue(np.allclose(block.ub, 1.0))
+            # Materialize and verify per-row semantics against legacy formula.
+            A = sparse.coo_array(
+                (block.vals, (block.rows, block.cols)),
+                shape=(block.n_rows, n),
+            ).toarray()
+            x = np.random.rand(n)
+            # First row is (i=0, j=0) → columns shifted by indices only.
+            self.assertAlmostEqual(float(A[0] @ x), x[1] + 2 * x[2])
+            # Last row is (i=b-1, j=q-1).
+            offset = (b - 1) * q * d + (q - 1) * d
+            self.assertAlmostEqual(float(A[-1] @ x), x[offset + 1] + 2 * x[offset + 2])
 
-        # inequality constraints, 1d indices
+        # inequality constraints, 1d indices → lb=rhs, ub=+inf
         for shapeX in [torch.Size([1, 1, 2]), torch.Size([1, 2])]:
-            lcs = _make_linear_constraints(
+            block = _make_linear_constraints(
                 indices=torch.tensor([1]),
                 coefficients=torch.tensor([1.0]),
                 rhs=1.0,
                 shapeX=shapeX,
                 eq=False,
             )
-            self.assertEqual(len(lcs), 1)
-            self.assertEqual(lcs[0]["type"], "ineq")
+            self.assertEqual(block.n_rows, 1)
+            self.assertTrue(np.allclose(block.lb, 1.0))
+            self.assertTrue(np.all(np.isinf(block.ub)))
 
-        # constraint across q-batch (2d indics), equality constraint
+        # inter-point: 2d indices → one row per t-batch element
         indices = torch.tensor([[0, 3], [1, 2]], dtype=torch.long, device=self.device)
-
         for dtype, shapeX in product(
             (torch.float, torch.double), (torch.Size([3, 2, 4]), torch.Size([2, 4]))
         ):
+            b = shapeX[0] if len(shapeX) == 3 else 1
             q, d = shapeX[-2:]
-            b = 1 if len(shapeX) == 2 else shapeX[0]
+            n = shapeX.numel()
             coefficients = torch.tensor([1.0, 2.0], dtype=dtype, device=self.device)
-            constraints = _make_linear_constraints(
+            block = _make_linear_constraints(
                 indices=indices,
                 coefficients=coefficients,
                 rhs=1.0,
                 shapeX=shapeX,
                 eq=True,
             )
-            self.assertTrue(
-                all(set(c.keys()) == {"fun", "jac", "type"} for c in constraints)
-            )
-            self.assertTrue(all(c["type"] == "eq" for c in constraints))
-            self.assertEqual(len(constraints), b)
-            x = np.random.rand(shapeX.numel())
-            offsets = [q * d, d]
-            # rule is [i, j, k] is i * offset[0] + j * offset[1] + k
+            self.assertEqual(block.n_rows, b)
+            self.assertTrue(np.allclose(block.lb, 1.0))
+            self.assertTrue(np.allclose(block.ub, 1.0))
+            A = sparse.coo_array(
+                (block.vals, (block.rows, block.cols)),
+                shape=(block.n_rows, n),
+            ).toarray()
+            x = np.random.rand(n)
             for i in range(b):
-                pos1 = i * offsets[0] + 3
-                pos2 = i * offsets[0] + 1 * offsets[1] + 2
-                self.assertEqual(constraints[i]["fun"](x), x[pos1] + 2 * x[pos2] - 1.0)
-                jac_exp = np.zeros(shapeX.numel())
-                jac_exp[[pos1, pos2]] = [1, 2]
-                self.assertTrue(np.allclose(constraints[i]["jac"](x), jac_exp))
-        # make sure error is raised for scalar tensors
+                pos1 = i * (q * d) + 0 * d + 3  # q-row=0, feature=3
+                pos2 = i * (q * d) + 1 * d + 2  # q-row=1, feature=2
+                self.assertAlmostEqual(float(A[i] @ x), x[pos1] + 2 * x[pos2])
+
+        # scalar tensor → ValueError
         with self.assertRaises(ValueError):
-            constraints = _make_linear_constraints(
+            _make_linear_constraints(
                 indices=torch.tensor(0),
                 coefficients=torch.tensor([1.0]),
                 rhs=1.0,
                 shapeX=torch.Size([1, 1, 2]),
                 eq=False,
             )
-        # test that len(shapeX) < 2 raises an error
+        # shapeX dim < 2 → UnsupportedError
         with self.assertRaises(UnsupportedError):
             _make_linear_constraints(
                 shapeX=torch.Size([2]),
@@ -269,42 +274,178 @@ class TestParameterConstraints(BotorchTestCase):
     def test_make_scipy_linear_constraints(self):
         for shapeX in [torch.Size([2, 1, 4]), torch.Size([1, 4])]:
             b = shapeX[0] if len(shapeX) == 3 else 1
+            n = shapeX.numel()
+            # None when no constraints
             res = make_scipy_linear_constraints(
                 shapeX=shapeX, inequality_constraints=None, equality_constraints=None
             )
-            self.assertEqual(res, [])
+            self.assertIsNone(res)
+
             indices = torch.tensor([0, 1], dtype=torch.long, device=self.device)
             coefficients = torch.tensor([1.5, -1.0], device=self.device)
+
             # both inequality and equality constraints
-            cs = make_scipy_linear_constraints(
+            lc = make_scipy_linear_constraints(
                 shapeX=shapeX,
                 inequality_constraints=[(indices, coefficients, 1.0)],
                 equality_constraints=[(indices, coefficients, 1.0)],
             )
-            self.assertEqual(len(cs), 2 * b)
-            self.assertTrue({c["type"] for c in cs} == {"ineq", "eq"})
+            self.assertIsInstance(lc, LinearConstraint)
+            # A is sparse and shape matches (m_total, n)
+            self.assertTrue(sparse.issparse(lc.A))
+            self.assertEqual(lc.A.shape, (2 * b, n))
+            # Order: inequality rows first (lb=rhs, ub=+inf), then equality rows
+            # (lb=ub=rhs). Verify per-row.
+            self.assertTrue(np.allclose(lc.lb[:b], 1.0))
+            self.assertTrue(np.all(np.isinf(lc.ub[:b])))
+            self.assertTrue(np.allclose(lc.lb[b:], 1.0))
+            self.assertTrue(np.allclose(lc.ub[b:], 1.0))
+
+            # Round-trip via scipy's standardize_constraints → dicts. scipy
+            # emits ONE vectorized dict per category (eq / ineq), each with a
+            # ``fun`` returning a vector and ``jac`` returning a matrix.
+            # Verifying these against per-row direct math catches regressions
+            # in either layer.
+            x = np.random.rand(n)
+            A_dense = lc.A.toarray()
+            old = standardize_constraints([lc], x0=np.zeros(n), meth="slsqp")
+            self.assertEqual({c["type"] for c in old}, {"ineq", "eq"})
+            # ineq portion is the first b rows; eq portion is the last b rows.
+            ineq_expected = A_dense[:b] @ x - lc.lb[:b]
+            eq_expected = A_dense[b:] @ x - lc.lb[b:]
+            for c in old:
+                val = np.atleast_1d(np.asarray(c["fun"](x), dtype=float))
+                jac = np.atleast_2d(np.asarray(c["jac"](x), dtype=float))
+                if c["type"] == "ineq":
+                    np.testing.assert_allclose(val, ineq_expected, atol=1e-10)
+                    np.testing.assert_allclose(jac, A_dense[:b], atol=1e-10)
+                else:
+                    np.testing.assert_allclose(val, eq_expected, atol=1e-10)
+                    np.testing.assert_allclose(jac, A_dense[b:], atol=1e-10)
+
             # inequality only
-            cs = make_scipy_linear_constraints(
+            lc = make_scipy_linear_constraints(
                 shapeX=shapeX, inequality_constraints=[(indices, coefficients, 1.0)]
             )
-            self.assertEqual(len(cs), b)
-            self.assertTrue(all(c["type"] == "ineq" for c in cs))
+            self.assertEqual(lc.A.shape, (b, n))
+            self.assertTrue(np.all(np.isinf(lc.ub)))
             # equality only
-            cs = make_scipy_linear_constraints(
+            lc = make_scipy_linear_constraints(
                 shapeX=shapeX, equality_constraints=[(indices, coefficients, 1.0)]
             )
-            self.assertEqual(len(cs), b)
-            self.assertTrue(all(c["type"] == "eq" for c in cs))
+            self.assertEqual(lc.A.shape, (b, n))
+            self.assertTrue(np.allclose(lc.lb, lc.ub))
 
-            # test that 2-dim indices work properly
-            indices = indices.unsqueeze(0)
-            cs = make_scipy_linear_constraints(
+            # 2-dim (inter-point) indices: still produces a valid LinearConstraint.
+            indices2 = indices.unsqueeze(0)
+            lc = make_scipy_linear_constraints(
                 shapeX=shapeX,
-                inequality_constraints=[(indices, coefficients, 1.0)],
-                equality_constraints=[(indices, coefficients, 1.0)],
+                inequality_constraints=[(indices2, coefficients, 1.0)],
+                equality_constraints=[(indices2, coefficients, 1.0)],
             )
-            self.assertEqual(len(cs), 2 * b)
-            self.assertTrue({c["type"] for c in cs} == {"ineq", "eq"})
+            # b rows for ineq + b rows for eq
+            self.assertEqual(lc.A.shape, (2 * b, n))
+
+    def test_make_scipy_linear_constraints_sparsity_intra_point(self):
+        """Intra-point mixture: per-row column sets are pairwise disjoint
+        (block-diagonal pattern) and nnz == b * q * len(indices)."""
+        b, q, d = 4, 3, 5
+        shapeX = torch.Size([b, q, d])
+        indices = torch.tensor([0, 1, 2], dtype=torch.long, device=self.device)
+        coefficients = torch.tensor([1.0, 1.0, 1.0], device=self.device)
+        lc = make_scipy_linear_constraints(
+            shapeX=shapeX,
+            equality_constraints=[(indices, coefficients, 1.0)],
+        )
+        self.assertEqual(lc.A.shape, (b * q, b * q * d))
+        self.assertEqual(lc.A.nnz, b * q * len(indices))
+        dense = lc.A.toarray()
+        col_sets = [set(np.flatnonzero(dense[row])) for row in range(b * q)]
+        for r1 in range(b * q):
+            self.assertEqual(len(col_sets[r1]), len(indices))
+            for r2 in range(r1 + 1, b * q):
+                self.assertTrue(col_sets[r1].isdisjoint(col_sets[r2]))
+
+    def test_make_scipy_linear_constraints_inter_point_pattern(self):
+        """Inter-point: scattered strided non-zeros, e.g. cols [0, d, 2d]."""
+        b, q, d = 1, 3, 5
+        shapeX = torch.Size([b, q, d])
+        # one constraint touching feature 0 of each q-row
+        indices = torch.tensor(
+            [[0, 0], [1, 0], [2, 0]], dtype=torch.long, device=self.device
+        )
+        coefficients = torch.tensor([1.0, 1.0, 1.0], device=self.device)
+        lc = make_scipy_linear_constraints(
+            shapeX=shapeX,
+            inequality_constraints=[(indices, coefficients, 0.0)],
+        )
+        self.assertEqual(lc.A.shape, (b, b * q * d))
+        nz_cols = sorted(np.flatnonzero(lc.A.toarray()[0]).tolist())
+        self.assertEqual(nz_cols, [0, d, 2 * d])
+
+    def test_make_scipy_linear_constraints_mixed_intra_inter(self):
+        """Stack an intra-point and an inter-point constraint into one
+        LinearConstraint, verifying the COO row-offset arithmetic across
+        blocks with mismatched n_rows (intra contributes b*q rows; inter
+        contributes b)."""
+        b, q, d = 3, 2, 4
+        shapeX = torch.Size([b, q, d])
+        n = shapeX.numel()
+        intra_indices = torch.tensor([0, 1], dtype=torch.long, device=self.device)
+        inter_indices = torch.tensor(
+            [[0, 2], [1, 3]], dtype=torch.long, device=self.device
+        )
+        coeffs = torch.tensor([1.0, -1.0], device=self.device)
+        lc = make_scipy_linear_constraints(
+            shapeX=shapeX,
+            equality_constraints=[
+                (intra_indices, coeffs, 0.5),  # broadcast → b*q = 6 rows
+                (inter_indices, coeffs, 0.7),  # broadcast → b   = 3 rows
+            ],
+        )
+        # 6 intra rows then 3 inter rows over n = b*q*d = 24 columns.
+        self.assertEqual(lc.A.shape, (b * q + b, n))
+        self.assertTrue(np.allclose(lc.lb[: b * q], 0.5))
+        self.assertTrue(np.allclose(lc.ub[: b * q], 0.5))
+        self.assertTrue(np.allclose(lc.lb[b * q :], 0.7))
+        self.assertTrue(np.allclose(lc.ub[b * q :], 0.7))
+
+        x = np.random.rand(n)
+        A = lc.A.toarray()
+        # Intra row 0 → (i=0, j=0); cols [0, 1].
+        self.assertAlmostEqual(float(A[0] @ x), x[0] - x[1])
+        # Intra row 1 → (i=0, j=1); cols offset by d = 4.
+        self.assertAlmostEqual(float(A[1] @ x), x[4] - x[5])
+        # Intra last row → (i=b-1, j=q-1); cols (b-1)*q*d + (q-1)*d + [0, 1].
+        intra_last_off = (b - 1) * q * d + (q - 1) * d
+        self.assertAlmostEqual(
+            float(A[b * q - 1] @ x), x[intra_last_off] - x[intra_last_off + 1]
+        )
+        # Inter row 0 (== global row b*q) → i=0; cols [0*d+2, 1*d+3] = [2, 7].
+        self.assertAlmostEqual(float(A[b * q] @ x), x[2] - x[7])
+        # Inter last row → i=b-1; cols (b-1)*q*d + [0*d+2, 1*d+3] = [18, 23].
+        inter_last_off = (b - 1) * q * d
+        self.assertAlmostEqual(
+            float(A[-1] @ x),
+            x[inter_last_off + 2] - x[inter_last_off + d + 3],
+        )
+
+        # Round-trip via scipy's standardizer: one ineq dict would be absent
+        # (we passed only equalities), so we expect one eq dict whose
+        # vectorized fun(x) equals A @ x - lb element-wise.
+        old = standardize_constraints([lc], x0=np.zeros(n), meth="slsqp")
+        self.assertEqual({c["type"] for c in old}, {"eq"})
+        eq_dict = next(c for c in old if c["type"] == "eq")
+        np.testing.assert_allclose(
+            np.atleast_1d(np.asarray(eq_dict["fun"](x), dtype=float)),
+            A @ x - lc.lb,
+            atol=1e-10,
+        )
+        np.testing.assert_allclose(
+            np.atleast_2d(np.asarray(eq_dict["jac"](x), dtype=float)),
+            A,
+            atol=1e-10,
+        )
 
     def test_make_scipy_linear_constraints_unsupported(self):
         shapeX = torch.Size([2, 1, 4])


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

`make_scipy_linear_constraints` currently returns a `list[ScipyConstraintDict]` — one dense dict per `(restart, q-row)` block, where each `jac(x)` closure builds an `np.zeros(n)` row with a few entries set. That works for SLSQP/COBYLA (which only accept the dict form), but it throws away the constraint Jacobian's sparsity structure for *any* solver that could exploit it.

Motivating use case:

**Sparse-aware custom solvers.** When a user passes a callable via `options["method"]` (scipy's `_custom` dispatch), the callable receives the constraints as-is. With dicts, the solver has no way to recover sparsity short of fragile probing. With a `LinearConstraint(sparse_A, lb, ub)` object, it can read `A.row`/`A.col`/`A.data` directly and hand Ipopt-style solvers a sparse `jacobianstructure` / `jacobian`. This can help for aggregated BoTorch problems with b·q·d up into the hundred or even thousands.

This PR switches `make_scipy_linear_constraints` to return up to **two** `scipy.optimize.LinearConstraint` objects (a `list` of 0, 1, or 2 entries): one stacking all inequality rows, one stacking all equality rows. Each carries a single `scipy.sparse.coo_array` for `A` plus the corresponding `lb` / `ub` vectors (equalities: `lb=ub=rhs`; inequalities: `lb=rhs, ub=+inf`, matching BoTorch's existing `A @ x >= rhs` convention). Keeping eq and ineq in separate objects avoids the `OptimizeWarning` scipy emits during SLSQP conversion when both row types share an `A`.

**Backward compatibility** is preserved end-to-end:

- SLSQP and COBYLA still work via scipy's `standardize_constraints`, which auto-converts each `LinearConstraint` back into per-row dicts via `new_constraint_to_old` before dispatch.
- Mixed lists like `[LinearConstraint, LinearConstraint, dict, dict]` (linear + nonlinear) are natively supported by `scipy.optimize.minimize`.
- The only internal consumers (`botorch/generation/gen.py:345` and `botorch/optim/parameter_constraints.py:project_to_feasible_space_via_slsqp`) are migrated to the new return type with a trivial `list(...)` wrap so the result composes with downstream nonlinear-constraint dicts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests for `_make_linear_constraints` and `make_scipy_linear_constraints` are rewritten to assert on the new structure (sparse `A`, `lb`/`ub` vectors, list-of-LCs return type) while preserving the semantic checks. New tests added in `test/optim/test_parameter_constraints.py`:

- `test_make_scipy_linear_constraints` now uses `scipy.optimize._minimize.standardize_constraints` to round-trip the list of `LinearConstraint`s back into the legacy dict form and verifies the per-row `fun(x)` / `jac(x)` math is unchanged. Catches both incorrect COO emission *and* any future regression in scipy's converter. The round-trip is run under `warnings.simplefilter("error", OptimizeWarning)` to pin the eq/ineq split (any future re-merge into a single `LinearConstraint` will fail the test).
- `test_make_scipy_linear_constraints_sparsity_intra_point` — for `shapeX=(b=4, q=3, d=5)` intra-point mixture, asserts the per-row column sets are pairwise disjoint (block-diagonal) and `nnz == b * q * len(indices)`.
- `test_make_scipy_linear_constraints_inter_point_pattern` — for an inter-point constraint `[(0,0), (1,0), (2,0)]`, asserts the resulting row has non-zeros at the strided positions `[0, d, 2d]`.
- `test_make_scipy_linear_constraints_mixed_intra_inter` — stacks one intra-point and one inter-point equality constraint in the same call and verifies the COO row-offset arithmetic, the `lb`/`ub` slicing across blocks, per-row math at five row positions, and the `standardize_constraints` round-trip. This case was never covered before this PR.

Separately, a small dispatch smoke test in `test/generation/test_gen.py`:

- `test_gen_candidates_scipy_custom_method_dispatch` — passes a callable that raises a sentinel exception as `options["method"]` and asserts the exception bubbles up through `gen_candidates_scipy → minimize_with_timeout → scipy → _custom`. Pins the integration point that custom solvers (pounce, ipopt-via-cyipopt, …) rely on; if any layer ever drops the callable on the floor, this test catches it.


## Related PRs

https://github.com/meta-pytorch/botorch/pull/2368 is related, but it can be closed after this PR as the option to pass in a seperate callable to scipy.optimize.minimize makes changes in botorch (despite expression of the sparsity structure obsolete). 