### PR TITLE
Skip codecov upload during release to avoid blocking deploys

### DIFF
--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       use_latest_pytorch_gpytorch: false
+      upload_coverage: false
     secrets: inherit
 
   package-deploy-pypi:


### PR DESCRIPTION
## Summary

A flaky codecov upload can currently block a BoTorch release.

`reusable_test.yml` runs the coverage upload with `fail_ci_if_error: true`, so a transient codecov failure fails the `tests-and-coverage` job. In `deploy_on_release.yml`, the deploy jobs gate on that job:

- `package-deploy-pypi` → `needs: tests-and-coverage`
- `version-and-publish-website` → `needs: package-deploy-pypi`

So a codecov hiccup → tests-and-coverage fails → **PyPI publish skipped → website publish skipped** → the whole release is blocked.

## Change

Pass `upload_coverage: false` from the release workflow. The reusable workflow already supports this input; it gates the codecov step. One-line change.

Coverage is still uploaded by regular CI (`test.yml`) on merged PRs, so nothing meaningful is lost.