### PR TITLE
Open-source EmpiricalOneDimensionalGP (#3322)

### DIFF
--- a/botorch/models/__init__.py
+++ b/botorch/models/__init__.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
         GenericDeterministicModel,
         PosteriorMeanModel,
     )
+    from botorch.models.empirical_gps.empirical_1d_gp import (  # noqa: F401
+        EmpiricalOneDimensionalGP,
+    )
     from botorch.models.gp_regression import SingleTaskGP as SingleTaskGP  # noqa: F401
     from botorch.models.gp_regression_fidelity import (  # noqa: F401
         SingleTaskMultiFidelityGP,
@@ -53,6 +56,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "AffineDeterministicModel": (".deterministic", "AffineDeterministicModel"),
     "GenericDeterministicModel": (".deterministic", "GenericDeterministicModel"),
     "PosteriorMeanModel": (".deterministic", "PosteriorMeanModel"),
+    "EmpiricalOneDimensionalGP": (
+        ".empirical_gps.empirical_1d_gp",
+        "EmpiricalOneDimensionalGP",
+    ),
     "SingleTaskGP": (".gp_regression", "SingleTaskGP"),
     "SingleTaskMultiFidelityGP": (
         ".gp_regression_fidelity",

--- a/botorch/models/empirical_gps/__init__.py
+++ b/botorch/models/empirical_gps/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from botorch.models.empirical_gps.empirical_1d_gp import (
+    EmpiricalOneDimensionalGP,
+    EmpiricalOneDimensionalKernel,
+    EmpiricalOneDimensionalMean,
+)
+
+
+__all__ = [
+    "EmpiricalOneDimensionalGP",
+    "EmpiricalOneDimensionalKernel",
+    "EmpiricalOneDimensionalMean",
+]

--- a/botorch/models/empirical_gps/empirical_1d_gp.py
+++ b/botorch/models/empirical_gps/empirical_1d_gp.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Empirical one-dimensional Gaussian Process models.
+
+These models use a collection of historical one-dimensional curves to define an
+empirical prior mean and covariance for a ``SingleTaskGP``. They support both
+single-output and batch-independent multi-output modeling.
+
+References
+
+.. [lin2026empirical]
+    J. A. Lin, S. Ament, L. C. Tiao, D. Eriksson, M. Balandat, and E. Bakshy.
+    Empirical Gaussian Processes. International Conference on Machine Learning
+    (ICML), 2026. https://arxiv.org/abs/2602.12082
+"""
+
+from __future__ import annotations
+
+from botorch.exceptions.errors import UnsupportedError
+from botorch.models import SingleTaskGP
+from botorch.models.empirical_gps.utils import (
+    center_curves,
+    compute_basis_matrix,
+    compute_orthogonal_basis,
+    compute_sample_covariance,
+    extract_slice_for_interp,
+    instantiate_ard,
+    LinearInterpolation1D,
+)
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+from gpytorch.kernels import Kernel
+from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.means import Mean
+from torch import Tensor
+
+
+# =============================================================================
+# EmpiricalOneDimensionalGP Model
+# =============================================================================
+
+
+class EmpiricalOneDimensionalGP(SingleTaskGP):
+    """Single-task GP with an empirical prior learned from historical 1-D curves.
+
+    The prior mean and covariance are estimated from a collection of related
+    historical curves and interpolated to the query inputs (see
+    ``EmpiricalOneDimensionalMean`` and ``EmpiricalOneDimensionalKernel``),
+    yielding a data-driven prior for settings where related curves have been
+    observed previously.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        historical_X: Tensor,
+        historical_Y: Tensor,
+        train_Yvar: Tensor | None = None,
+        likelihood: Likelihood | None = None,
+        input_transform: InputTransform | None = None,
+        outcome_transform: OutcomeTransform | None = None,
+        mean_module: Mean | None = None,
+        covar_module: Kernel | None = None,
+        ard: bool = False,
+    ) -> None:
+        """Instantiates an empirical one-dimensional GP model.
+
+        This GP uses historical one-dimensional curves to define the prior mean and
+        covariance, following [lin2026empirical]_. Supports both single-output and
+        multi-output with independent outputs (batch-independent GPs).
+
+        Args:
+            train_X: `batch_shape x n x 1`-dim Tensor of training inputs.
+            train_Y: `batch_shape x n x m`-dim Tensor of training targets.
+            historical_X: `num_progression x 1`-dim Tensor of progression values.
+            historical_Y: `num_curves x num_progression x m`-dim Tensor of historical
+                curves, where m is the number of outputs (m=1 for single-output).
+            train_Yvar: `batch_shape x n x m`-dim Tensor of observation noise.
+            likelihood: A likelihood. If omitted, use a standard GaussianLikelihood
+                with inferred noise level if train_Yvar is None, and a
+                FixedNoiseGaussianLikelihood with the given noise observations
+                if train_Yvar is not None.
+            input_transform: Input transform for the model. Not yet supported.
+            outcome_transform: Outcome transform for the model. Not yet supported.
+            mean_module: Optional custom mean module.
+            covar_module: Optional custom covariance module.
+            ard: Whether to use Automatic Relevance Determination on the basis.
+
+        Raises:
+            ValueError: If historical_Y is not 3-dimensional or if the number of
+                outputs in historical_Y does not match train_Y.
+            UnsupportedError: If input_transform or outcome_transform is provided.
+        """
+        # Check for unsupported transforms
+        if input_transform is not None:
+            raise UnsupportedError(
+                "input_transform is not yet supported for EmpiricalOneDimensionalGP."
+            )
+        if outcome_transform is not None:
+            raise UnsupportedError(
+                "outcome_transform is not yet supported for EmpiricalOneDimensionalGP."
+            )
+
+        # Validate historical_Y is 3D
+        if historical_Y.ndim != 3:
+            raise ValueError(
+                f"Expected historical_Y to be 3-dim (num_curves x num_progression x m),"
+                f" got {historical_Y.ndim}-dim."
+            )
+
+        # Validate matching number of outputs
+        num_outputs_train = train_Y.shape[-1]
+        num_outputs_historical = historical_Y.shape[-1]
+
+        if num_outputs_train != num_outputs_historical:
+            raise ValueError(
+                f"Number of outputs in train_Y ({num_outputs_train}) must match "
+                f"historical_Y ({num_outputs_historical})."
+            )
+
+        if covar_module is None:
+            covar_module = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                ard=ard,
+            )
+        elif not isinstance(covar_module, EmpiricalOneDimensionalKernel):
+            raise ValueError(
+                "covar_module must be an instance of EmpiricalOneDimensionalKernel."
+            )
+        elif ard != covar_module.ard:
+            raise ValueError("`ard` argument must equal `covar_module.ard`.")
+
+        if mean_module is None:
+            mean_module = EmpiricalOneDimensionalMean(
+                X_full=historical_X,
+                Y_full=historical_Y,
+            )
+
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            likelihood=likelihood,
+            mean_module=mean_module,
+            covar_module=covar_module,
+            input_transform=input_transform,
+            outcome_transform=outcome_transform,
+        )
+
+
+# =============================================================================
+# Mean Module
+# =============================================================================
+
+
+class EmpiricalOneDimensionalMean(Mean):
+    """Empirical one-dimensional mean function.
+
+    Computes the mean by averaging historical curves and interpolating.
+    """
+
+    def __init__(
+        self,
+        X_full: Tensor,
+        Y_full: Tensor,
+    ):
+        """Instantiates an empirical one-dimensional mean function.
+
+        Args:
+            X_full: `num_progression x 1`-dim Tensor of progression values.
+            Y_full: `num_curves x num_progression x m`-dim Tensor of historical
+                curves, where m is the number of outputs (m=1 for single-output).
+        """
+        if Y_full.ndim != 3:
+            raise ValueError(
+                f"Expected Y_full to be 3-dim (num_curves x num_progression x m), "
+                f"got {Y_full.ndim}-dim."
+            )
+
+        super().__init__()
+        self.X_full = X_full  # num_progression x 1
+
+        self.num_outputs = Y_full.shape[-1]
+
+        # Compute mean across curves:
+        # num_curves x num_progression x m -> num_progression x m
+        # Then transpose to m x num_progression for interpolation
+        self.mean_full = Y_full.mean(dim=0).T  # m x num_progression
+
+        self.f = LinearInterpolation1D(
+            self.X_full.squeeze(-1),
+            self.mean_full,
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Computes the mean function at x.
+
+        Args:
+            x: Input locations. For single-output, a `batch_shape x n x d`-dim
+                Tensor. For multi-output (after the SingleTaskGP transform), a
+                `batch_shape x m x n x d`-dim Tensor whose m slices are identical
+                (replicated by SingleTaskGP).
+
+        Returns:
+            A `batch_shape x n`-dim Tensor for single-output, or a
+            `batch_shape x m x n`-dim Tensor for multi-output.
+        """
+        x_for_interp = extract_slice_for_interp(x, self.num_outputs)
+
+        # Interpolate: result is m x batch_shape x n. Out-of-range inputs are
+        # rejected by the interpolant itself (bounds_error=True).
+        y = self.f(x_for_interp)
+
+        # Rearrange: move m from position 0 to position -2 → batch_shape x m x n
+        y = y.movedim(0, -2)
+
+        # For single-output, squeeze the m=1 dimension
+        if self.num_outputs == 1:
+            y = y.squeeze(-2)
+
+        return y
+
+
+# =============================================================================
+# Kernel Module
+# =============================================================================
+
+
+class EmpiricalOneDimensionalKernel(Kernel):
+    r"""Empirical One-Dimensional Kernel.
+
+    This kernel computes the empirical covariance of one-dimensional curves at given
+    progression points by interpolating historical curve data.
+
+    By default, when `num_curves > num_progression` and `ard=False`, the kernel
+    uses SVD decomposition to accelerate computation. This reduces complexity
+    from O(n1 * num_curves * n2) to O(n1 * r * n2) where r = min(num_curves,
+    num_progression).
+    """
+
+    ard: bool = False
+
+    def __init__(
+        self,
+        X_full: Tensor,
+        Y_full: Tensor,
+        ard: bool = False,
+        curve_weights: Tensor | None = None,
+        use_svd: bool | None = None,
+        correction: int = 0,
+    ) -> None:
+        """Instantiates an empirical one-dimensional kernel.
+
+        Args:
+            X_full: `num_progression x 1`-dim Tensor of progression values.
+            Y_full: `num_curves x num_progression x m`-dim Tensor of historical
+                curves, where m is the number of outputs (m=1 for single-output).
+            ard: Whether to use Automatic Relevance Determination (ARD).
+            curve_weights: `num_curves`-dim Tensor of ARD weights.
+            use_svd: Whether to use SVD acceleration. If None (default), SVD is
+                used when num_curves > num_progression and ard=False. If True or
+                False, directly toggles SVD on or off. Note: using ARD on the SVD
+                basis implies a different prior than ARD on the original basis.
+                This flag explicitly allows both approaches.
+            correction: Degree of freedom correction to use for the computation of
+                sample covariance, see `compute_sample_covariance` for details.
+        """
+        if Y_full.ndim != 3:
+            raise ValueError(
+                f"Expected Y_full to be 3-dim (num_curves x num_progression x m), "
+                f"got {Y_full.ndim}-dim."
+            )
+
+        super().__init__()
+
+        self.X_full = X_full
+
+        self.num_curves = Y_full.shape[0]
+        self.correction = correction
+        self.num_outputs = Y_full.shape[-1]
+        num_progression = Y_full.shape[1]
+
+        # Center curves across the curve dimension (dim 0)
+        _, Y_centered = center_curves(Y_full, curve_dim=0)
+
+        # Reshape for interpolation: m x num_curves x num_progression
+        Y_for_interp = Y_centered.movedim(-1, 0)
+
+        # Apply SVD if requested (must be after reshaping for correct batched SVD)
+        if use_svd is None:
+            # Default: use SVD when num_curves > num_progression and ard is False
+            self._use_svd = not ard and self.num_curves > num_progression
+        else:
+            self._use_svd = use_svd
+
+        if self._use_svd:
+            Y_for_interp = compute_orthogonal_basis(Y_for_interp, method="eigh")
+            # After SVD, curve dim becomes r = min(num_curves, num_progression)
+            self._effective_num_curves = min(self.num_curves, num_progression)
+        else:
+            self._effective_num_curves = self.num_curves
+
+        self.f = LinearInterpolation1D(self.X_full.squeeze(-1), Y_for_interp)
+
+        self.Y_full = Y_full
+        self.Y_full_centered = Y_centered
+
+        if ard:
+            # When using SVD + ARD, apply ARD weights to the SVD basis vectors
+            # which have dimension r = min(num_curves, num_progression)
+            instantiate_ard(
+                obj=self,
+                num_curves=self._effective_num_curves,
+                curve_weights=curve_weights,
+                dtype=Y_full.dtype,
+                device=Y_full.device,
+            )
+        else:
+            self.curve_weights = curve_weights
+            self.ard = False
+
+    @property
+    def use_svd(self) -> bool:
+        """A Boolean indicating whether the kernel uses the SVD efficiency technique."""
+        return self._use_svd
+
+    def forward(
+        self,
+        x1: Tensor,
+        x2: Tensor,
+        diag: bool = False,
+        last_dim_is_batch: bool = False,
+    ) -> Tensor:
+        """Computes the kernel matrix k(x1, x2).
+
+        Args:
+            x1: Input tensor. For single-output, `batch_shape x n1 x d`; for
+                multi-output, `batch_shape x m x n1 x d` (after
+                `multioutput_to_batch_mode_transform` has been applied).
+            x2: Input tensor with the same shape structure as x1.
+            diag: If True, only returns the diagonal.
+            last_dim_is_batch: If True, treats the last dimension as batch.
+
+        Returns:
+            A `batch_shape x n1 x n2`-dim covariance matrix for single-output, or
+            a `batch_shape x m x n1 x n2`-dim covariance matrix for multi-output.
+            If diag=True, returns the diagonal with one fewer trailing dimension.
+        """
+        if last_dim_is_batch:
+            raise NotImplementedError(
+                "last_dim_is_batch=True not supported by EmpiricalOneDimensionalKernel."
+            )
+
+        # Prepare inputs for interpolation (extracts slice for multi-output)
+        x1_for_interp = extract_slice_for_interp(x1, self.num_outputs)
+        x2_for_interp = (
+            x1_for_interp
+            if x2 is x1
+            else extract_slice_for_interp(x2, self.num_outputs)
+        )
+
+        # Compute basis matrices using shared helper
+        Ux1 = compute_basis_matrix(
+            f=self.f,
+            x=x1_for_interp,
+            num_outputs=self.num_outputs,
+            curve_weights=self.curve_weights,
+        )
+        Ux2 = (
+            Ux1
+            if x2_for_interp is x1_for_interp
+            else compute_basis_matrix(
+                f=self.f,
+                x=x2_for_interp,
+                num_outputs=self.num_outputs,
+                curve_weights=self.curve_weights,
+            )
+        )
+
+        # Compute sample covariance
+        K = compute_sample_covariance(
+            U1=Ux1,
+            U2=None if x2_for_interp is x1_for_interp else Ux2,
+            num_curves=self.num_curves,
+            diag=diag,
+            correction=self.correction,
+        )
+
+        # Rearrange: move m from position 0 to position -3 → batch_shape x m x n1 x n2
+        if diag:
+            K = K.movedim(0, -2)  # batch_shape x m x n
+        else:
+            K = K.movedim(0, -3)  # batch_shape x m x n1 x n2
+
+        # For single-output, squeeze the m=1 dimension
+        if self.num_outputs == 1:
+            if diag:
+                K = K.squeeze(-2)
+            else:
+                K = K.squeeze(-3)
+
+        return K

--- a/botorch/models/empirical_gps/utils.py
+++ b/botorch/models/empirical_gps/utils.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Utility functions for empirical one-dimensional Gaussian Processes."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+from botorch.exceptions.errors import UnsupportedError
+from botorch.utils.constraints import NonTransformedInterval
+from torch import Tensor
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
+
+# =============================================================================
+# Covariance Computation Helpers
+# =============================================================================
+
+
+def compute_orthogonal_basis(A: Tensor, method: str = "svd") -> Tensor:
+    """Compute an orthogonal basis for efficient Gram matrix computation.
+
+    For a matrix A with shape (..., m, n) where m >> n, the Gram matrix A.T @ A
+    can be computed more efficiently using a compact orthogonal basis.
+
+    Mathematical Background:
+        The economy SVD gives A = U @ diag(S) @ Vh where:
+        - U: (..., m, r) with orthonormal columns (U.T @ U = I_r)
+        - S: (..., r) singular values
+        - Vh: (..., r, n) with orthonormal rows
+        - r = min(m, n)
+
+        Since U.T @ U = I_r:
+            A.T @ A = (U @ S @ Vh).T @ (U @ S @ Vh)
+                    = Vh.T @ S @ U.T @ U @ S @ Vh
+                    = Vh.T @ S^2 @ Vh
+                    = (S @ Vh).T @ (S @ Vh)
+
+        By using the (..., r, n) matrix S @ Vh instead of the (..., m, n) matrix A,
+        we reduce complexity from O(k1 * m * k2) to O(k1 * r * k2) when
+        computing products like A[..., idx1].T @ A[..., idx2].
+
+    Two algorithms produce a basis with the same Gram matrix (B.T @ B = A.T @ A):
+        - "svd" (default): economy SVD of A. Numerically robust.
+        - "eigh": eigendecomposition of the Gram matrix A.T @ A. This avoids
+          forming the (m, r) left singular vectors, so it is typically faster
+          when m >> n, at the cost of squaring the condition number (reduced
+          accuracy for the smallest singular values).
+
+    Example:
+        >>> A = torch.randn(10000, 50)  # tall matrix with m >> n
+        >>> B = compute_orthogonal_basis(A)  # shape (50, 50)
+        >>> # B.T @ B equals A.T @ A
+        >>> A_batched = torch.randn(3, 10000, 50)  # batched tall matrices
+        >>> B_batched = compute_orthogonal_basis(A_batched)  # shape (3, 50, 50)
+
+    Args:
+        A: (..., m, n) tensor with arbitrary batch dimensions.
+        method: Decomposition to use, either "svd" or "eigh".
+
+    Returns:
+        (..., r, n) tensor with r = min(m, n) such that
+        B.T @ B = A.T @ A. Its rows are mutually orthogonal but not
+        orthonormal (each is scaled by its singular value).
+    """
+    if method == "svd":
+        # Economy SVD: A = U @ diag(S) @ Vh
+        # U: (..., m, r), S: (..., r), Vh: (..., r, n) where r = min(m, n)
+        _, S, Vh = torch.linalg.svd(A, full_matrices=False)
+        # Return S @ Vh, shape (..., r, n)
+        return S.unsqueeze(-1) * Vh
+    if method == "eigh":
+        # A.T @ A = V @ diag(lambda) @ V.T, so B = diag(sqrt(lambda)) @ V.T
+        # satisfies B.T @ B = A.T @ A.
+        gram = A.transpose(-2, -1) @ A
+        eigvals, eigvecs = torch.linalg.eigh(gram)
+        # eigh returns ascending eigenvalues; flip to descending (to match SVD)
+        # and clamp tiny negative eigenvalues from round-off before the sqrt.
+        eigvals = eigvals.flip(-1).clamp_min(0.0)
+        eigvecs = eigvecs.flip(-1)
+        B = eigvals.sqrt().unsqueeze(-1) * eigvecs.transpose(-2, -1)
+        # Truncate to r = min(m, n) rows to match the economy-SVD shape.
+        # When m < n the dropped rows have zero eigenvalues, so B.T @ B
+        # is unchanged.
+        r = min(A.shape[-2], A.shape[-1])
+        return B[..., :r, :]
+    raise ValueError(f"Unknown method: {method!r}. Must be 'svd' or 'eigh'.")
+
+
+def center_curves(Y: Tensor, curve_dim: int = -2) -> tuple[Tensor, Tensor]:
+    """Center curves by subtracting the mean across the curve dimension.
+
+    This is a common operation used by both mean and kernel modules.
+
+    Args:
+        Y: Tensor containing curves. The curve dimension contains different
+            realizations to average over.
+        curve_dim: Dimension containing the curves to average over.
+
+    Returns:
+        A tuple `(mean, centered)` where `mean` is the average across curves
+        (with `curve_dim` removed) and `centered` is `Y` minus that mean,
+        broadcast back to the shape of `Y`.
+    """
+    mean = Y.mean(dim=curve_dim, keepdim=True)
+    centered = Y - mean
+    return mean.squeeze(curve_dim), centered
+
+
+def compute_sample_covariance(
+    U1: Tensor,
+    U2: Tensor | None,
+    num_curves: int,
+    diag: bool = False,
+    correction: int = 0,
+) -> Tensor:
+    """Compute sample covariance from basis matrices.
+
+    Computes U1.T @ U2 / (num_curves - correction) (or its diagonal if
+    diag=True). ``correction`` defaults to 0, i.e. division by ``num_curves``.
+
+    Args:
+        U1: `... x num_curves x n1`-dim basis matrix.
+        U2: `... x num_curves x n2`-dim basis matrix, or None to use U1.
+        num_curves: Number of curves (for normalization).
+        diag: If True, only compute the diagonal.
+        correction: Degrees of freedom correction.
+
+    Returns:
+        Covariance matrix of shape `... x n1 x n2`, or diagonal `... x n1` if diag=True.
+    """
+    if U2 is None:
+        U2 = U1
+
+    if diag:
+        K = (U1 * U2).sum(dim=-2)
+    else:
+        K = U1.transpose(-2, -1) @ U2
+
+    if num_curves <= correction:
+        raise ValueError(
+            f"num_curves ({num_curves}) must be greater than correction ({correction})."
+        )
+
+    K = K / (num_curves - correction)
+    return K
+
+
+def extract_slice_for_interp(x: Tensor, num_outputs: int) -> Tensor:
+    """Prepare input tensor for interpolation.
+
+    For multi-output (num_outputs > 1), SingleTaskGP replicates X m times at
+    dim -3. Since all slices are identical, we extract one slice to avoid
+    broadcasting issues during interpolation.
+
+    Also squeezes the trailing dimension if d=1, as required for 1D interpolation.
+
+    Args:
+        x: Input tensor. For single-output (m=1), `batch_shape x n x d`; for
+            multi-output (m>1), `batch_shape x m x n x d` (replicated by
+            SingleTaskGP).
+
+    Returns:
+        For d=1: `batch_shape x n` tensor suitable for 1D interpolation.
+        For d>1: `batch_shape x n x d` tensor.
+    """
+    # For multi-output, extract one slice from the m dimension at position -3
+    if num_outputs > 1 and x.ndim >= 3 and x.shape[-3] == num_outputs:
+        x = x[..., 0, :, :]  # batch_shape x n x d
+
+    # Squeeze trailing dimension if d=1 (for 1D interpolation)
+    if x.shape[-1] == 1:
+        x = x.squeeze(-1)
+
+    return x
+
+
+def compute_basis_matrix(
+    f: Callable[[Tensor], Tensor],
+    x: Tensor,
+    num_outputs: int,
+    curve_weights: Tensor | None = None,
+) -> Tensor:
+    """Compute the basis matrix U(x) for covariance computation.
+
+    Args:
+        f: Interpolation function that takes x and returns interpolated values.
+            Returns `m x num_curves x batch_shape x n` where m is num_outputs.
+        x: `batch_shape x n`-dim Tensor of input locations (no trailing 1).
+        num_outputs: Number of outputs (m). Always >= 1.
+        curve_weights: Optional `num_curves`-dim Tensor of ARD weights.
+
+    Returns:
+        `m x batch_shape x num_curves x n`-dim Tensor.
+    """
+    # Interpolate: returns m x num_curves x batch_shape x n
+    Ux = f(x)
+    Ux = torch.as_tensor(Ux)
+
+    # Move num_curves from position 1 to position -2: m x batch_shape x num_curves x n
+    Ux = Ux.movedim(1, -2)
+
+    # Apply ARD weights if present
+    if curve_weights is not None:
+        Ux = Ux * curve_weights.unsqueeze(-1)
+
+    return Ux
+
+
+def instantiate_ard(
+    obj: Module,
+    num_curves: int,
+    curve_weights: Tensor | None,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device | None = None,
+) -> None:
+    """Instantiates the curve_weights parameter and constraint.
+
+    Args:
+        obj: The object to which to add the parameter and constraint.
+        num_curves: Number of curves (or orthogonal basis vectors when a
+            reduced basis is used).
+        curve_weights: `num_curves`-dim Tensor of ARD weights. If None, initialized
+            to ones.
+        dtype: Data type for the curve_weights if created.
+        device: Device for the curve_weights if created.
+    """
+    if curve_weights is None:
+        curve_weights = Parameter(torch.ones(num_curves, dtype=dtype, device=device))
+    obj.register_parameter("curve_weights", curve_weights)
+    # IDEA: Could also apply a softmax so that we are taking a weighted average.
+    obj.register_constraint(
+        "curve_weights",
+        NonTransformedInterval(lower_bound=0.0, upper_bound=torch.inf),
+    )
+    obj.ard = True
+
+
+# =============================================================================
+# Interpolation Utilities
+# =============================================================================
+
+
+class LinearInterpolation1D(Module):
+    """PyTorch module for 1D linear interpolation with device-aware buffers.
+
+    Stores interpolation knots and values as registered buffers, ensuring
+    they move with `.to(device)` / `.cuda()` and are included in `state_dict()`.
+
+    Similar to `scipy.interpolate.interp1d` with `kind="linear"`.
+
+    Args:
+        x: `n`-dim Tensor of observed input positions (knots).
+        y: `batch_size x n`-dim Tensor of observed values at the knots.
+        bounds_error: If True, raises a ValueError when x_new is beyond the
+            bounds of the input data.
+        fill_value: Value to use for points beyond the bounds of the input data.
+        assume_sorted: If True, assumes that x is already sorted in ascending
+            order. If False (default), x will be sorted and y reordered
+            accordingly.
+
+    Note:
+        ``assume_sorted`` is a construction-time optimization flag and is not
+        stored — after construction, ``_x`` is always sorted.
+
+    Example:
+        >>> x = torch.linspace(0, 1, 10)
+        >>> y = torch.sin(x).unsqueeze(0)  # 1 x 10
+        >>> interp = LinearInterpolation1D(x, y)
+        >>> x_new = torch.tensor([0.25, 0.75])
+        >>> y_new = interp(x_new)  # 1 x 2
+    """
+
+    def __init__(
+        self,
+        x: Tensor,
+        y: Tensor,
+        bounds_error: bool = True,
+        fill_value: float = torch.nan,
+        assume_sorted: bool = False,
+    ) -> None:
+        """Initialize the interpolant. See the class docstring for argument details."""
+        super().__init__()
+
+        if x.ndim != 1:
+            raise UnsupportedError(f"Expected x to be 1-dim, but got {x.shape}.")
+
+        if not assume_sorted:
+            x_ind = torch.argsort(x)
+            x = x[x_ind]
+            y = y[..., x_ind]
+
+        self.register_buffer("_x", x)
+        self.register_buffer("_y", y)
+        self.register_buffer(
+            "_bounds_error", torch.tensor(bounds_error, dtype=torch.bool)
+        )
+        self.register_buffer("_fill_value", torch.tensor(fill_value))
+
+    def forward(self, x_new: Tensor) -> Tensor:
+        """Interpolates y at x_new.
+
+        Args:
+            x_new: `new_batch_size x m`-dim Tensor of new inputs.
+
+        Returns:
+            y_new: `batch_size x new_batch_size x m`-dim Tensor of
+                interpolated values.
+        """
+        return _interp1d_torch(
+            x=self._x,
+            y=self._y,
+            x_new=x_new,
+            bounds_error=self._bounds_error.item(),
+            fill_value=self._fill_value.item(),
+        )
+
+
+def _interp1d_torch(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    x_new: torch.Tensor,
+    bounds_error: bool | None = None,
+    fill_value: float = torch.nan,
+) -> torch.Tensor:
+    """
+    Torch implementation similar to scipy.interp1d. Supports batched evaluation.
+
+    Args:
+        x: ``n``-dim Tensor of observed inputs (sorted, 1D).
+        y: ``batch_size x n``-dim Tensor of observed values at ``x``.
+        x_new: ``new_batch_size x m``-dim Tensor of query locations.
+        bounds_error: If True, raises ``ValueError`` when any value in
+            ``x_new`` is outside ``[x.min(), x.max()]``.
+        fill_value: Value used for out-of-bounds locations when
+            ``bounds_error`` is False.
+
+    Returns:
+        ``batch_size x new_batch_size x m``-dim Tensor of interpolated values.
+    """
+    # dydx is the piecewise-linear slope within each interval of size len(x)-2
+    dydx = y.diff(dim=-1) / x.diff(dim=-1)
+    # searchsorted gives the point idx to be inserted before
+    # -1 gives the interval idx, also the left-point idx to add dydx*dx to
+    # Use contiguous tensors for searchsorted to avoid performance warning
+    idx = torch.searchsorted(x.contiguous(), x_new.contiguous()) - 1
+    # clamp to len(x)-2, as we never extrapolate beyond the last point, and set these
+    # values to nan
+    idx = torch.clamp(idx, 0, x.shape[-1] - 2)
+    # relevant shift in location
+    # need to expand the shape of x_new to match the shape of x
+    x_expanded = x.expand(x_new.shape[:-1] + x.shape[-1:])
+    dx = x_new - torch.gather(x_expanded, -1, idx)
+    # add dydx*dx to get y_new
+    y_new = y[..., idx] + dydx[..., idx] * dx
+    x_min, x_max = x[..., [0, -1]]
+    out_of_bounds = (x_new < x_min) | (x_new > x_max)
+    if out_of_bounds.any() and bounds_error is not False:
+        _interp1d_raise_out_of_bounds_error(x_new, x)
+
+    return torch.where(out_of_bounds, fill_value, y_new)
+
+
+def _interp1d_raise_out_of_bounds_error(
+    x_new: Tensor,
+    x: Tensor,
+) -> None:
+    x_new_min = x_new.min()
+    if x_new_min < x.min():
+        raise ValueError(
+            f"A value ({x_new_min}) in x_new is below the interpolation "
+            f"range's minimum value ({x.min()})."
+        )
+    x_new_max = x_new.max()
+    if x_new_max > x.max():
+        raise ValueError(
+            f"A value ({x_new_max}) in x_new is above the interpolation "
+            f"range's maximum value ({x.max()})."
+        )

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -54,6 +54,11 @@ Contextual GP Models with Context Rewards
 .. automodule:: botorch.models.contextual_multioutput
     :members:
 
+Empirical GP Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.empirical_gps.empirical_1d_gp
+    :members:
+
 Fully Bayesian GP Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.fully_bayesian
@@ -225,4 +230,9 @@ Priors
 Other Utilties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.utils.assorted
+    :members:
+
+Empirical GP Utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: botorch.models.empirical_gps.utils
     :members:

--- a/test/models/empirical_gps/__init__.py
+++ b/test/models/empirical_gps/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/models/empirical_gps/test_empirical_1d_gp.py
+++ b/test/models/empirical_gps/test_empirical_1d_gp.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+import torch
+from botorch.exceptions.errors import UnsupportedError
+from botorch.fit import fit_gpytorch_mll
+from botorch.models.empirical_gps import (
+    EmpiricalOneDimensionalGP,
+    EmpiricalOneDimensionalKernel,
+    EmpiricalOneDimensionalMean,
+)
+from botorch.models.empirical_gps.utils import (
+    compute_sample_covariance,
+    LinearInterpolation1D,
+)
+from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.models.transforms.input import Normalize
+from botorch.models.transforms.outcome import Standardize
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import RBFKernel
+from gpytorch.likelihoods import FixedNoiseGaussianLikelihood, GaussianLikelihood
+from gpytorch.mlls import ExactMarginalLogLikelihood, SumMarginalLogLikelihood
+from torch import Tensor
+
+
+class TestEmpiricalOneDimensionalGP(BotorchTestCase):
+    """Tests for EmpiricalOneDimensionalGP and related modules."""
+
+    # Use double precision for numerical stability in GP posterior computations
+    dtype = torch.float64
+
+    def _get_data(
+        self,
+        num_curves: int,
+        num_progression: int,
+        num_train: int,
+        batch_shape: tuple[int, ...] = (),
+        num_outputs: int = 1,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+        """Generate test data for empirical one-dimensional GP.
+
+        Args:
+            num_curves: Number of historical curves.
+            num_progression: Number of progression values.
+            num_train: Number of training progression values.
+            batch_shape: Batch shape for outputs.
+            num_outputs: Number of output dimensions (m).
+
+        Returns:
+            Tuple of (train_X, train_Y, all_Y, historical_X, historical_Y).
+        """
+        a, b = 1.0, 10.0
+        historical_X = torch.linspace(
+            a, b, num_progression, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+
+        # Generate historical_Y with shape: num_curves x num_progression x m
+        historical_Y = torch.randn(
+            num_curves,
+            num_progression,
+            num_outputs,
+            device=self.device,
+            dtype=self.dtype,
+        )
+
+        all_X = historical_X.expand((*batch_shape, *historical_X.shape))
+        train_X = all_X[..., :num_train, :]
+
+        # Generate targets as linear combinations of historical curves
+        def _sample_from_curves(Y_2d: Tensor) -> Tensor:
+            """Sample from the empirical distribution of historical curves.
+
+            Computes mean + sqrt(cov) @ z where z ~ N(0, I) to generate samples
+            that have the same mean and covariance as the historical curves.
+            """
+            mean_Y = Y_2d.mean(dim=0, keepdim=True)
+            centered_Y = Y_2d - mean_Y
+            root_cov = centered_Y / math.sqrt(num_curves - 1)
+            activations = torch.randn(
+                *batch_shape, num_curves, 1, device=self.device, dtype=self.dtype
+            )
+            return (mean_Y.T + root_cov.T @ activations).squeeze(-1)
+
+        all_Y = torch.stack(
+            [_sample_from_curves(historical_Y[..., i]) for i in range(num_outputs)],
+            dim=-1,
+        )
+
+        train_Y = all_Y[..., :num_train, :]
+        return train_X, train_Y, all_Y, historical_X, historical_Y
+
+    # =========================================================================
+    # Private test helpers
+    # =========================================================================
+
+    def _test_posterior_prediction(self) -> None:
+        """Test basic posterior prediction with over-and under-determined cases."""
+        num_progression = 128
+        test_cases = [
+            # (num_curves, num_train, expected_train_rmse, expected_pred_rmse)
+            (4, 64, 1e-4, 1e-4),  # overdetermined: posterior contracts quickly
+            (32, 28, 1e-2, None),  # underdetermined: check calibration instead
+        ]
+
+        for batch_shape in ((), (2, 3)):
+            for num_curves, num_train, train_rmse_bound, pred_rmse_bound in test_cases:
+                with self.subTest(
+                    batch_shape=batch_shape,
+                    num_curves=num_curves,
+                    num_train=num_train,
+                ):
+                    torch.manual_seed(1234)
+                    train_X, train_Y, all_Y, historical_X, historical_Y = (
+                        self._get_data(
+                            num_curves=num_curves,
+                            num_progression=num_progression,
+                            num_train=num_train,
+                            batch_shape=batch_shape,
+                        )
+                    )
+                    model = EmpiricalOneDimensionalGP(
+                        train_X=train_X,
+                        train_Y=train_Y,
+                        train_Yvar=torch.full_like(train_Y, 1e-4),
+                        historical_X=historical_X,
+                        historical_Y=historical_Y,
+                    )
+
+                    # Verify module types
+                    self.assertIsInstance(
+                        model.mean_module, EmpiricalOneDimensionalMean
+                    )
+                    self.assertIsInstance(
+                        model.covar_module, EmpiricalOneDimensionalKernel
+                    )
+
+                    # Compute posterior
+                    post = model.posterior(historical_X, observation_noise=False)
+                    Y_pred = post.mean
+                    Ystd_pred = post.variance.sqrt()
+
+                    self.assertEqual(
+                        Ystd_pred.shape, (*batch_shape, num_progression, 1)
+                    )
+
+                    # Check residuals
+                    R = Y_pred - all_Y
+                    R_train = R[..., :num_train, :]
+                    self.assertLess(R_train.square().mean().sqrt(), train_rmse_bound)
+
+                    if pred_rmse_bound is not None:
+                        R_pred = R[..., num_train:, :]
+                        self.assertLess(R_pred.square().mean().sqrt(), pred_rmse_bound)
+                        self.assertLess(Ystd_pred.max(), 1e-2)
+                    else:
+                        # Check calibration for underdetermined case
+                        standardized = R / Ystd_pred
+                        standardized = standardized[..., num_train:, :]
+                        self.assertLess(standardized.square().mean().sqrt(), 2)
+                        self.assertGreater(standardized.square().mean().sqrt(), 0.5)
+
+    def _test_kernel_diagonal(self) -> None:
+        """Test that kernel diag=True matches diagonal of full kernel matrix."""
+        torch.manual_seed(1234)
+        for batch_shape in ((), (2, 3)):
+            with self.subTest(batch_shape=batch_shape):
+                num_train = 28
+                train_X, train_Y, _, historical_X, historical_Y = self._get_data(
+                    num_curves=32,
+                    num_progression=128,
+                    num_train=num_train,
+                    batch_shape=batch_shape,
+                )
+                model = EmpiricalOneDimensionalGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=torch.full_like(train_Y, 1e-4),
+                    historical_X=historical_X,
+                    historical_Y=historical_Y,
+                )
+
+                train_covar = model.covar_module(train_X)
+                diag_train_covar = model.covar_module(train_X, diag=True)
+
+                self.assertEqual(diag_train_covar.shape, (*batch_shape, num_train))
+                expected_diag = train_covar.diagonal(dim1=-2, dim2=-1)
+                self.assertAllClose(diag_train_covar, expected_diag)
+
+    def _test_likelihood_handling(self) -> None:
+        """Test that likelihood is correctly inferred or set."""
+        train_X, train_Y, _, historical_X, historical_Y = self._get_data(
+            num_curves=5, num_progression=20, num_train=10
+        )
+
+        # Test inferred noise (train_Yvar=None)
+        model_inferred = EmpiricalOneDimensionalGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            historical_X=historical_X,
+            historical_Y=historical_Y,
+        )
+        self.assertIsInstance(model_inferred.likelihood, GaussianLikelihood)
+
+        # Test fixed noise (train_Yvar provided)
+        train_Yvar = torch.full_like(train_Y, 0.01)
+        model_fixed = EmpiricalOneDimensionalGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            historical_X=historical_X,
+            historical_Y=historical_Y,
+        )
+        self.assertIsInstance(model_fixed.likelihood, FixedNoiseGaussianLikelihood)
+
+        # Test custom likelihood
+        custom_likelihood = GaussianLikelihood()
+        model_custom = EmpiricalOneDimensionalGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            historical_X=historical_X,
+            historical_Y=historical_Y,
+            likelihood=custom_likelihood,
+        )
+        self.assertIs(model_custom.likelihood, custom_likelihood)
+
+    def _test_input_validation(self) -> None:
+        """Test that invalid inputs raise appropriate errors."""
+        train_X, train_Y, _, historical_X, historical_Y = self._get_data(
+            num_curves=7, num_progression=5, num_train=4
+        )
+
+        # Test invalid covar_module type
+        with self.assertRaisesRegex(
+            ValueError, "must be an instance of EmpiricalOneDimensionalKernel"
+        ):
+            EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                historical_X=historical_X,
+                historical_Y=historical_Y,
+                covar_module=RBFKernel(),
+            )
+
+        # Test ARD mismatch
+        for ard in [True, False]:
+            with self.subTest(ard=ard):
+                with self.assertRaisesRegex(
+                    ValueError, "`ard` argument must equal `covar_module.ard`"
+                ):
+                    EmpiricalOneDimensionalGP(
+                        train_X=train_X,
+                        train_Y=train_Y,
+                        historical_X=historical_X,
+                        historical_Y=historical_Y,
+                        covar_module=EmpiricalOneDimensionalKernel(
+                            X_full=historical_X,
+                            Y_full=historical_Y,
+                            ard=ard,
+                        ),
+                        ard=(not ard),
+                    )
+
+        # historical_Y / Y_full must be 3-dim (num_curves x num_progression x m)
+        historical_Y_2d = historical_Y.squeeze(-1)
+        with self.assertRaisesRegex(ValueError, "Expected historical_Y to be 3-dim"):
+            EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                historical_X=historical_X,
+                historical_Y=historical_Y_2d,
+            )
+        with self.assertRaisesRegex(ValueError, "Expected Y_full to be 3-dim"):
+            EmpiricalOneDimensionalMean(X_full=historical_X, Y_full=historical_Y_2d)
+        with self.assertRaisesRegex(ValueError, "Expected Y_full to be 3-dim"):
+            EmpiricalOneDimensionalKernel(X_full=historical_X, Y_full=historical_Y_2d)
+
+    def _test_edge_cases(self) -> None:
+        """Cover the use_svd property, last_dim_is_batch, and the mean NaN guard."""
+        _, _, _, historical_X, historical_Y = self._get_data(
+            num_curves=5, num_progression=10, num_train=4
+        )
+
+        kernel = EmpiricalOneDimensionalKernel(X_full=historical_X, Y_full=historical_Y)
+        # use_svd property getter
+        self.assertIsInstance(kernel.use_svd, bool)
+        self.assertEqual(kernel.use_svd, kernel._use_svd)
+
+        # last_dim_is_batch is not supported
+        with self.assertRaisesRegex(
+            NotImplementedError, "last_dim_is_batch=True not supported"
+        ):
+            kernel.forward(historical_X, historical_X, last_dim_is_batch=True)
+
+    def _test_unsupported_transforms(self) -> None:
+        """Test that input_transform and outcome_transform raise UnsupportedError."""
+        train_X, train_Y, _, historical_X, historical_Y = self._get_data(
+            num_curves=5, num_progression=10, num_train=6
+        )
+
+        # Test that input_transform raises UnsupportedError
+        with self.assertRaisesRegex(
+            UnsupportedError, "input_transform is not yet supported"
+        ):
+            EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                historical_X=historical_X,
+                historical_Y=historical_Y,
+                input_transform=Normalize(d=1),
+            )
+
+        # Test that outcome_transform raises UnsupportedError
+        with self.assertRaisesRegex(
+            UnsupportedError, "outcome_transform is not yet supported"
+        ):
+            EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y,
+                historical_X=historical_X,
+                historical_Y=historical_Y,
+                outcome_transform=Standardize(m=1),
+            )
+
+    def _test_ard_curve_selection(self) -> None:
+        """Test that ARD correctly identifies target curves via sparsification."""
+        torch.manual_seed(5678)
+        num_curves = 6
+        num_train = 4
+        train_X, _, _, historical_X, historical_Y = self._get_data(
+            num_curves=num_curves,
+            num_progression=10,
+            num_train=num_train,
+        )
+
+        for target_curve_idx in [0, 3]:
+            with self.subTest(target_curve_idx=target_curve_idx):
+                # Use replication of a single curve as target
+                # historical_Y is now 3D: num_curves x num_progression x m (m=1)
+                train_Y = historical_Y[target_curve_idx, :num_train, :]
+                train_Yvar = torch.full_like(train_Y, 1e-10)  # very low noise
+
+                ard_model = EmpiricalOneDimensionalGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=train_Yvar,
+                    historical_X=historical_X,
+                    historical_Y=historical_Y,
+                    ard=True,
+                )
+                mll = ExactMarginalLogLikelihood(
+                    model=ard_model, likelihood=ard_model.likelihood
+                )
+                fit_gpytorch_mll(mll)
+
+                w = ard_model.covar_module.curve_weights
+                # Target curve should have high weight
+                self.assertGreater(w[target_curve_idx].item(), 0.9)
+                # Other curves should be pruned
+                for j in range(num_curves):
+                    if j != target_curve_idx:
+                        self.assertLess(w[j].item(), 1e-3)
+
+                # ARD model should extrapolate accurately
+                ard_post = ard_model.posterior(historical_X, observation_noise=False)
+                full_Y = historical_Y[target_curve_idx, :, :]
+                self.assertAllClose(ard_post.mean, full_Y, atol=1e-3, rtol=1e-3)
+
+                # Non-ARD model should NOT extrapolate as accurately
+                non_ard_model = EmpiricalOneDimensionalGP(
+                    train_X=train_X,
+                    train_Y=train_Y,
+                    train_Yvar=torch.full_like(train_Y, 1e-10),
+                    historical_X=historical_X,
+                    historical_Y=historical_Y,
+                    ard=False,
+                )
+                non_ard_post = non_ard_model.posterior(
+                    historical_X, observation_noise=False
+                )
+                self.assertGreater((non_ard_post.mean - full_Y).abs().max(), 1e-3)
+
+    def _test_mean_multi_output(self) -> None:
+        """Test EmpiricalOneDimensionalMean with single and multi-output Y_full."""
+        num_curves = 5
+        num_progression = 10
+        m = 3
+
+        X_full = torch.linspace(
+            0, 1, num_progression, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+
+        # Single-output (3D Y_full with m=1)
+        Y_full_single = torch.randn(
+            num_curves, num_progression, 1, device=self.device, dtype=self.dtype
+        )
+        mean_single = EmpiricalOneDimensionalMean(X_full=X_full, Y_full=Y_full_single)
+        self.assertEqual(mean_single.mean_full.shape, (1, num_progression))
+
+        # Multi-output (3D Y_full with m=3)
+        Y_full_multi = torch.randn(
+            num_curves, num_progression, m, device=self.device, dtype=self.dtype
+        )
+        mean_multi = EmpiricalOneDimensionalMean(X_full=X_full, Y_full=Y_full_multi)
+        self.assertEqual(mean_multi.mean_full.shape, (m, num_progression))
+        self.assertAllClose(mean_multi.mean_full, Y_full_multi.mean(dim=0).T)
+
+        # Test forward shapes
+        batch_shape = (2, 4)
+        n = 7
+        x = torch.rand(*batch_shape, n, 1, device=self.device, dtype=self.dtype)
+        x = x * (X_full.max() - X_full.min()) + X_full.min()
+
+        # Single-output forward
+        y_single = mean_single(x)
+        self.assertEqual(y_single.shape, (*batch_shape, n))
+
+        # Multi-output forward (with SingleTaskGP-style batched input)
+        x_batched = x.unsqueeze(-3).expand(*batch_shape, m, n, 1)
+        y_multi = mean_multi(x_batched)
+        self.assertEqual(y_multi.shape, (*batch_shape, m, n))
+
+        # Verify each output matches single-output mean
+        for i in range(m):
+            Y_i = Y_full_multi[..., [i]]  # Keep 3D with m=1
+            mean_i = EmpiricalOneDimensionalMean(X_full=X_full, Y_full=Y_i)
+            y_i = mean_i(x)
+            self.assertAllClose(y_multi[..., i, :], y_i, atol=1e-6, rtol=1e-4)
+
+    def _test_kernel_multi_output(self) -> None:
+        """Test EmpiricalOneDimensionalKernel produces independent covariances
+        per output.
+        """
+        num_curves = 10
+        num_progression = 20
+        m = 3
+        n = 5
+
+        X_full = torch.linspace(
+            0, 1, num_progression, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+        Y_full_3d = torch.randn(
+            num_curves, num_progression, m, device=self.device, dtype=self.dtype
+        )
+
+        kernel = EmpiricalOneDimensionalKernel(X_full=X_full, Y_full=Y_full_3d)
+        self.assertEqual(kernel.num_curves, num_curves)
+        self.assertEqual(kernel.num_outputs, m)
+
+        x = torch.linspace(0.1, 0.9, n, device=self.device, dtype=self.dtype)
+        x = x.unsqueeze(-1)
+
+        K = kernel.forward(x, x)
+        self.assertEqual(K.shape, (m, n, n))
+
+        # Each slice should be PSD and symmetric
+        for i in range(m):
+            K_i = K[i]
+            self.assertAllClose(K_i, K_i.T, atol=1e-6)
+            eigvals = torch.linalg.eigvalsh(K_i)
+            self.assertTrue((eigvals >= -1e-6).all())
+
+            # Should match single-output kernel on that output (use slicing to keep 3D)
+            Y_i = Y_full_3d[..., [i]]  # Keep 3D with m=1
+            kernel_i = EmpiricalOneDimensionalKernel(X_full=X_full, Y_full=Y_i)
+            K_i_expected = kernel_i.forward(x, x)
+            self.assertAllClose(K[i], K_i_expected, atol=1e-7, rtol=1e-4)
+
+        # Test diagonal
+        K_diag = kernel.forward(x, x, diag=True)
+        self.assertEqual(K_diag.shape, (m, n))
+        for i in range(m):
+            self.assertAllClose(K_diag[i], K[i].diag(), atol=1e-7)
+
+        # Test batched multi-output input
+        batch_shape = (2, 4)
+        x_batch = torch.rand(*batch_shape, n, 1, device=self.device, dtype=self.dtype)
+        x_batch = x_batch * 0.8 + 0.1
+        x_batched_multi = x_batch.unsqueeze(-3).expand(*batch_shape, m, n, 1)
+
+        K_batch = kernel.forward(x_batched_multi, x_batched_multi)
+        self.assertEqual(K_batch.shape, (*batch_shape, m, n, n))
+
+        K_diag_batch = kernel.forward(x_batched_multi, x_batched_multi, diag=True)
+        self.assertEqual(K_diag_batch.shape, (*batch_shape, m, n))
+
+        # Test ARD
+        kernel_ard = EmpiricalOneDimensionalKernel(
+            X_full=X_full, Y_full=Y_full_3d, ard=True
+        )
+        self.assertTrue(kernel_ard.ard)
+        self.assertEqual(kernel_ard.curve_weights.shape, (num_curves,))
+        self.assertEqual(kernel_ard.correction, 0)  # default
+
+        # Test correction parameter is passed to compute_sample_covariance
+        for correction in (0, 1, 2):
+            kernel_corrected = EmpiricalOneDimensionalKernel(
+                X_full=X_full, Y_full=Y_full_3d, correction=correction
+            )
+            self.assertEqual(kernel_corrected.correction, correction)
+            with patch(
+                "botorch.models.empirical_gps."
+                "empirical_1d_gp.compute_sample_covariance",
+                wraps=compute_sample_covariance,
+            ) as mock_cov:
+                kernel_corrected.forward(x, x)
+            self.assertEqual(mock_cov.call_args.kwargs["correction"], correction)
+
+    def _get_multi_output_data(
+        self,
+        num_curves: int = 8,
+        num_progression: int = 20,
+        num_train: int = 12,
+        m: int = 3,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, list[Tensor]]:
+        """Generate multi-output test data for ModelListGP.
+
+        Returns:
+            Tuple of (historical_X, historical_Y, train_X, weights, train_Y_list).
+        """
+        historical_X = torch.linspace(
+            0, 1, num_progression, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+        historical_Y = torch.randn(
+            num_curves, num_progression, m, device=self.device, dtype=self.dtype
+        )
+        train_X = torch.linspace(
+            0.05, 0.95, num_train, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+
+        # Create training targets via interpolation
+        weights = torch.randn(num_curves, device=self.device, dtype=self.dtype)
+        weights = weights / weights.abs().sum()
+
+        train_Y_list = []
+        for i in range(m):
+            curves_i = historical_Y[:, :, i]
+            f_i = LinearInterpolation1D(historical_X.squeeze(-1), curves_i)
+            curves_at_train = f_i(train_X.squeeze(-1))
+            train_y_i = (weights.unsqueeze(-1) * curves_at_train).sum(dim=0)
+            train_Y_list.append(train_y_i.unsqueeze(-1))
+
+        return historical_X, historical_Y, train_X, weights, train_Y_list
+
+    def _test_multi_output_gp(self) -> None:
+        """Test multi-output GP with ModelListGP and direct 3D historical_Y."""
+        torch.manual_seed(42)
+
+        m = 3
+        sigma = 1e-3
+        historical_X, historical_Y, train_X, weights, train_Y_list = (
+            self._get_multi_output_data(m=m)
+        )
+
+        # Create ModelListGP with individual models
+        models = []
+        for i in range(m):
+            train_Y_i = train_Y_list[i]
+            train_Yvar_i = torch.full_like(train_Y_i, sigma**2)
+            model_i = EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y_i,
+                train_Yvar=train_Yvar_i,
+                historical_X=historical_X,
+                historical_Y=historical_Y[..., [i]],  # Keep 3D with m=1
+            )
+            models.append(model_i)
+        model_list = ModelListGP(*models)
+
+        # Test posterior
+        test_X = torch.linspace(
+            0.1, 0.9, 5, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+        # we'll use post to compare against the batched model
+        post = model_list.posterior(test_X, observation_noise=False)
+        self.assertEqual(post.mean.shape, (5, m))
+        self.assertEqual(post.variance.shape, (5, m))
+        self.assertTrue((post.variance >= 0).all())
+
+        # Test direct multi-output GP with 3D historical_Y
+        train_Y_multi = torch.stack([t.squeeze(-1) for t in train_Y_list], dim=-1)
+        train_Yvar_multi = torch.full_like(train_Y_multi, sigma**2)
+
+        model_direct = EmpiricalOneDimensionalGP(
+            train_X=train_X,
+            train_Y=train_Y_multi,
+            train_Yvar=train_Yvar_multi,
+            historical_X=historical_X,
+            historical_Y=historical_Y,
+        )
+        self.assertEqual(model_direct.covar_module.num_outputs, m)
+        self.assertEqual(model_direct.mean_module.num_outputs, m)
+
+        # Predictions should match ModelListGP
+        post_direct = model_direct.posterior(test_X, observation_noise=False)
+        self.assertAllClose(post_direct.mean, post.mean, atol=1e-4, rtol=1e-3)
+
+        # Test mismatched outputs error
+        with self.assertRaisesRegex(
+            ValueError, "Number of outputs in train_Y .* must match historical_Y"
+        ):
+            EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y_list[0],
+                train_Yvar=torch.full_like(train_Y_list[0], sigma**2),
+                historical_X=historical_X,
+                historical_Y=historical_Y,
+            )
+
+    def _test_multi_output_ard(self) -> None:
+        """Test ARD optimization with ModelListGP."""
+        torch.manual_seed(42)
+
+        m = 3
+        sigma = 1e-3
+        historical_X, historical_Y, train_X, weights, train_Y_list = (
+            self._get_multi_output_data(m=m)
+        )
+
+        # Create ARD models
+        models_ard = []
+        for i in range(m):
+            train_Y_i = train_Y_list[i]
+            train_Yvar_i = torch.full_like(train_Y_i, sigma**2)
+            model_i = EmpiricalOneDimensionalGP(
+                train_X=train_X,
+                train_Y=train_Y_i,
+                train_Yvar=train_Yvar_i,
+                historical_X=historical_X,
+                historical_Y=historical_Y[..., [i]],  # Keep 3D with m=1
+                ard=True,
+            )
+            models_ard.append(model_i)
+        model_list_ard = ModelListGP(*models_ard)
+
+        # Fit with SumMarginalLogLikelihood
+        mll = SumMarginalLogLikelihood(
+            likelihood=model_list_ard.likelihood,
+            model=model_list_ard,
+        )
+        fit_gpytorch_mll(mll)
+
+        # Weights should have been updated
+        for model in model_list_ard.models:
+            self.assertTrue(model.covar_module.ard)
+            curve_weights = model.covar_module.curve_weights
+            self.assertFalse(
+                torch.allclose(curve_weights, torch.ones_like(curve_weights)),
+                "ARD weights should have been updated during fitting",
+            )
+
+    def _test_differentiability(self) -> None:
+        """Test that GP mean and covariance are differentiable w.r.t. inputs."""
+        torch.manual_seed(1234)
+        num_curves = 5
+        num_progression = 20
+
+        X_full = torch.linspace(
+            0, 1, num_progression, device=self.device, dtype=self.dtype
+        ).unsqueeze(-1)
+        Y_full = torch.randn(
+            num_curves, num_progression, 1, device=self.device, dtype=self.dtype
+        )
+
+        mean_module = EmpiricalOneDimensionalMean(X_full=X_full, Y_full=Y_full)
+        covar_module = EmpiricalOneDimensionalKernel(X_full=X_full, Y_full=Y_full)
+
+        # Test mean differentiability w.r.t. x
+        x = torch.rand(5, 1, device=self.device, dtype=self.dtype) * 0.8 + 0.1
+        x.requires_grad_(True)
+        mean_module(x).sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertFalse(x.grad.isnan().any())
+
+        # Test covariance differentiability w.r.t. x1 and x2
+        x1 = torch.rand(4, 1, device=self.device, dtype=self.dtype) * 0.8 + 0.1
+        x2 = torch.rand(3, 1, device=self.device, dtype=self.dtype) * 0.8 + 0.1
+        x1.requires_grad_(True)
+        x2.requires_grad_(True)
+        covar_module(x1, x2).to_dense().sum().backward()
+        self.assertIsNotNone(x1.grad)
+        self.assertIsNotNone(x2.grad)
+        self.assertFalse(x1.grad.isnan().any())
+        self.assertFalse(x2.grad.isnan().any())
+
+        # Test full model posterior differentiability
+        train_X, train_Y, _, historical_X, historical_Y = self._get_data(
+            num_curves=5, num_progression=20, num_train=10
+        )
+        model = EmpiricalOneDimensionalGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=torch.full_like(train_Y, 1e-4),
+            historical_X=historical_X,
+            historical_Y=historical_Y,
+        )
+
+        test_X = torch.rand(3, 1, device=self.device, dtype=self.dtype) * 8 + 1
+        test_X.requires_grad_(True)
+        posterior = model.posterior(test_X, observation_noise=False)
+        (posterior.mean.sum() + posterior.variance.sum()).backward()
+        self.assertIsNotNone(test_X.grad)
+        self.assertFalse(test_X.grad.isnan().any())
+
+    def _test_svd_acceleration(self) -> None:
+        """Test that the kernel produces identical values with and without SVD."""
+        torch.manual_seed(42)
+
+        for dtype in [torch.float32, torch.float64]:
+            tol = 1e-4 if dtype == torch.float32 else 1e-10
+
+            # Test case 1: num_curves > num_progression - default auto-enables SVD
+            # Also verifies SVD produces equivalent results to non-SVD
+            num_curves, num_progression = 300, 25
+            historical_X = torch.linspace(
+                1.0, 10.0, num_progression, dtype=dtype, device=self.device
+            ).unsqueeze(-1)
+            historical_Y = torch.randn(
+                num_curves, num_progression, 1, dtype=dtype, device=self.device
+            )
+
+            kernel_default = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+            )
+            kernel_explicit_svd = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                use_svd=True,
+            )
+            kernel_no_svd = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                use_svd=False,
+            )
+
+            n1, n2 = 10, 8
+            x1 = torch.linspace(
+                2.0, 9.0, n1, dtype=dtype, device=self.device
+            ).unsqueeze(-1)
+            x2 = torch.linspace(
+                3.0, 8.0, n2, dtype=dtype, device=self.device
+            ).unsqueeze(-1)
+
+            K_default = kernel_default(x1, x2).to_dense()
+            K_explicit_svd = kernel_explicit_svd(x1, x2).to_dense()
+            K_no_svd = kernel_no_svd(x1, x2).to_dense()
+
+            # Kernel squeezes m=1 dimension, so shape is (n1, n2) not (1, n1, n2)
+            self.assertEqual(K_default.shape, (n1, n2))
+            # Default should match explicit SVD=True (auto-enabled)
+            self.assertAllClose(K_default, K_explicit_svd, atol=tol, rtol=tol)
+            # All should produce equivalent results
+            self.assertAllClose(K_default, K_no_svd, atol=tol, rtol=tol)
+
+            # Also test diagonal computation
+            K_default_diag = kernel_default(x1, diag=True)
+            K_svd_diag = kernel_explicit_svd(x1, diag=True)
+            K_no_svd_diag = kernel_no_svd(x1, diag=True)
+
+            self.assertEqual(K_default_diag.shape, (n1,))
+            self.assertAllClose(K_default_diag, K_svd_diag, atol=tol, rtol=tol)
+            self.assertAllClose(K_svd_diag, K_no_svd_diag, atol=tol, rtol=tol)
+
+            # Test case 2: num_curves <= num_progression - default does NOT use SVD
+            num_curves, num_progression = 15, 50
+            historical_Y = torch.randn(
+                num_curves, num_progression, 1, dtype=dtype, device=self.device
+            )
+            historical_X = torch.linspace(
+                1.0, 10.0, num_progression, dtype=dtype, device=self.device
+            ).unsqueeze(-1)
+
+            kernel_default = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+            )
+            kernel_disabled = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                use_svd=False,
+            )
+
+            K_default = kernel_default(x1, x2).to_dense()
+            K_disabled = kernel_disabled(x1, x2).to_dense()
+
+            self.assertAllClose(K_default, K_disabled, atol=tol, rtol=tol)
+
+            # Test case 3: with ard=True, default does NOT use SVD
+            num_curves, num_progression = 300, 25
+            historical_X = torch.linspace(
+                1.0, 10.0, num_progression, dtype=dtype, device=self.device
+            ).unsqueeze(-1)
+            historical_Y = torch.randn(
+                num_curves, num_progression, 1, dtype=dtype, device=self.device
+            )
+
+            kernel_ard_default = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                ard=True,
+            )
+            kernel_ard_no_svd = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                ard=True,
+                use_svd=False,
+            )
+
+            K_ard_default = kernel_ard_default(x1, x2).to_dense()
+            K_ard_no_svd = kernel_ard_no_svd(x1, x2).to_dense()
+
+            self.assertAllClose(K_ard_default, K_ard_no_svd, atol=tol, rtol=tol)
+
+            # Test case 4: explicit use_svd=True with ard=True is supported
+            # (produces different prior but should still compute valid kernel)
+            kernel_ard_with_svd = EmpiricalOneDimensionalKernel(
+                X_full=historical_X,
+                Y_full=historical_Y,
+                ard=True,
+                use_svd=True,
+            )
+            K_ard_with_svd = kernel_ard_with_svd(x1, x2).to_dense()
+            self.assertEqual(K_ard_with_svd.shape, (n1, n2))
+
+            # Verify it's positive semi-definite
+            K_self = kernel_ard_with_svd(x1, x1).to_dense()
+            eigvals = torch.linalg.eigvalsh(K_self)
+            self.assertTrue((eigvals >= -tol).all())
+
+    # =========================================================================
+    # Main public test method
+    # =========================================================================
+
+    def test_empirical_one_dimensional_gp(self) -> None:
+        """Main test for EmpiricalOneDimensionalGP and related modules."""
+        # Basic GP tests
+        self._test_posterior_prediction()
+        self._test_kernel_diagonal()
+
+        # Likelihood tests
+        self._test_likelihood_handling()
+
+        # Input validation tests
+        self._test_input_validation()
+        self._test_unsupported_transforms()
+        self._test_edge_cases()
+
+        # ARD tests
+        self._test_ard_curve_selection()
+
+        # Multi-output tests
+        self._test_mean_multi_output()
+        self._test_kernel_multi_output()
+        self._test_multi_output_gp()
+        self._test_multi_output_ard()
+
+        # Differentiability tests
+        self._test_differentiability()
+
+        # SVD acceleration tests
+        self._test_svd_acceleration()

--- a/test/models/empirical_gps/test_utils.py
+++ b/test/models/empirical_gps/test_utils.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+from typing import Callable
+
+import numpy as np
+import torch
+from botorch.exceptions.errors import UnsupportedError
+from botorch.models.empirical_gps.utils import (
+    center_curves,
+    compute_basis_matrix,
+    compute_orthogonal_basis,
+    compute_sample_covariance,
+    instantiate_ard,
+    LinearInterpolation1D,
+)
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import Kernel
+from scipy.interpolate import interp1d
+from torch import Tensor
+
+
+class TestUtils(BotorchTestCase):
+    def test_compute_orthogonal_basis(self) -> None:
+        # Test that the orthogonal basis produces the same Gram matrix as original
+        torch.manual_seed(42)  # Fix seed for reproducibility
+
+        for dtype in [torch.float32, torch.float64]:
+            # float32 SVD on CUDA (cuSOLVER) is less precise than CPU LAPACK;
+            # use a looser float32 tolerance for the Gram reconstruction.
+            tol = 1e-2 if dtype == torch.float32 else 1e-10
+
+            # Test case 1: tall matrix (m >> n) - typical use case
+            m, n = 1000, 50
+            A = torch.randn(m, n, dtype=dtype, device=self.device)
+
+            B = compute_orthogonal_basis(A)
+
+            # B should have shape (r, n) where r = min(m, n) = n
+            self.assertEqual(B.shape, (n, n))
+            # B.T @ B should equal A.T @ A
+            gram_original = A.T @ A
+            gram_svd = B.T @ B
+            self.assertAllClose(gram_original, gram_svd, atol=tol, rtol=tol)
+
+            # Test case 2: wide matrix (m < n)
+            m, n = 30, 100
+            A = torch.randn(m, n, dtype=dtype, device=self.device)
+
+            B = compute_orthogonal_basis(A)
+
+            # B should have shape (r, n) where r = min(m, n) = m
+            self.assertEqual(B.shape, (m, n))
+            # B.T @ B should equal A.T @ A
+            gram_original = A.T @ A
+            gram_svd = B.T @ B
+            self.assertAllClose(gram_original, gram_svd, atol=tol, rtol=tol)
+
+            # Test case 3: square matrix
+            m, n = 50, 50
+            A = torch.randn(m, n, dtype=dtype, device=self.device)
+
+            B = compute_orthogonal_basis(A)
+
+            self.assertEqual(B.shape, (n, n))
+            gram_original = A.T @ A
+            gram_svd = B.T @ B
+            self.assertAllClose(gram_original, gram_svd, atol=tol, rtol=tol)
+
+    def test_compute_orthogonal_basis_eigh(self) -> None:
+        # The eigh-based basis must yield the same Gram matrix as the SVD path.
+        torch.manual_seed(42)
+        for dtype in [torch.float32, torch.float64]:
+            # float32 eigh on CUDA is less precise than CPU; loosen float32 tol.
+            tol = 1e-2 if dtype == torch.float32 else 1e-8
+
+            # Tall matrix (m >> n): the intended regime.
+            m, n = 1000, 50
+            A = torch.randn(m, n, dtype=dtype, device=self.device)
+            B = compute_orthogonal_basis(A, method="eigh")
+            self.assertEqual(B.shape, (n, n))
+            self.assertAllClose(B.T @ B, A.T @ A, atol=tol, rtol=tol)
+
+            # Matches the SVD path's Gram matrix.
+            B_svd = compute_orthogonal_basis(A, method="svd")
+            self.assertAllClose(B.T @ B, B_svd.T @ B_svd, atol=tol, rtol=tol)
+
+            # Batched inputs.
+            A_b = torch.randn(3, m, n, dtype=dtype, device=self.device)
+            B_b = compute_orthogonal_basis(A_b, method="eigh")
+            self.assertEqual(B_b.shape, (3, n, n))
+            self.assertAllClose(
+                B_b.transpose(-2, -1) @ B_b,
+                A_b.transpose(-2, -1) @ A_b,
+                atol=tol,
+                rtol=tol,
+            )
+
+            # Wide matrix (m < n): eigh truncates to r = min(m, n) = m rows
+            # (matching the economy SVD); dropped rows have zero eigenvalues,
+            # so the Gram matrix is preserved.
+            mw, nw = 30, 100
+            Aw = torch.randn(mw, nw, dtype=dtype, device=self.device)
+            Bw = compute_orthogonal_basis(Aw, method="eigh")
+            self.assertEqual(Bw.shape, (mw, nw))
+            self.assertAllClose(Bw.T @ Bw, Aw.T @ Aw, atol=tol, rtol=tol)
+
+        # Unknown method raises.
+        with self.assertRaisesRegex(ValueError, "Unknown method"):
+            compute_orthogonal_basis(A, method="bogus")
+
+    def test_covariance_computation_helpers(self) -> None:
+        """Test helper functions for covariance computation."""
+        # Test center_curves with 2D tensor
+        num_curves = 5
+        num_progression = 10
+        Y_2d = torch.randn(
+            num_curves, num_progression, dtype=torch.float64, device=self.device
+        )
+
+        mean_2d, centered_2d = center_curves(Y_2d, curve_dim=-2)
+
+        # Mean should have shape (num_progression,)
+        self.assertEqual(mean_2d.shape, (num_progression,))
+        # Centered should have same shape as original
+        self.assertEqual(centered_2d.shape, Y_2d.shape)
+        # Centered curves should have zero mean along curve_dim
+        self.assertAllClose(
+            centered_2d.mean(dim=-2),
+            torch.zeros(num_progression, dtype=torch.float64, device=self.device),
+            atol=1e-10,
+        )
+        # Mean + centered should recover original
+        self.assertAllClose(mean_2d.unsqueeze(-2) + centered_2d, Y_2d)
+
+        # Test center_curves with 3D tensor (multi-output)
+        m = 3  # number of outputs
+        Y_3d = torch.randn(
+            num_curves, num_progression, m, dtype=torch.float64, device=self.device
+        )
+
+        mean_3d, centered_3d = center_curves(Y_3d, curve_dim=-3)
+
+        # Mean should have shape (num_progression, m)
+        self.assertEqual(mean_3d.shape, (num_progression, m))
+        # Centered should have same shape as original
+        self.assertEqual(centered_3d.shape, Y_3d.shape)
+        # Centered curves should have zero mean along curve_dim
+        self.assertAllClose(
+            centered_3d.mean(dim=-3),
+            torch.zeros(num_progression, m, dtype=torch.float64, device=self.device),
+            atol=1e-10,
+        )
+
+        # Test compute_sample_covariance - full covariance
+        n1, n2 = 4, 6
+        U1 = torch.randn(num_curves, n1, dtype=torch.float64, device=self.device)
+        U2 = torch.randn(num_curves, n2, dtype=torch.float64, device=self.device)
+
+        K = compute_sample_covariance(U1, U2, num_curves=num_curves, diag=False)
+
+        # Shape should be n1 x n2
+        self.assertEqual(K.shape, (n1, n2))
+        # Should equal U1.T @ U2 / num_curves
+        expected_K = (U1.mT @ U2) / num_curves
+        self.assertAllClose(K, expected_K)
+
+        # Test compute_sample_covariance - symmetric case (U2=None)
+        K_sym = compute_sample_covariance(U1, None, num_curves=num_curves, diag=False)
+
+        self.assertEqual(K_sym.shape, (n1, n1))
+        # Should be symmetric
+        self.assertAllClose(K_sym, K_sym.T)
+
+        # Test compute_sample_covariance - diagonal
+        K_diag = compute_sample_covariance(U1, None, num_curves=num_curves, diag=True)
+
+        self.assertEqual(K_diag.shape, (n1,))
+        # Should equal diagonal of full covariance
+        self.assertAllClose(K_diag, K_sym.diag())
+
+        # Test compute_sample_covariance - with correction parameter
+        for correction in (0, 1, 2):
+            K_corrected = compute_sample_covariance(
+                U1, U2, num_curves=num_curves, diag=False, correction=correction
+            )
+            # With correction=1, should divide by (num_curves - correction)
+            expected_K_corrected = U1.mT @ U2 / (num_curves - correction)
+            self.assertAllClose(K_corrected, expected_K_corrected)
+
+        # Test compute_sample_covariance - error when num_curves <= correction
+        with self.assertRaisesRegex(
+            ValueError, "num_curves .* must be greater than correction"
+        ):
+            compute_sample_covariance(
+                U1, U2, num_curves=num_curves, diag=False, correction=num_curves
+            )
+
+        # Test compute_basis_matrix - single output (m=1)
+        x = torch.linspace(0, 1, 8, dtype=torch.float64, device=self.device)
+        # For single-output, Y_for_interp should be m x num_curves x num_progression
+        Y_for_interp = torch.randn(
+            1, num_curves, num_progression, dtype=torch.float64, device=self.device
+        )
+        f = LinearInterpolation1D(
+            torch.linspace(
+                0, 1, num_progression, dtype=torch.float64, device=self.device
+            ),
+            Y_for_interp,
+        )
+
+        Ux = compute_basis_matrix(f=f, x=x, num_outputs=1, curve_weights=None)
+
+        # Shape should be m x batch_shape x num_curves x n = 1 x num_curves x 8
+        self.assertEqual(Ux.shape, (1, num_curves, 8))
+
+        # Test compute_basis_matrix - with ARD weights
+        curve_weights = torch.rand(num_curves, dtype=torch.float64, device=self.device)
+        Ux_ard = compute_basis_matrix(
+            f=f, x=x, num_outputs=1, curve_weights=curve_weights
+        )
+
+        # Should have applied weights
+        self.assertEqual(Ux_ard.shape, (1, num_curves, 8))
+        # Verify weights were applied correctly
+        expected_Ux_ard = Ux * curve_weights.unsqueeze(-1)
+        self.assertAllClose(Ux_ard, expected_Ux_ard)
+
+        # Test instantiate_ard - creates curve_weights parameter and constraint
+        class DummyModule(Kernel):
+            ard: bool = False
+
+        dummy = DummyModule()
+        instantiate_ard(
+            dummy,
+            num_curves=num_curves,
+            curve_weights=None,
+            dtype=Y_2d.dtype,
+            device=self.device,
+        )
+
+        self.assertTrue(dummy.ard)
+        self.assertTrue(hasattr(dummy, "curve_weights"))
+        self.assertEqual(dummy.curve_weights.shape, (num_curves,))
+        # Initial weights should be ones
+        self.assertAllClose(
+            dummy.curve_weights,
+            torch.ones(num_curves, dtype=torch.float64, device=self.device),
+        )
+
+        # Test instantiate_ard with 3D tensor
+        dummy_3d = DummyModule()
+        instantiate_ard(
+            dummy_3d,
+            num_curves=num_curves,
+            curve_weights=None,
+            dtype=Y_3d.dtype,
+            device=self.device,
+        )
+
+        self.assertTrue(dummy_3d.ard)
+        self.assertEqual(dummy_3d.curve_weights.shape, (num_curves,))
+
+        # Test instantiate_ard with provided curve_weights
+        dummy_custom = DummyModule()
+        custom_weights = torch.nn.Parameter(
+            torch.rand(num_curves, dtype=torch.float64, device=self.device)
+        )
+        instantiate_ard(
+            dummy_custom, num_curves=num_curves, curve_weights=custom_weights
+        )
+
+        self.assertTrue(dummy_custom.ard)
+        self.assertAllClose(dummy_custom.curve_weights, custom_weights)
+
+    def test_linear_interpolation_1d(self) -> None:
+        """Test LinearInterpolation1D: scipy correctness, batching, module features."""
+
+        def wrapped_interp1d_scipy(
+            x: Tensor, y: Tensor, bounds_error: bool | None = None
+        ) -> Callable[[Tensor], Tensor]:
+            x = x.cpu().numpy()
+            y = y.cpu().numpy()
+
+            def f(xnew: Tensor, x: np.ndarray = x, y: np.ndarray = y) -> Tensor:
+                return torch.as_tensor(
+                    interp1d(x, y, bounds_error=bounds_error)(xnew.cpu().numpy()),
+                    device=xnew.device,
+                    dtype=xnew.dtype,
+                )
+
+            return f
+
+        # --- Correctness against scipy ---
+        n = 5
+        x = torch.rand(n, device=self.device)
+        x = (x - x.min()) / (x.max() - x.min())
+        y = torch.sin(x * 2 * math.pi)
+        n2 = 2 * n
+        xq = torch.linspace(0, 1, n2, device=self.device)
+        yq_hat = LinearInterpolation1D(x, y)(xq)
+
+        yq_hat_scipy = wrapped_interp1d_scipy(x, y)(xq)
+        dtype = y.dtype
+        tol = 1e-12 if dtype == torch.float64 else 1e-5
+        self.assertAllClose(yq_hat_scipy, yq_hat, atol=tol)
+
+        # --- Batched targets ---
+        batch_size = (3, 7)
+        y = torch.rand(*batch_size, n, device=self.device)
+        yq_hat_scipy = wrapped_interp1d_scipy(x, y)(xq)
+        yq_hat = LinearInterpolation1D(x, y)(xq)
+        self.assertAllClose(yq_hat_scipy, yq_hat, atol=tol)
+
+        # --- Batched inputs + batched targets ---
+        x_batch_size = (4, 9)
+        xq = torch.rand(*x_batch_size, n2, device=self.device)
+        yq_hat_scipy = wrapped_interp1d_scipy(x, y)(xq)
+        yq_hat = LinearInterpolation1D(x, y)(xq)
+        self.assertEqual(yq_hat.shape, (*batch_size, *x_batch_size, n2))
+        self.assertAllClose(yq_hat_scipy, yq_hat, atol=tol)
+
+        # --- Batch train inputs not supported ---
+        with self.assertRaisesRegex(
+            UnsupportedError, "Expected x to be 1-dim, but got"
+        ):
+            LinearInterpolation1D(torch.rand(*batch_size, n, device=self.device), y)
+
+        # --- Out of bounds errors (both directions) ---
+        xq = torch.linspace(-1, 1, n2, device=self.device)
+        with self.assertRaisesRegex(ValueError, "is below the interpolation range"):
+            LinearInterpolation1D(x, y)(xq)
+
+        xq = torch.linspace(0, 2, n2, device=self.device)
+        with self.assertRaisesRegex(ValueError, "is above the interpolation range"):
+            LinearInterpolation1D(x, y)(xq)
+
+        # --- bounds_error=False fills with NaN (default fill_value) ---
+        xq = torch.linspace(-1, 2, n2, device=self.device)
+        yq_hat_scipy = wrapped_interp1d_scipy(x, y, bounds_error=False)(xq)
+        yq_hat = LinearInterpolation1D(x, y, bounds_error=False)(xq)
+        self.assertAllClose(yq_hat, yq_hat_scipy, atol=tol, equal_nan=True)
+
+        # --- bounds_error=False with custom fill_value ---
+        yq_filled = LinearInterpolation1D(x, y, bounds_error=False, fill_value=0.0)(xq)
+        in_bounds = (xq >= x.min()) & (xq <= x.max())
+        self.assertAllClose(
+            yq_filled[..., ~in_bounds], torch.zeros_like(yq_filled[..., ~in_bounds])
+        )
+        self.assertAllClose(yq_filled[..., in_bounds], yq_hat[..., in_bounds], atol=tol)
+
+        # --- Differentiability ---
+        x = torch.rand(2, device=self.device)
+        y = torch.randn(2, device=self.device)
+        xq = x.mean().detach().requires_grad_(True)
+        yq_hat = LinearInterpolation1D(x, y)(xq)
+        yq_hat.backward()
+        expected_grad = y.diff() / x.diff()
+        self.assertAllClose(expected_grad.item(), xq.grad.item(), atol=1e-5)
+
+        # --- Module features: buffers, state_dict, unsorted x ---
+        n = 10
+        x = torch.linspace(0, 1, n, device=self.device)
+        y = torch.sin(x * 2 * math.pi).unsqueeze(0)  # 1 x n
+        interp = LinearInterpolation1D(x, y)
+
+        # Buffers should be registered
+        buffer_names = {name for name, _ in interp.named_buffers()}
+        self.assertIn("_x", buffer_names)
+        self.assertIn("_y", buffer_names)
+
+        # state_dict should contain the buffers
+        sd = interp.state_dict()
+        self.assertIn("_x", sd)
+        self.assertIn("_y", sd)
+        self.assertIn("_bounds_error", sd)
+        self.assertIn("_fill_value", sd)
+        self.assertAllClose(sd["_x"], x)
+        self.assertAllClose(sd["_y"], y)
+
+        # state_dict round-trip preserves predictions
+        x_new = torch.tensor([0.25, 0.5, 0.75], device=self.device)
+        y_original = interp(x_new)
+
+        interp2 = LinearInterpolation1D(
+            torch.zeros(n, device=self.device),
+            torch.zeros(1, n, device=self.device),
+        )
+        interp2.load_state_dict(sd)
+        self.assertAllClose(interp2(x_new), y_original)
+
+        # Unsorted x should be sorted automatically
+        perm = torch.randperm(n, device=self.device)
+        interp_unsorted = LinearInterpolation1D(x[perm], y[..., perm])
+        self.assertAllClose(interp_unsorted(x_new), y_original)
+
+        # .to() moves buffers and preserves predictions (dtype transfer
+        # works on CPU; device transfer exercises the same code path on GPU)
+        x_knots = torch.linspace(0, 1, n)
+        y_knots = torch.sin(x_knots * 2 * math.pi).unsqueeze(0)
+        x_query = torch.tensor([0.25, 0.5, 0.75])
+
+        interp_f32 = LinearInterpolation1D(x_knots, y_knots)
+        y_f32 = interp_f32(x_query)
+
+        interp_f64 = LinearInterpolation1D(x_knots, y_knots).to(dtype=torch.float64)
+        for buf in interp_f64.buffers():
+            if buf.is_floating_point():
+                self.assertEqual(buf.dtype, torch.float64)
+        y_f64 = interp_f64(x_query.to(torch.float64))
+        self.assertAllClose(y_f64.float(), y_f32, atol=1e-6)
+
+        interp_moved = LinearInterpolation1D(x_knots, y_knots).to(self.device)
+        for buf in interp_moved.buffers():
+            # Compare device type (self.device is e.g. 'cuda', buf.device 'cuda:0').
+            self.assertEqual(buf.device.type, self.device.type)
+        y_moved = interp_moved(x_query.to(self.device))
+        self.assertAllClose(y_moved.cpu(), y_f32, atol=1e-6)


### PR DESCRIPTION
Summary:

Open-sources the Empirical one-dimensional Gaussian Process and its
dependencies from the internal botorch_fb package into open-source BoTorch.

- Adds botorch/models/empirical_gps/empirical_1d_gp.py with
  EmpiricalOneDimensionalGP and its EmpiricalOneDimensionalMean /
  EmpiricalOneDimensionalKernel components (moved from botorch_fb's
  empirical_learning_curve_gp.py). Uses the MIT license header and drops
  the deprecated EmpiricalLearningCurve* aliases.
- Adds botorch/models/empirical_gps/utils.py with the model's utility
  dependencies (center_curves, compute_basis_matrix, compute_sample_covariance,
  compute_svd_basis_vectors, extract_slice_for_interp, instantiate_ard,
  LinearInterpolation1D).
- Registers EmpiricalOneDimensionalGP in botorch.models and documents the
  module and its utils in the Sphinx API reference.
- Adds the ICML 2026 citation (Lin et al., "Empirical Gaussian Processes",
  https://arxiv.org/abs/2602.12082).
- Adds a dedicated test_empirical_gp (cpu + cuda) Buck target for the
  empirical GP test suite and excludes it from the broad test_models glob.
- Updates internal botorch_fb importers to consume the model and shared utils
  from open-source BoTorch, and moves/splits the corresponding tests.

Reviewed By: jandylin

Differential Revision: D108161279
