### PR TITLE
Added input constructor for LogRegionalExpectedImprovement and qLogRegionalExpectedImprovement

### DIFF
--- a/botorch_community/acquisition/input_constructors.py
+++ b/botorch_community/acquisition/input_constructors.py
@@ -8,7 +8,10 @@ r"""
 A registry of helpers for generating inputs to acquisition function
 constructors programmatically from a consistent input format.
 
-Contributor: hvarfner (bayesian_active_learning, scorebo)
+Contributors:
+    hvarfner (bayesian_active_learning, scorebo)
+    SaiAakash (rei)
+    sahilKirangi (113878) (rei input constructor)
 """
 
 from __future__ import annotations
@@ -37,6 +40,10 @@ from botorch_community.acquisition.discretized import (
     DiscretizedExpectedImprovement,
     DiscretizedNoisyExpectedImprovement,
     DiscretizedProbabilityOfImprovement,
+)
+from botorch_community.acquisition.rei import (
+    LogRegionalExpectedImprovement,
+    qLogRegionalExpectedImprovement,
 )
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
 from torch import Tensor
@@ -131,6 +138,67 @@ def construct_inputs_SAL(
         "X_pending": X_pending,
     }
     return inputs
+
+
+@acqf_input_constructor(
+    LogRegionalExpectedImprovement,
+    qLogRegionalExpectedImprovement,
+)
+def construct_inputs_rei(
+    model: Model,
+    training_data: SupervisedDataset | dict[Hashable, SupervisedDataset],
+    X_dev: Tensor,
+    posterior_transform: PosteriorTransform | None = None,
+    best_f: float | Tensor | None = None,
+    length: float = 0.8,
+    bounds: Tensor | None = None,
+) -> dict[str, Any]:
+    r"""Construct kwargs for Regional Expected Improvement.
+
+    Supports both the analytic ``LogRegionalExpectedImprovement`` and the
+    Monte Carlo ``qLogRegionalExpectedImprovement``.  The returned dict
+    covers the shared constructor arguments; MC-specific parameters
+    (e.g. ``sampler``, ``X_pending``) can be added by the caller.
+
+    Args:
+        model: A fitted single-outcome model.
+        training_data: Dataset(s) used to train the model.
+            Used to infer ``best_f`` when it is not provided explicitly.
+        X_dev: A ``n x d``-dim Tensor of ``n`` pre-drawn sample points in
+            ``[0, 1]^d`` representing relative positions within a trust
+            region.  Larger ``n`` gives a more accurate region average at
+            the cost of extra model evaluations.
+        posterior_transform: A ``PosteriorTransform``.  Required when using
+            a multi-output model so the posterior can be collapsed to a
+            single scalar output before computing improvement.
+        best_f: The incumbent (best observed) function value.  Improvement
+            is measured relative to this threshold.  Defaults to the
+            maximum observed ``Y`` in ``training_data``.
+        length: Side length of the cubic trust region centred on the
+            candidate point ``X``.  Must be in ``(0, 1]`` when the design
+            space is normalised to ``[0, 1]^d``.  Defaults to ``0.8``.
+        bounds: A ``2 x d``-dim Tensor of lower (row 0) and upper (row 1)
+            bounds for each input dimension.  Used to clamp the trust
+            region so it never extends outside the feasible space.
+            Defaults to the unit hypercube ``[0, 1]^d``.
+
+    Returns:
+        A dict mapping kwarg names of the acquisition function constructor
+        to their values.
+    """
+    if best_f is None:
+        best_f = get_best_f_analytic(
+            training_data=training_data,
+            posterior_transform=posterior_transform,
+        )
+    return {
+        "model": model,
+        "best_f": best_f,
+        "X_dev": X_dev,
+        "posterior_transform": posterior_transform,
+        "length": length,
+        "bounds": bounds,
+    }
 
 
 @acqf_input_constructor(qSelfCorrectingBayesianOptimization)

--- a/test_community/acquisition/test_input_constructors.py
+++ b/test_community/acquisition/test_input_constructors.py
@@ -21,6 +21,10 @@ from botorch_community.acquisition.discretized import (
     DiscretizedNoisyExpectedImprovement,
     DiscretizedProbabilityOfImprovement,
 )
+from botorch_community.acquisition.rei import (
+    LogRegionalExpectedImprovement,
+    qLogRegionalExpectedImprovement,
+)
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
 
 
@@ -85,6 +89,56 @@ class TestAnalyticalAcquisitionFunctionInputConstructors(InputConstructorBaseTes
                 self.assertIs(kwargs["model"], mock_model)
                 self.assertIsNone(kwargs["posterior_transform"])
                 self.assertEqual(kwargs["best_f"], 0.1)
+                acqf = acqf_cls(**kwargs)
+                self.assertIs(acqf.model, mock_model)
+
+    def test_construct_inputs_rei(self) -> None:
+        # Contributor: sahilKirangi (113878)
+        for acqf_cls in [
+            LogRegionalExpectedImprovement,
+            qLogRegionalExpectedImprovement,
+        ]:
+            with self.subTest(acqf_cls=acqf_cls):
+                c = get_acqf_input_constructor(acqf_cls)
+                mock_model = self.mock_model
+                X_dev = torch.rand(5, 2)
+
+                # best_f inferred from training data
+                kwargs = c(
+                    model=mock_model,
+                    training_data=self.blockX_blockY,
+                    X_dev=X_dev,
+                )
+                best_f_expected = self.blockX_blockY[0].Y.squeeze().max()
+                self.assertIs(kwargs["model"], mock_model)
+                self.assertTrue(torch.equal(kwargs["X_dev"], X_dev))
+                self.assertEqual(kwargs["best_f"], best_f_expected)
+                self.assertIsNone(kwargs["posterior_transform"])
+                self.assertEqual(kwargs["length"], 0.8)
+                self.assertIsNone(kwargs["bounds"])
+                acqf = acqf_cls(**kwargs)
+                self.assertIs(acqf.model, mock_model)
+
+                # explicit best_f overrides inferred value
+                kwargs = c(
+                    model=mock_model,
+                    training_data=self.blockX_blockY,
+                    X_dev=X_dev,
+                    best_f=0.5,
+                )
+                self.assertEqual(kwargs["best_f"], 0.5)
+
+                # explicit length and bounds are passed through unchanged
+                bounds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
+                kwargs = c(
+                    model=mock_model,
+                    training_data=self.blockX_blockY,
+                    X_dev=X_dev,
+                    length=0.5,
+                    bounds=bounds,
+                )
+                self.assertEqual(kwargs["length"], 0.5)
+                self.assertTrue(torch.equal(kwargs["bounds"], bounds))
                 acqf = acqf_cls(**kwargs)
                 self.assertIs(acqf.model, mock_model)
 


### PR DESCRIPTION
Registers `construct_inputs_rei` for both `LogRegionalExpectedImprovement`
  and `qLogRegionalExpectedImprovement` in `botorch_community/acquisition/input_constructors.py`.
- Infers `best_f` from training data when not provided, consistent with
  the pattern used by `construct_inputs_best_f`.
- Passes through `X_dev`, `posterior_transform`, `length`, and `bounds`.
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

Without this constructor, calling `get_acquisition_function` with either
REI class raises a KeyError. This fills the gap left when the original
REI implementation was merged.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, I filled out the application for these as well.

## Test Plan

- Added `test_construct_inputs_rei` to `test_community/acquisition/test_input_constructors.py`.
- Covers: auto-inferred `best_f`, explicit `best_f`, explicit `length`
  and `bounds`, and successful acqf instantiation from returned kwargs.
- Tests pass for both analytic and MC variants.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/meta-pytorch/botorch, and link to your PR here.)
