### PR TITLE
Add AddTree GP for tree-structured / conditional parameter spaces

### DIFF
--- a/botorch_community/acquisition/addtree.py
+++ b/botorch_community/acquisition/addtree.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Acquisition-function optimisation for the AddTree conditional space.
+
+This is a **thin** wrapper around BoTorch's
+:func:`~botorch.optim.optimize.optimize_acqf_mixed`: the AddTree spec
+already exposes its ``fixed_features_list``, so optimisation is a single
+call.
+
+Sign convention:
+    BoTorch maximises; AddTree's original acquisition (LCB) minimises.
+    Negate observed objective values when constructing the
+    :class:`~botorch_community.models.addtree.model.AddTreeGP` and pass a
+    maximisation acquisition function (the default
+    :class:`~botorch.acquisition.UpperConfidenceBound` here).
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from botorch.acquisition import (
+    AcquisitionFunction,
+    qUpperConfidenceBound,
+    UpperConfidenceBound,
+)
+from botorch.optim import optimize_acqf_mixed
+
+from botorch_community.models.addtree.model import AddTreeGP
+from torch import Tensor
+
+
+__all__ = ["optimize_addtree_acqf"]
+
+
+def optimize_addtree_acqf(
+    model: AddTreeGP,
+    *,
+    acqf: AcquisitionFunction | None = None,
+    beta: float = 1.0,
+    q: int = 1,
+    num_restarts: int = 2,
+    raw_samples: int = 128,
+    **optimize_acqf_mixed_kwargs: Any,
+) -> tuple[Tensor, Tensor]:
+    r"""Optimise an acquisition function over the AddTree space.
+
+    Args:
+        model: A fitted :class:`AddTreeGP`. The space is read from
+            ``model.addtree_space``.
+        acqf: Optional acquisition function. If ``None``, defaults to
+            :class:`~botorch.acquisition.UpperConfidenceBound` with the
+            supplied ``beta``.
+        beta: ``beta`` for the default UCB acquisition. Ignored if
+            ``acqf`` is provided.
+        q: Batch size (number of candidates). q > 1 is supported for
+            q-batch acquisitions; sequential greedy is used internally.
+        num_restarts: Multistart count for L-BFGS-B (forwarded).
+        raw_samples: Sobol initialisation samples per fixed-features
+            entry (forwarded).
+        **optimize_acqf_mixed_kwargs: Forwarded to
+            :func:`optimize_acqf_mixed`.
+
+    Returns:
+        ``(candidates, acq_values)`` exactly as
+        :func:`optimize_acqf_mixed` returns; ``candidates`` has shape
+        ``(q, space.dim)``.
+    """
+    space = model.addtree_space
+    if acqf is None:
+        if q == 1:
+            acqf = UpperConfidenceBound(model=model, beta=beta, maximize=True)
+        else:
+            # q > 1 needs an MC acquisition that supports X_pending.
+            acqf = qUpperConfidenceBound(model=model, beta=beta)
+
+    # Move bounds to the model's dtype/device so optimize_acqf_mixed is
+    # happy.
+    train_X = model.train_inputs[0]
+    bounds = space.bounds.to(dtype=train_X.dtype, device=train_X.device)
+
+    return optimize_acqf_mixed(
+        acq_function=acqf,
+        bounds=bounds,
+        q=q,
+        num_restarts=num_restarts,
+        raw_samples=raw_samples,
+        fixed_features_list=list(space.fixed_features_list),
+        **optimize_acqf_mixed_kwargs,
+    )

--- a/botorch_community/models/addtree/__init__.py
+++ b/botorch_community/models/addtree/__init__.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""AddTree GP for tree-structured / conditional parameter spaces.
+
+Implements the AddTree covariance kernel and Bayesian-optimisation
+utilities from:
+
+.. [Ma2020addtree]
+    X. Ma and M. Blaschko. Additive Tree-Structured Covariance Function
+    for Conditional Parameter Spaces in Bayesian Optimization. AISTATS
+    2020.
+
+User-facing API:
+
+* :class:`AddTreeSpace` -- declarative spec of the conditional parameter
+  space (constructed from a Python builder, a nested dict, or a YAML
+  file).
+* :class:`AddTreeGP` -- the corresponding GP model.
+* :func:`encode` / :func:`decode` -- bridge user-facing parameter dicts
+  and BFS tensors.
+* :func:`~botorch_community.acquisition.addtree.optimize_addtree_acqf`
+  -- one-call BO step (a thin wrapper over
+  :func:`botorch.optim.optimize_acqf_mixed`).
+
+Contributor: maxc01
+"""
+
+from botorch_community.models.addtree.encoding import decode, encode, param_key
+from botorch_community.models.addtree.kernels import (
+    AddTreeDeltaKernel,
+    build_addtree_kernel,
+)
+from botorch_community.models.addtree.model import AddTreeGP
+from botorch_community.models.addtree.space import (
+    AddTreeSpace,
+    Choice,
+    Continuous,
+    make_node,
+    Node,
+)
+
+
+__all__ = [
+    "AddTreeDeltaKernel",
+    "AddTreeGP",
+    "AddTreeSpace",
+    "Choice",
+    "Continuous",
+    "Node",
+    "build_addtree_kernel",
+    "decode",
+    "encode",
+    "make_node",
+    "param_key",
+]

--- a/botorch_community/models/addtree/encoding.py
+++ b/botorch_community/models/addtree/encoding.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Encoding / decoding between user-facing parameter dicts and BFS tensors.
+
+Two formats:
+
+1. **User dict** -- a plain ``dict[str, str | float]`` keyed by:
+
+   * ``"<choice_name>"``  -> ``str`` option name (e.g. ``"left"``)
+   * ``"<node_name>.<continuous_name>"`` -> ``float``
+
+   The dict only needs to contain entries for nodes / choices that are on
+   the path (off-path parameters are implicit).
+
+2. **BFS tensor** -- a 1-d ``torch.Tensor`` of length
+   :attr:`AddTreeSpace.dim`, with ``-1`` (the sentinel) in off-path slots,
+   the integer ``local_id`` in on-path categorical-flag slots, and the
+   actual value in on-path continuous slots.
+
+Round-trip:
+
+>>> space.decode(space.encode(p)) == p   # for any feasible ``p``
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import torch
+
+from botorch_community.models.addtree.space import AddTreeSpace
+from torch import Tensor
+
+
+__all__ = ["encode", "decode", "param_key"]
+
+
+def param_key(node_name: str, cont_name: str) -> str:
+    """The user-dict key for a continuous parameter.
+
+    By convention the key is ``f"{node_name}.{cont_name}"``.
+    """
+    return f"{node_name}.{cont_name}"
+
+
+# ---------------------------------------------------------------------------
+# encode
+# ---------------------------------------------------------------------------
+
+
+def encode(
+    space: AddTreeSpace,
+    params: Mapping[str, Any],
+    *,
+    dtype: torch.dtype = torch.float64,
+    device: torch.device | str | None = None,
+) -> Tensor:
+    r"""Encode a user-facing parameter dict into a BFS tensor.
+
+    Args:
+        space: The :class:`AddTreeSpace` defining the encoding.
+        params: A mapping with entries ``"<choice_name>" -> "<option_name>"``
+            for every choice the path traverses, and
+            ``"<node_name>.<continuous_name>" -> float`` for every
+            continuous parameter on that path. Off-path entries are
+            ignored if present (so users can pass over-specified dicts).
+        dtype: Output tensor dtype. Defaults to ``torch.float64``.
+        device: Output tensor device. Defaults to CPU.
+
+    Returns:
+        A ``(space.dim,)`` tensor in BFS encoding.
+
+    Raises:
+        KeyError: if a required choice or continuous parameter is missing.
+        ValueError: if a choice value is not a known option, or a
+            continuous value is outside ``[lo, hi]``.
+    """
+    out = torch.full((space.dim,), space.SENTINEL, dtype=dtype, device=device)
+
+    # Walk from root, following the user's choice picks.
+    rec = space._all_records[0]
+    out[rec.flag_index] = float(rec.local_id)
+    _write_continuous(out, rec, params)
+
+    while rec.node.choice is not None:
+        choice = rec.node.choice
+        if choice.name not in params:
+            raise KeyError(
+                f"Missing choice '{choice.name}' in params; "
+                f"valid options: {[o for o, _ in choice.options]}."
+            )
+        chosen = params[choice.name]
+        match_idx = None
+        for opt_idx, (opt_name, _child) in enumerate(choice.options):
+            if opt_name == chosen:
+                match_idx = opt_idx
+                break
+        if match_idx is None:
+            raise ValueError(
+                f"Choice '{choice.name}': value {chosen!r} is not a valid "
+                f"option (known: {[o for o, _ in choice.options]})."
+            )
+        child_node = choice.options[match_idx][1]
+        rec = space._record_by_name(child_node.name)
+        out[rec.flag_index] = float(rec.local_id)
+        _write_continuous(out, rec, params)
+
+    return out
+
+
+def _write_continuous(out: Tensor, rec, params: Mapping[str, Any]) -> None:
+    for ax, c in zip(rec.cont_indices, rec.node.continuous):
+        key = param_key(rec.node.name, c.name)
+        if key not in params:
+            raise KeyError(
+                f"Missing continuous parameter '{key}' in params for node "
+                f"'{rec.node.name}'."
+            )
+        v = float(params[key])
+        if not (c.lo - 1e-12 <= v <= c.hi + 1e-12):
+            raise ValueError(
+                f"Continuous '{key}': value {v} out of bounds " f"[{c.lo}, {c.hi}]."
+            )
+        out[ax] = v
+
+
+# ---------------------------------------------------------------------------
+# decode
+# ---------------------------------------------------------------------------
+
+
+def decode(space: AddTreeSpace, x: Tensor) -> dict[str, Any]:
+    r"""Decode a BFS tensor back to a user-facing parameter dict.
+
+    Args:
+        space: The :class:`AddTreeSpace` defining the encoding.
+        x: A ``(space.dim,)`` tensor in BFS encoding (off-path slots ==
+            ``space.SENTINEL``, on-path flag slots == ``local_id``,
+            on-path continuous slots == data).
+
+    Returns:
+        A flat ``dict`` with keys ``"<choice_name>"`` for traversed
+        choices and ``"<node_name>.<continuous_name>"`` for on-path
+        continuous parameters.
+    """
+    if x.shape[-1] != space.dim:
+        raise ValueError(
+            f"Decode expects last-dim {space.dim}; got shape {tuple(x.shape)}."
+        )
+    if x.ndim > 1:
+        if x.ndim != 2 or x.shape[0] != 1:
+            raise ValueError(
+                "decode expects a 1-d tensor or a 1xdim batch; got "
+                f"shape {tuple(x.shape)}."
+            )
+        x = x.squeeze(0)
+
+    out: dict[str, Any] = {}
+    # Walk from the root, reading the chosen option from each on-path
+    # categorical-flag slot.
+    rec = space._all_records[0]
+    _read_continuous(out, rec, x)
+
+    while rec.node.choice is not None:
+        choice = rec.node.choice
+        # Find which child has its flag set (i.e. != sentinel).
+        chosen_child_idx: int | None = None
+        chosen_option_name: str | None = None
+        for opt_idx, (opt_name, child_node) in enumerate(choice.options):
+            child_rec = space._record_by_name(child_node.name)
+            if float(x[child_rec.flag_index]) != float(space.SENTINEL):
+                if chosen_child_idx is not None:
+                    raise ValueError(
+                        f"Decoded path is ambiguous at choice '{choice.name}'"
+                        f": multiple options have non-sentinel flags."
+                    )
+                chosen_child_idx = opt_idx
+                chosen_option_name = opt_name
+        if chosen_child_idx is None:
+            # No child on path; tree must end here, but the choice
+            # dictates that a child is expected. This is a malformed
+            # encoding.
+            raise ValueError(
+                f"Decoded path stops short of choice '{choice.name}'"
+                f": none of its option flags are set."
+            )
+        out[choice.name] = chosen_option_name
+        rec = space._record_by_name(choice.options[chosen_child_idx][1].name)
+        _read_continuous(out, rec, x)
+
+    return out
+
+
+def _read_continuous(out: dict[str, Any], rec, x: Tensor) -> None:
+    for ax, c in zip(rec.cont_indices, rec.node.continuous):
+        out[param_key(rec.node.name, c.name)] = float(x[ax])

--- a/botorch_community/models/addtree/examples/__init__.py
+++ b/botorch_community/models/addtree/examples/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/botorch_community/models/addtree/examples/jenatton3_synthetic.py
+++ b/botorch_community/models/addtree/examples/jenatton3_synthetic.py
@@ -1,0 +1,345 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""3-level binary AddTree synthetic benchmark.
+
+This is a strictly harder analogue of the Jenatton-small example: the
+tree has **three** levels of binary categorical decisions (instead of
+two), each interior or leaf node carries a 1-D continuous parameter, and
+the off-best paths have a structured bias that grows with the Hamming
+distance from the global-optimum path. The library must therefore learn
+*both* the right path **and** the right continuous values at every level
+on that path.
+
+Tree structure::
+
+    root
+    ├── A
+    │   ├── A1
+    │   │   ├── A1a   (continuous v in [0, 1])  <-- best leaf
+    │   │   └── A1b
+    │   └── A2
+    │       ├── A2a
+    │       └── A2b
+    └── B
+        ├── B1
+        │   ├── B1a
+        │   └── B1b
+        └── B2
+            ├── B2a
+            └── B2b
+
+Eight root-to-leaf paths, BFS-encoded dimension is 29.
+
+Objective (minimised)::
+
+    f(p) = TARGET
+         + path_bias(path_id)                  # depends on which path
+         + sum_{node on path} (v_node - 0.3)**2
+
+with ``TARGET = 0.05`` reached at path ``A/1/a`` with all on-path
+``v = 0.3``. The most "wrong" path (``B/2/b``) has ``path_bias = 0.45``.
+
+Run from the BoTorch repo root::
+
+    python -m botorch_community.models.addtree.examples.jenatton3_synthetic
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from typing import Any
+
+import numpy as np
+import torch
+from botorch import fit_gpytorch_mll
+from botorch_community.acquisition.addtree import optimize_addtree_acqf
+from botorch_community.models.addtree import AddTreeGP, AddTreeSpace, decode, encode
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+
+# ---------------------------------------------------------------------------
+# Spec construction
+# ---------------------------------------------------------------------------
+
+
+def _node1d(name: str, choices: list[dict] | None = None) -> dict:
+    """Helper: a node with one continuous param and an optional choice."""
+    out: dict = {
+        "name": name,
+        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+    }
+    if choices:
+        out["choices"] = choices
+    return out
+
+
+def jenatton3_spec() -> dict[str, Any]:
+    """Return the 3-level binary tree spec."""
+    return {
+        "name": "root",
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "A": _node1d(
+                        "A",
+                        choices=[
+                            {
+                                "name": "A.choice",
+                                "options": {
+                                    "1": _node1d(
+                                        "A1",
+                                        choices=[
+                                            {
+                                                "name": "A1.choice",
+                                                "options": {
+                                                    "a": _node1d("A1a"),
+                                                    "b": _node1d("A1b"),
+                                                },
+                                            }
+                                        ],
+                                    ),
+                                    "2": _node1d(
+                                        "A2",
+                                        choices=[
+                                            {
+                                                "name": "A2.choice",
+                                                "options": {
+                                                    "a": _node1d("A2a"),
+                                                    "b": _node1d("A2b"),
+                                                },
+                                            }
+                                        ],
+                                    ),
+                                },
+                            }
+                        ],
+                    ),
+                    "B": _node1d(
+                        "B",
+                        choices=[
+                            {
+                                "name": "B.choice",
+                                "options": {
+                                    "1": _node1d(
+                                        "B1",
+                                        choices=[
+                                            {
+                                                "name": "B1.choice",
+                                                "options": {
+                                                    "a": _node1d("B1a"),
+                                                    "b": _node1d("B1b"),
+                                                },
+                                            }
+                                        ],
+                                    ),
+                                    "2": _node1d(
+                                        "B2",
+                                        choices=[
+                                            {
+                                                "name": "B2.choice",
+                                                "options": {
+                                                    "a": _node1d("B2a"),
+                                                    "b": _node1d("B2b"),
+                                                },
+                                            }
+                                        ],
+                                    ),
+                                },
+                            }
+                        ],
+                    ),
+                },
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Objective (library minimises -- pass -y as train_Y)
+# ---------------------------------------------------------------------------
+
+
+TARGET: float = 0.05  # global optimum value at A/1/a, v == 0.3 everywhere
+BEST_PATH: tuple[str, str, str] = ("A", "1", "a")
+PATH_BIAS_STEP: float = 0.15
+CONT_OPT: float = 0.3
+
+
+def path_bias(L1: str, L2: str, L3: str) -> float:
+    """Heuristic bias = 0.15 * Hamming distance from the best path."""
+    target = BEST_PATH
+    parts = (L1, L2, L3)
+    return PATH_BIAS_STEP * sum(1 for a, b in zip(parts, target) if a != b)
+
+
+def obj_func(params: dict[str, Any]) -> float:
+    """Synthetic objective; minimum value is :data:`TARGET`."""
+    L1 = params["L1"]
+    L2 = params[f"{L1}.choice"]
+    n2 = f"{L1}{L2}"
+    L3 = params[f"{n2}.choice"]
+    n3 = f"{n2}{L3}"
+
+    bias = path_bias(L1, L2, L3)
+    cont = sum((params[f"{node}.v"] - CONT_OPT) ** 2 for node in (L1, n2, n3))
+    return TARGET + bias + cont
+
+
+# ---------------------------------------------------------------------------
+# Random initial design
+# ---------------------------------------------------------------------------
+
+
+def random_params(rng: np.random.Generator) -> dict[str, Any]:
+    L1 = rng.choice(["A", "B"])
+    L2 = rng.choice(["1", "2"])
+    L3 = rng.choice(["a", "b"])
+    n1, n2, n3 = L1, f"{L1}{L2}", f"{L1}{L2}{L3}"
+    return {
+        "L1": L1,
+        f"{L1}.choice": L2,
+        f"{n2}.choice": L3,
+        f"{n1}.v": float(rng.random()),
+        f"{n2}.v": float(rng.random()),
+        f"{n3}.v": float(rng.random()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# BO loop
+# ---------------------------------------------------------------------------
+
+
+def main(
+    n_init: int = 20,
+    n_iter: int = 60,
+    beta: float = 3.0,
+    q: int = 1,
+    seed: int = 0,
+    output_dir: str | None = None,
+) -> dict[str, Any]:
+    """Run AddTree v2 BO on the 3-level synthetic. Returns summary statistics."""
+    logger = logging.getLogger("addtree.examples.jenatton3_synthetic")
+    if not logger.handlers:
+        h = logging.StreamHandler()
+        h.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+        logger.addHandler(h)
+    logger.setLevel(logging.INFO)
+
+    rng = np.random.default_rng(seed)
+    torch.manual_seed(seed)
+    torch.set_default_dtype(torch.float64)
+
+    space = AddTreeSpace.from_dict(jenatton3_spec())
+    logger.info(
+        "space: dim=%d  num_paths=%d  paths=%s",
+        space.dim,
+        space.num_paths,
+        space.path_ids,
+    )
+
+    if output_dir is not None:
+        os.makedirs(output_dir, exist_ok=True)
+
+    Xs: list[torch.Tensor] = []
+    Ys: list[float] = []
+    history: list[dict[str, Any]] = []
+
+    # ---------- random init ----------
+    for i in range(n_init):
+        p = random_params(rng)
+        y = obj_func(p)
+        Xs.append(encode(space, p))
+        Ys.append(-y)
+        history.append({"iteration": i + 1, "phase": "init", "params": p, "value": y})
+        logger.info(
+            "iter %3d (init):  y=%.4f (best=%.4f)",
+            i + 1,
+            y,
+            -max(Ys),
+        )
+
+    # ---------- BO loop ----------
+    iter_idx = n_init
+    while iter_idx < n_iter:
+        train_X = torch.stack(Xs)
+        train_Y = torch.tensor(Ys, dtype=torch.float64).unsqueeze(-1)
+
+        model = AddTreeGP(space, train_X, train_Y)
+        fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))
+
+        candidates, _ = optimize_addtree_acqf(
+            model,
+            beta=beta,
+            q=q,
+            num_restarts=2,
+            raw_samples=64,
+        )
+
+        for j in range(candidates.shape[0]):
+            x_new = candidates[j]
+            p = decode(space, x_new)
+            y = obj_func(p)
+            Xs.append(x_new)
+            Ys.append(-y)
+            iter_idx += 1
+            history.append(
+                {
+                    "iteration": iter_idx,
+                    "phase": "bo",
+                    "params": p,
+                    "value": y,
+                }
+            )
+            logger.info(
+                "iter %3d (bo):  y=%.4f (best=%.4f)",
+                iter_idx,
+                y,
+                -max(Ys),
+            )
+            if output_dir is not None:
+                with open(os.path.join(output_dir, f"iter_{iter_idx}.json"), "w") as f:
+                    json.dump(history[-1], f)
+            if iter_idx >= n_iter:
+                break
+
+    best_y = -max(Ys)
+    summary = {
+        "best_value": best_y,
+        "gap_to_target": best_y - TARGET,
+        "n_init": n_init,
+        "n_iter": n_iter,
+        "history": history,
+    }
+    logger.info(
+        "FINAL best_value = %.4f (target = %.4f, gap = %.4f)",
+        best_y,
+        TARGET,
+        best_y - TARGET,
+    )
+    return summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n_init", type=int, default=20)
+    p.add_argument("--n_iter", type=int, default=60)
+    p.add_argument("--beta", type=float, default=3.0)
+    p.add_argument("--q", type=int, default=1)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--output_dir", type=str, default=None)
+    args = p.parse_args()
+    main(**vars(args))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/botorch_community/models/addtree/examples/jenatton_small.py
+++ b/botorch_community/models/addtree/examples/jenatton_small.py
@@ -1,0 +1,242 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""End-to-end AddTree BO example on the Jenatton-small synthetic function.
+
+Reproduces the Jenatton-small benchmark from the AddTree paper using
+the v2 declarative API. Compared to the upstream ``addtree`` repo this
+example has *no* registry-management ritual, *no* per-tree adapter
+function, and *no* manual BFS-encoding logic --- everything goes
+through :class:`AddTreeSpace` and :func:`optimize_addtree_acqf`.
+
+Run from the BoTorch repo root::
+
+    python -m botorch_community.models.addtree.examples.jenatton_small
+
+The optimum of Jenatton-small is ``0.1``; ~30 BO iterations should
+reliably reach it.
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from typing import Any
+
+import numpy as np
+import torch
+from botorch import fit_gpytorch_mll
+from botorch_community.acquisition.addtree import optimize_addtree_acqf
+from botorch_community.models.addtree import AddTreeGP, AddTreeSpace, decode, encode
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+
+# ---------------------------------------------------------------------------
+# 1. Declare the parameter space.
+# ---------------------------------------------------------------------------
+
+
+def jenatton_small_spec() -> dict[str, Any]:
+    r"""Return the Jenatton-small spec as a nested dict.
+
+    Tree (each leaf has a 1-D continuous parameter named ``v``)::
+
+                       root
+                       /  \
+                  L1=left  L1=right
+                 (.v)        (.v)
+                 /   \       /    \
+              L2=l L2=r   L2=l  L2=r
+              (.v) (.v)  (.v)  (.v)
+    """
+    leaf = lambda name: {  # noqa: E731 - tiny helper
+        "name": name,
+        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+    }
+    return {
+        "name": "root",
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "left": {
+                        "name": "L1_left",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_ll"),
+                                    "right": leaf("L2_lr"),
+                                },
+                            }
+                        ],
+                    },
+                    "right": {
+                        "name": "L1_right",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_rl"),
+                                    "right": leaf("L2_rr"),
+                                },
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. Define the (library-minimised) objective. Optimum value is 0.1.
+# ---------------------------------------------------------------------------
+
+
+def obj_func(params: dict[str, Any]) -> float:
+    """Synthetic objective from Jenatton 2017."""
+    SHIFT = 0.5
+    L1 = params["L1"]
+    L2 = params["L2"]
+    L1_v = params[f"L1_{L1}.v"]
+    L2_v = params[f"L2_{L1[0]}{L2[0]}.v"]
+    bias = {"left,left": 0.1, "left,right": 0.2, "right,left": 0.3, "right,right": 0.4}[
+        f"{L1},{L2}"
+    ]
+    return L1_v + (L2_v - SHIFT) ** 2 + bias
+
+
+# ---------------------------------------------------------------------------
+# 3. Random initial design (uniform over options + uniform on continuous).
+# ---------------------------------------------------------------------------
+
+
+def random_params(rng: np.random.Generator) -> dict[str, Any]:
+    L1 = rng.choice(["left", "right"])
+    L2 = rng.choice(["left", "right"])
+    return {
+        "L1": L1,
+        f"L1_{L1}.v": float(rng.random()),
+        "L2": L2,
+        f"L2_{L1[0]}{L2[0]}.v": float(rng.random()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. BO loop.
+# ---------------------------------------------------------------------------
+
+
+def main(
+    n_init: int = 10,
+    n_iter: int = 100,
+    beta: float = 3.0,
+    seed: int = 0,
+    output_dir: str | None = None,
+) -> dict[str, Any]:
+    """Run AddTree v2 BO on Jenatton-small. Returns summary statistics."""
+    logger = logging.getLogger("addtree.examples.jenatton_small")
+    if not logger.handlers:
+        h = logging.StreamHandler()
+        h.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+        logger.addHandler(h)
+    logger.setLevel(logging.INFO)
+
+    rng = np.random.default_rng(seed)
+    torch.manual_seed(seed)
+    torch.set_default_dtype(torch.float64)
+
+    space = AddTreeSpace.from_dict(jenatton_small_spec())
+
+    if output_dir is not None:
+        os.makedirs(output_dir, exist_ok=True)
+
+    Xs: list[torch.Tensor] = []
+    Ys: list[float] = []
+    history: list[dict[str, Any]] = []
+
+    # ---------- random init ----------
+    for i in range(n_init):
+        p = random_params(rng)
+        y = obj_func(p)
+        Xs.append(encode(space, p))
+        Ys.append(-y)  # negate for maximisation
+        record = {"iteration": i + 1, "phase": "init", "params": p, "value": y}
+        history.append(record)
+        logger.info(
+            "iter %3d (init):  y=%.4f (best=%.4f)",
+            i + 1,
+            y,
+            -max(Ys),
+        )
+        if output_dir is not None:
+            with open(os.path.join(output_dir, f"iter_{i+1}.json"), "w") as f:
+                json.dump(record, f)
+
+    # ---------- BO loop ----------
+    for i in range(n_init, n_iter):
+        train_X = torch.stack(Xs)
+        train_Y = torch.tensor(Ys, dtype=torch.float64).unsqueeze(-1)
+
+        model = AddTreeGP(space, train_X, train_Y)
+        fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))
+
+        candidates, _ = optimize_addtree_acqf(
+            model,
+            beta=beta,
+            q=1,
+            num_restarts=2,
+            raw_samples=128,
+        )
+        x_new = candidates[0]
+        p = decode(space, x_new)
+        y = obj_func(p)
+        Xs.append(x_new)
+        Ys.append(-y)
+
+        record = {"iteration": i + 1, "phase": "bo", "params": p, "value": y}
+        history.append(record)
+        logger.info(
+            "iter %3d (bo):  y=%.4f (best=%.4f)",
+            i + 1,
+            y,
+            -max(Ys),
+        )
+        if output_dir is not None:
+            with open(os.path.join(output_dir, f"iter_{i+1}.json"), "w") as f:
+                json.dump(record, f)
+
+    best_y = -max(Ys)
+    summary = {
+        "best_value": best_y,
+        "best_iteration": int(np.argmin([h["value"] for h in history])) + 1,
+        "n_init": n_init,
+        "n_iter": n_iter,
+        "history": history,
+    }
+    logger.info("FINAL best_value = %.4f (optimum = 0.1)", best_y)
+    return summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n_init", type=int, default=10)
+    p.add_argument("--n_iter", type=int, default=100)
+    p.add_argument("--beta", type=float, default=3.0)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--output_dir", type=str, default=None)
+    args = p.parse_args()
+    main(**vars(args))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/botorch_community/models/addtree/kernels.py
+++ b/botorch_community/models/addtree/kernels.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""AddTree covariance kernel for GPyTorch.
+
+The AddTree kernel is
+
+.. math::
+    k(x, x') = c \cdot \sum_{v \in \mathrm{tree}}
+        k_{\Delta,v}(\mathrm{flag}_v(x), \mathrm{flag}_v(x'))
+        \cdot k_{\mathrm{RBF},v}(\mathrm{data}_v(x), \mathrm{data}_v(x'))
+
+where the sum runs over every node ``v`` in the BFS-ordered tree.
+``flag_v`` is the node's ``local_id`` slot in the BFS encoding (or the
+sentinel ``-1`` if the node is off-path), and ``data_v`` is the
+contiguous block of continuous-parameter slots immediately following it.
+
+This module provides:
+
+* :class:`AddTreeDeltaKernel` -- a stationary 1-d kernel that returns
+  ``1`` if its inputs are equal and ``0`` otherwise. The categorical
+  factor of the AddTree sum.
+* :func:`build_addtree_kernel` -- assembles the additive sum from an
+  :class:`~botorch_community.models.addtree.space.AddTreeSpace`.
+
+References:
+
+.. [Ma2020addtree]
+    X. Ma and M. Blaschko. Additive Tree-Structured Covariance Function
+    for Conditional Parameter Spaces in Bayesian Optimization. AISTATS
+    2020.
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+import math
+from functools import reduce
+
+import torch
+
+from botorch_community.models.addtree.space import AddTreeSpace
+from gpytorch.constraints import Interval
+from gpytorch.kernels import Kernel, RBFKernel, ScaleKernel
+from torch import Tensor
+
+
+__all__ = ["AddTreeDeltaKernel", "build_addtree_kernel"]
+
+
+# ``metric_bounds = [(-7, 4)]`` (george-AddTree paper) means
+# ``log(metric) in [-7, 4]``, where ``metric = lengthscale**2``. So the
+# plain-lengthscale interval is ``[exp(-3.5), exp(2)] ~= [0.030, 7.39]``.
+_LS_LOWER = math.exp(-3.5)
+_LS_UPPER = math.exp(2.0)
+# ``ConstantKernel(-0.69, bounds=[(-7, 4)])`` -> ``c in [exp(-7), exp(4)]``.
+_OS_LOWER = math.exp(-7.0)
+_OS_UPPER = math.exp(4.0)
+# Initial values from the AddTree paper.
+_LS_INIT = math.sqrt(0.5)
+_OS_INIT = math.exp(-0.69)
+
+
+class AddTreeDeltaKernel(Kernel):
+    r"""Hard delta kernel: ``K(x1, x2) = 1 if x1 == x2 else 0``.
+
+    Stationary, no learnable parameters, not differentiable. Designed to
+    be multiplied by a continuous kernel (e.g. :class:`RBFKernel`) on a
+    disjoint set of ``active_dims``. Equality is exact tensor equality
+    along the (typically 1-d) active dimensions; the AddTree encoding
+    only stores integer-valued floats in the dimensions this kernel
+    operates on, so this is well-defined.
+    """
+
+    has_lengthscale = False
+    is_stationary = True
+
+    def forward(
+        self,
+        x1: Tensor,
+        x2: Tensor,
+        diag: bool = False,
+        last_dim_is_batch: bool = False,
+        **params,
+    ) -> Tensor:
+        if last_dim_is_batch:
+            # GPyTorch convention: move the last dim into a leading batch dim.
+            x1 = x1.transpose(-1, -2).unsqueeze(-1)
+            x2 = x2.transpose(-1, -2).unsqueeze(-1)
+        if diag:
+            eq = (x1 == x2).all(dim=-1)
+            return eq.to(x1.dtype)
+        eq = (x1.unsqueeze(-2) == x2.unsqueeze(-3)).all(dim=-1)
+        return eq.to(x1.dtype)
+
+
+def build_addtree_kernel(
+    space: AddTreeSpace,
+    *,
+    lengthscale_init: float = _LS_INIT,
+    outputscale_init: float = _OS_INIT,
+    lengthscale_bounds: tuple[float, float] = (_LS_LOWER, _LS_UPPER),
+    outputscale_bounds: tuple[float, float] = (_OS_LOWER, _OS_UPPER),
+) -> ScaleKernel:
+    r"""Build the AddTree kernel for an :class:`AddTreeSpace`.
+
+    Args:
+        space: The :class:`AddTreeSpace` defining the tree.
+        lengthscale_init: Initial lengthscale for per-node RBF kernels.
+            Defaults to ``sqrt(0.5)`` (matches the AddTree paper).
+        outputscale_init: Initial value of the outer ``ScaleKernel``.
+            Defaults to ``exp(-0.69)``.
+        lengthscale_bounds: ``(lower, upper)`` interval constraint for
+            the RBF lengthscale. Defaults match the paper's
+            ``metric_bounds = [(-7, 4)]`` translated from log-metric to
+            plain lengthscale (i.e. ``[exp(-3.5), exp(2)]``).
+        outputscale_bounds: ``(lower, upper)`` constraint for the
+            ``ScaleKernel.outputscale``.
+
+    Returns:
+        A :class:`ScaleKernel` wrapping the additive sum
+        ``Sum_v DeltaKernel(active_dims=[flag_v]) *
+                 RBFKernel(active_dims=cont_dims_v)`` over all nodes.
+    """
+    ls_constraint = Interval(*lengthscale_bounds)
+    os_constraint = Interval(*outputscale_bounds)
+
+    components: list[Kernel] = []
+    for rec in space._all_records:
+        delta = AddTreeDeltaKernel(active_dims=(rec.flag_index,))
+        if not rec.cont_indices:
+            components.append(delta)
+            continue
+
+        rbf = RBFKernel(
+            ard_num_dims=len(rec.cont_indices),
+            active_dims=tuple(rec.cont_indices),
+            lengthscale_constraint=ls_constraint,
+        )
+        # Initialise lengthscale strictly inside (lo, hi).
+        ls = max(lengthscale_bounds[0] * 1.01, lengthscale_init)
+        ls = min(lengthscale_bounds[1] * 0.99, ls)
+        with torch.no_grad():
+            rbf.lengthscale = torch.full(
+                (1, len(rec.cont_indices)),
+                ls,
+                dtype=torch.get_default_dtype(),
+            )
+        components.append(delta * rbf)
+
+    additive = reduce(lambda a, b: a + b, components)
+    scaled = ScaleKernel(additive, outputscale_constraint=os_constraint)
+    os = max(outputscale_bounds[0] * 1.01, outputscale_init)
+    os = min(outputscale_bounds[1] * 0.99, os)
+    with torch.no_grad():
+        scaled.outputscale = os
+    return scaled

--- a/botorch_community/models/addtree/model.py
+++ b/botorch_community/models/addtree/model.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""AddTree GP regression model.
+
+A :class:`~botorch.models.gp_regression.SingleTaskGP` whose covariance
+is the AddTree kernel built from an
+:class:`~botorch_community.models.addtree.space.AddTreeSpace`.
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
+
+from botorch_community.models.addtree.kernels import build_addtree_kernel
+from botorch_community.models.addtree.space import AddTreeSpace
+from gpytorch.likelihoods import Likelihood
+from gpytorch.means import Mean
+from torch import Tensor
+
+
+__all__ = ["AddTreeGP"]
+
+
+class AddTreeGP(SingleTaskGP):
+    r"""SingleTaskGP whose covariance is the AddTree kernel for a given space.
+
+    Inputs are BFS-encoded vectors produced by
+    :func:`~botorch_community.models.addtree.encoding.encode` (one
+    function call per training point); see also
+    :func:`~botorch_community.acquisition.addtree.optimize_addtree_acqf`
+    which produces them automatically during optimisation.
+
+    Sign convention:
+        BoTorch maximises acquisition functions; the original AddTree
+        algorithm minimises the objective. Negate the observed objective
+        values before passing them as ``train_Y`` (i.e. ``train_Y =
+        -y_obs``) and use a maximisation acquisition such as
+        :class:`~botorch.acquisition.UpperConfidenceBound`. The helper
+        :func:`~botorch_community.acquisition.addtree.optimize_addtree_acqf`
+        handles this convention by default.
+    """
+
+    def __init__(
+        self,
+        space: AddTreeSpace,
+        train_X: Tensor,
+        train_Y: Tensor,
+        train_Yvar: Tensor | None = None,
+        likelihood: Likelihood | None = None,
+        mean_module: Mean | None = None,
+        outcome_transform: OutcomeTransform | None = None,
+        input_transform: InputTransform | None = None,
+    ) -> None:
+        r"""Initialise an AddTreeGP.
+
+        Args:
+            space: The :class:`AddTreeSpace` describing the conditional
+                parameter space.
+            train_X: ``batch_shape x n x space.dim`` BFS-encoded inputs.
+            train_Y: ``batch_shape x n x m`` observations (negated if
+                minimising; see the class docstring).
+            train_Yvar: Optional observation noise variances.
+            likelihood: Optional GPyTorch likelihood.
+            mean_module: Optional mean module (default ``ConstantMean``).
+            outcome_transform: Optional outcome transform. ``None`` keeps
+                the BoTorch default (``Standardize``).
+            input_transform: Optional input transform. Usually ``None``
+                because the AddTree encoding is already structured.
+        """
+        if not isinstance(space, AddTreeSpace):
+            raise TypeError(
+                f"AddTreeGP expects an AddTreeSpace; got {type(space).__name__}."
+            )
+        if train_X.shape[-1] != space.dim:
+            raise ValueError(
+                f"train_X has last dim {train_X.shape[-1]} but "
+                f"space.dim={space.dim}."
+            )
+
+        kwargs: dict = {}
+        if likelihood is not None:
+            kwargs["likelihood"] = likelihood
+        if mean_module is not None:
+            kwargs["mean_module"] = mean_module
+        if outcome_transform is not None:
+            kwargs["outcome_transform"] = outcome_transform
+        if input_transform is not None:
+            kwargs["input_transform"] = input_transform
+
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            covar_module=build_addtree_kernel(space),
+            **kwargs,
+        )
+        self._addtree_space = space
+
+    @property
+    def addtree_space(self) -> AddTreeSpace:
+        """The :class:`AddTreeSpace` used to build this model."""
+        return self._addtree_space

--- a/botorch_community/models/addtree/space.py
+++ b/botorch_community/models/addtree/space.py
@@ -1,0 +1,512 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Declarative spec for AddTree parameter spaces.
+
+The user describes the conditional parameter space as a tree: each node
+optionally owns a list of continuous parameters; each node may also have
+exactly one categorical *choice* whose options branch into child nodes.
+
+A spec is a plain Python dict (or YAML file) with the following shape:
+
+.. code-block:: yaml
+
+    name: root
+    continuous: []                    # optional, list of {name, lo, hi}
+    choices:                          # optional; at most one entry in v2
+      - name: L1
+        options:
+          left:
+            name: L1_left
+            continuous: [{name: cont_value, lo: 0.0, hi: 1.0}]
+            choices:
+              - name: L2
+                options:
+                  left:
+                    name: L1_left.L2_left
+                    continuous: [{name: cont_value, lo: 0.0, hi: 1.0}]
+                  right:
+                    name: L1_left.L2_right
+                    continuous: [{name: cont_value, lo: 0.0, hi: 1.0}]
+          right:
+            name: L1_right
+            ...
+
+From this declaration the library computes:
+
+* ``space.dim``             — total length of the BFS-encoded vector
+* ``space.bounds``          — ``(2, dim)`` tensor of lower/upper bounds
+* ``space.cat_dims``        — indices of the categorical (flag) slots
+* ``space.cont_dims``       — indices of the continuous data slots
+* ``space.fixed_features_list`` — one ``dict[int, float]`` per leaf path,
+  ready to pass to :func:`botorch.optim.optimize_acqf_mixed`.
+* ``space.path_ids``        — string ids matching the fixed-features list
+
+There is **no** module-level state; multiple :class:`AddTreeSpace` objects
+can coexist freely.
+
+Contributor: maxc01
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+__all__ = [
+    "AddTreeSpace",
+    "Continuous",
+    "Choice",
+    "Node",
+]
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses (the immutable spec, post-validation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Continuous:
+    """A scalar continuous parameter with hard ``[lo, hi]`` bounds."""
+
+    name: str
+    lo: float = 0.0
+    hi: float = 1.0
+
+    def __post_init__(self) -> None:
+        """Validate bounds."""
+        if not self.lo < self.hi:
+            raise ValueError(
+                f"Continuous '{self.name}': lo ({self.lo}) must be < hi "
+                f"({self.hi})."
+            )
+
+
+@dataclass(frozen=True)
+class Choice:
+    """A categorical decision branching into named child nodes."""
+
+    name: str
+    options: tuple[tuple[str, "Node"], ...]
+    """Ordered ``(option_name, child_node)`` pairs.
+
+    Order determines the integer ``local_id`` used in the BFS encoding,
+    so two specs that differ only in option order produce different
+    (but equivalent) wire formats. Reorder deliberately.
+    """
+
+    def __post_init__(self) -> None:
+        """Validate options."""
+        if len(self.options) < 1:
+            raise ValueError(f"Choice '{self.name}' must have at least one option.")
+        seen = set()
+        for opt_name, _ in self.options:
+            if opt_name in seen:
+                raise ValueError(
+                    f"Choice '{self.name}' has duplicate option '{opt_name}'."
+                )
+            seen.add(opt_name)
+
+
+@dataclass(frozen=True)
+class Node:
+    """A node in the AddTree.
+
+    Each node owns:
+
+    * an unique ``name`` (used as a key in encoded/decoded dicts),
+    * an optional list of :class:`Continuous` parameters,
+    * an optional :class:`Choice` (a single categorical decision).
+
+    A node with neither continuous parameters nor a choice is a leaf
+    that contributes only its categorical flag to the kernel.
+    """
+
+    name: str
+    continuous: tuple[Continuous, ...] = ()
+    choice: Choice | None = None
+
+    def __post_init__(self) -> None:
+        """Validate parameter names."""
+        seen = set()
+        for c in self.continuous:
+            if c.name in seen:
+                raise ValueError(
+                    f"Node '{self.name}': duplicate continuous parameter "
+                    f"'{c.name}'."
+                )
+            seen.add(c.name)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers (dict / yaml -> Node)
+# ---------------------------------------------------------------------------
+
+
+def _node_from_dict(d: Mapping[str, Any]) -> Node:
+    """Recursively build a :class:`Node` tree from a plain dict."""
+    if "name" not in d:
+        raise ValueError(f"Node spec missing 'name': {d!r}")
+    name = str(d["name"])
+
+    continuous: list[Continuous] = []
+    for c in d.get("continuous", []) or []:
+        continuous.append(
+            Continuous(name=str(c["name"]), lo=float(c["lo"]), hi=float(c["hi"]))
+        )
+
+    choice: Choice | None = None
+    raw_choices = d.get("choices") or []
+    if len(raw_choices) > 1:
+        raise ValueError(
+            f"Node '{name}' has {len(raw_choices)} choices; v2 supports at most "
+            "one choice per node. Use intermediate nodes to model multi-choice "
+            "structures."
+        )
+    if raw_choices:
+        rc = raw_choices[0]
+        if "name" not in rc or "options" not in rc:
+            raise ValueError(
+                f"Node '{name}': choice must have 'name' and 'options' keys."
+            )
+        # Preserve the user-provided option order. Python dicts preserve
+        # insertion order in 3.7+, and our YAML loader uses a SafeLoader
+        # which also preserves order.
+        opts: list[tuple[str, Node]] = []
+        for opt_name, opt_spec in rc["options"].items():
+            opts.append((str(opt_name), _node_from_dict(opt_spec)))
+        choice = Choice(name=str(rc["name"]), options=tuple(opts))
+
+    return Node(name=name, continuous=tuple(continuous), choice=choice)
+
+
+# ---------------------------------------------------------------------------
+# AddTreeSpace
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _NodeRecord:
+    """Internal: BFS-ordered record describing one node's slots."""
+
+    node: Node
+    flag_index: int
+    """BFS slot holding the categorical flag (== ``local_id`` if this node
+    is on the path, else the sentinel ``-1.0``).
+    """
+    cont_indices: tuple[int, ...]
+    """BFS slots holding the continuous data."""
+    local_id: int
+    """The integer choice value among siblings (0 for root)."""
+    parent_record_index: int | None
+    """Index into ``AddTreeSpace.records`` of the parent node, or ``None``
+    for the root.
+    """
+
+
+@dataclass(frozen=True)
+class _PathRecord:
+    """Internal: a root-to-leaf path."""
+
+    path_id: str
+    """String of option names separated by '/' (excluding the root)."""
+    node_indices: tuple[int, ...]
+    """Indices into ``AddTreeSpace.records`` of nodes on the path."""
+
+
+class AddTreeSpace:
+    r"""An immutable conditional parameter space for AddTree GP models.
+
+    Construct from a nested dict, a YAML file, or by hand from
+    :class:`Node` / :class:`Choice` / :class:`Continuous` instances.
+
+    Examples:
+        >>> space = AddTreeSpace.from_dict({
+        ...     "name": "root",
+        ...     "choices": [{
+        ...         "name": "L1",
+        ...         "options": {
+        ...             "left":  {"name": "L1_left",
+        ...                       "continuous": [{"name": "v", "lo": 0., "hi": 1.}]},
+        ...             "right": {"name": "L1_right",
+        ...                       "continuous": [{"name": "v", "lo": 0., "hi": 1.}]},
+        ...         },
+        ...     }],
+        ... })
+        >>> space.dim
+        4
+        >>> space.path_ids
+        ('left', 'right')
+    """
+
+    SENTINEL: float = -1.0
+    """Slot value used to mark "this node is not on the encoded path"."""
+
+    def __init__(self, root: Node):
+        """Build the immutable spec from a finalised :class:`Node` tree."""
+        if not isinstance(root, Node):
+            raise TypeError(
+                f"AddTreeSpace expects a Node root; got {type(root).__name__}."
+            )
+        self._root = root
+        records, paths, name_to_record_index = _bfs_layout(root)
+        self._records: tuple[_NodeRecord, ...] = records
+        self._paths: tuple[_PathRecord, ...] = paths
+        self._name_to_record_index: dict[str, int] = name_to_record_index
+        self._dim: int = sum(1 + len(r.node.continuous) for r in records)
+
+        # Pre-compute bounds, cat/cont dims, fixed_features_list.
+        import torch
+
+        # Build the (2, dim) bounds tensor used by optimize_acqf_mixed.
+        # Every slot pinned by fixed_features will be overridden, but the
+        # bounds still need ``bounds[0] < bounds[1]`` everywhere so that
+        # the Sobol-based initial-condition generator is well-defined.
+        # We follow the upstream-AddTree convention of using ``[0, 1]``
+        # for *every* slot and rely on ``fixed_features`` to pin the
+        # off-path / flag slots to the correct value at solve time.
+        bounds = torch.empty(2, self._dim, dtype=torch.float64)
+        bounds[0, :] = 0.0
+        bounds[1, :] = 1.0
+        cat_dims: list[int] = []
+        cont_dims: list[int] = []
+        for rec in records:
+            cat_dims.append(rec.flag_index)
+            for ax, c in zip(rec.cont_indices, rec.node.continuous):
+                bounds[0, ax] = c.lo
+                bounds[1, ax] = c.hi
+                cont_dims.append(ax)
+        self._bounds: torch.Tensor = bounds
+        self._cat_dims: tuple[int, ...] = tuple(cat_dims)
+        self._cont_dims: tuple[int, ...] = tuple(cont_dims)
+
+        # fixed_features_list: one dict per leaf path. For each path, pin
+        # off-path slots to SENTINEL, on-path flag slots to their local_id,
+        # and leave on-path continuous slots unpinned.
+        ff_list: list[dict[int, float]] = []
+        for path in paths:
+            on_path_flags: dict[int, float] = {}
+            on_path_cont: set[int] = set()
+            for ri in path.node_indices:
+                rec = records[ri]
+                on_path_flags[rec.flag_index] = float(rec.local_id)
+                on_path_cont.update(rec.cont_indices)
+            ff: dict[int, float] = {}
+            for i in range(self._dim):
+                if i in on_path_cont:
+                    continue  # let the optimiser choose
+                if i in on_path_flags:
+                    ff[i] = on_path_flags[i]
+                else:
+                    ff[i] = self.SENTINEL
+            ff_list.append(ff)
+        self._fixed_features_list: tuple[dict[int, float], ...] = tuple(ff_list)
+
+    # ---- alternative constructors -----------------------------------------
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "AddTreeSpace":
+        """Build an :class:`AddTreeSpace` from a nested mapping."""
+        return cls(_node_from_dict(d))
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "AddTreeSpace":
+        """Build an :class:`AddTreeSpace` from a YAML file path.
+
+        Requires the optional ``pyyaml`` dependency.
+        """
+        try:
+            import yaml
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "AddTreeSpace.from_yaml requires PyYAML; install it via "
+                "`pip install pyyaml`."
+            ) from e
+        with open(path, "r") as f:
+            d = yaml.safe_load(f)
+        return cls.from_dict(d)
+
+    # ---- public properties (immutable views) ------------------------------
+
+    @property
+    def root(self) -> Node:
+        """The root :class:`Node` of the spec."""
+        return self._root
+
+    @property
+    def dim(self) -> int:
+        """Total length of the BFS-encoded vector."""
+        return self._dim
+
+    @property
+    def bounds(self):
+        """``(2, dim)`` tensor of lower/upper bounds for ``optimize_acqf*``."""
+        return self._bounds
+
+    @property
+    def cat_dims(self) -> tuple[int, ...]:
+        """Slot indices of the categorical flags."""
+        return self._cat_dims
+
+    @property
+    def cont_dims(self) -> tuple[int, ...]:
+        """Slot indices of the continuous data."""
+        return self._cont_dims
+
+    @property
+    def fixed_features_list(self) -> tuple[dict[int, float], ...]:
+        """One dict per leaf path; pass to ``optimize_acqf_mixed``."""
+        # Return shallow copies so callers can mutate the dicts.
+        return tuple(dict(ff) for ff in self._fixed_features_list)
+
+    @property
+    def path_ids(self) -> tuple[str, ...]:
+        """The path id strings, in the same order as ``fixed_features_list``."""
+        return tuple(p.path_id for p in self._paths)
+
+    @property
+    def num_paths(self) -> int:
+        """Total number of root-to-leaf paths."""
+        return len(self._paths)
+
+    # ---- internal accessors used by encoding & kernel modules -------------
+
+    def _records_for_path(self, path_id: str) -> tuple[_NodeRecord, ...]:
+        """Return the BFS records visited by ``path_id``, root first."""
+        for p in self._paths:
+            if p.path_id == path_id:
+                return tuple(self._records[i] for i in p.node_indices)
+        raise KeyError(f"Unknown path_id {path_id!r}; valid: {self.path_ids}")
+
+    def _record_by_name(self, node_name: str) -> _NodeRecord:
+        if node_name not in self._name_to_record_index:
+            raise KeyError(f"Unknown node name {node_name!r}.")
+        return self._records[self._name_to_record_index[node_name]]
+
+    @property
+    def _all_records(self) -> tuple[_NodeRecord, ...]:
+        return self._records
+
+    def __repr__(self) -> str:
+        return (
+            f"AddTreeSpace(root={self._root.name!r}, dim={self._dim}, "
+            f"num_paths={self.num_paths})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# BFS layout
+# ---------------------------------------------------------------------------
+
+
+def _bfs_layout(
+    root: Node,
+) -> tuple[tuple[_NodeRecord, ...], tuple[_PathRecord, ...], dict[str, int]]:
+    """Compute BFS-ordered slot indices for every node + enumerate paths.
+
+    Returns:
+        records: BFS-ordered tuple of :class:`_NodeRecord`s.
+        paths:   tuple of :class:`_PathRecord`, one per leaf.
+        name_to_index: name -> index into ``records``.
+    """
+    # ---- BFS over (node, parent_record_index, local_id) ----
+    queue: list[tuple[Node, int | None, int]] = [(root, None, 0)]
+    records: list[_NodeRecord] = []
+    name_to_index: dict[str, int] = {}
+    next_slot = 0
+    while queue:
+        node, parent_idx, local_id = queue.pop(0)
+        if node.name in name_to_index:
+            raise ValueError(f"Duplicate node name {node.name!r} in AddTree spec.")
+        flag_index = next_slot
+        cont_indices = tuple(range(next_slot + 1, next_slot + 1 + len(node.continuous)))
+        next_slot += 1 + len(node.continuous)
+        rec = _NodeRecord(
+            node=node,
+            flag_index=flag_index,
+            cont_indices=cont_indices,
+            local_id=local_id,
+            parent_record_index=parent_idx,
+        )
+        rec_idx = len(records)
+        records.append(rec)
+        name_to_index[node.name] = rec_idx
+
+        if node.choice is not None:
+            for opt_local_id, (_opt_name, child) in enumerate(node.choice.options):
+                queue.append((child, rec_idx, opt_local_id))
+
+    # ---- DFS to enumerate root-to-leaf paths ----
+    paths: list[_PathRecord] = []
+
+    def _walk(
+        rec_idx: int, prefix_record_indices: list[int], prefix_option_names: list[str]
+    ) -> None:
+        prefix_record_indices = prefix_record_indices + [rec_idx]
+        rec = records[rec_idx]
+        if rec.node.choice is None:
+            path_id = "/".join(prefix_option_names)
+            paths.append(
+                _PathRecord(
+                    path_id=path_id,
+                    node_indices=tuple(prefix_record_indices),
+                )
+            )
+            return
+        for opt_local_id, (opt_name, _child) in enumerate(rec.node.choice.options):
+            # Find the child's record index. It was inserted into ``records``
+            # in BFS order; the children are not contiguous, so look up by
+            # name.
+            child = rec.node.choice.options[opt_local_id][1]
+            child_idx = name_to_index[child.name]
+            _walk(child_idx, prefix_record_indices, prefix_option_names + [opt_name])
+
+    _walk(0, [], [])
+    return tuple(records), tuple(paths), name_to_index
+
+
+# ---------------------------------------------------------------------------
+# Sequence helpers (re-exports for convenience builder use)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_choice(c: Choice | Mapping[str, Any]) -> Choice:
+    """Allow Choice() instances and dicts side-by-side in the Python builder."""
+    if isinstance(c, Choice):
+        return c
+    options: list[tuple[str, Node]] = []
+    for opt_name, opt_node in c["options"].items():
+        if isinstance(opt_node, Node):
+            options.append((str(opt_name), opt_node))
+        else:
+            options.append((str(opt_name), _node_from_dict(opt_node)))
+    return Choice(name=str(c["name"]), options=tuple(options))
+
+
+def make_node(
+    name: str,
+    *,
+    continuous: Sequence[Continuous] | Sequence[Mapping[str, Any]] = (),
+    choice: Choice | Mapping[str, Any] | None = None,
+) -> Node:
+    """Convenience builder for :class:`Node`.
+
+    Accepts both already-typed dataclasses and raw dicts/mappings, so
+    Python builder code and YAML-derived dicts compose freely.
+    """
+    cont: list[Continuous] = []
+    for c in continuous:
+        if isinstance(c, Continuous):
+            cont.append(c)
+        else:
+            cont.append(
+                Continuous(name=str(c["name"]), lo=float(c["lo"]), hi=float(c["hi"]))
+            )
+    ch: Choice | None = None
+    if choice is not None:
+        ch = _coerce_choice(choice)
+    return Node(name=name, continuous=tuple(cont), choice=ch)

--- a/test_community/models/test_addtree_encoding.py
+++ b/test_community/models/test_addtree_encoding.py
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Tests for encode/decode round-trip in :mod:`botorch_community.models.addtree`."""
+
+import numpy as np
+import torch
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.models.addtree.encoding import decode, encode, param_key
+from botorch_community.models.addtree.space import AddTreeSpace
+
+
+def _jenatton_small_spec() -> dict:
+    leaf = lambda name: {  # noqa: E731
+        "name": name,
+        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+    }
+    return {
+        "name": "root",
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "left": {
+                        "name": "L1_left",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_ll"),
+                                    "right": leaf("L2_lr"),
+                                },
+                            }
+                        ],
+                    },
+                    "right": {
+                        "name": "L1_right",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_rl"),
+                                    "right": leaf("L2_rr"),
+                                },
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+
+class TestEncodeDecode(BotorchTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.space = AddTreeSpace.from_dict(_jenatton_small_spec())
+
+    def test_param_key(self) -> None:
+        self.assertEqual(param_key("L1_left", "v"), "L1_left.v")
+
+    def test_encode_left_left_path(self) -> None:
+        p = {"L1": "left", "L1_left.v": 0.3, "L2": "left", "L2_ll.v": 0.8}
+        x = encode(self.space, p)
+        self.assertEqual(x.shape, (self.space.dim,))
+        # Off-path slots are sentinels.
+        # For path left/left: L1_right slots (3, 4) and L2_lr slots (7, 8) and
+        # L2_rl slots (9, 10) and L2_rr slots (11, 12) are sentinels.
+        for off in (3, 4, 7, 8, 9, 10, 11, 12):
+            self.assertAlmostEqual(x[off].item(), -1.0)
+        # On-path values.
+        self.assertAlmostEqual(x[2].item(), 0.3)  # L1_left.v
+        self.assertAlmostEqual(x[6].item(), 0.8)  # L2_ll.v
+
+    def test_round_trip_random(self) -> None:
+        rng = np.random.default_rng(42)
+        choices = ["left", "right"]
+        for _ in range(50):
+            L1 = rng.choice(choices)
+            L2 = rng.choice(choices)
+            p = {
+                "L1": L1,
+                f"L1_{L1}.v": float(rng.random()),
+                "L2": L2,
+                f"L2_{L1[0]}{L2[0]}.v": float(rng.random()),
+            }
+            x = encode(self.space, p)
+            back = decode(self.space, x)
+            self.assertEqual(back, p)
+
+    def test_decode_2d_batch_of_one(self) -> None:
+        p = {"L1": "right", "L1_right.v": 0.5, "L2": "right", "L2_rr.v": 0.1}
+        x = encode(self.space, p).unsqueeze(0)  # (1, dim)
+        self.assertEqual(decode(self.space, x), p)
+
+    def test_encode_missing_choice(self) -> None:
+        with self.assertRaises(KeyError):
+            encode(self.space, {"L1_left.v": 0.5})  # missing L1
+
+    def test_encode_unknown_option(self) -> None:
+        with self.assertRaises(ValueError):
+            encode(self.space, {"L1": "middle"})  # not a valid option
+
+    def test_encode_out_of_bounds(self) -> None:
+        with self.assertRaises(ValueError):
+            encode(
+                self.space,
+                {"L1": "left", "L1_left.v": 99.0, "L2": "left", "L2_ll.v": 0.5},
+            )
+
+    def test_encode_dtype(self) -> None:
+        p = {"L1": "left", "L1_left.v": 0.3, "L2": "left", "L2_ll.v": 0.8}
+        for dtype in (torch.float32, torch.float64):
+            x = encode(self.space, p, dtype=dtype)
+            self.assertEqual(x.dtype, dtype)
+
+    def test_decode_wrong_dim(self) -> None:
+        bad = torch.zeros(self.space.dim - 1)
+        with self.assertRaises(ValueError):
+            decode(self.space, bad)

--- a/test_community/models/test_addtree_kernel.py
+++ b/test_community/models/test_addtree_kernel.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Tests for the AddTree kernel module."""
+
+import math
+
+import numpy as np
+import torch
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.models.addtree.encoding import encode
+from botorch_community.models.addtree.kernels import (
+    AddTreeDeltaKernel,
+    build_addtree_kernel,
+)
+from botorch_community.models.addtree.space import AddTreeSpace
+from gpytorch.kernels import RBFKernel
+
+
+def _binary_with_root_continuous_spec() -> dict:
+    """Tree with continuous params at every level (tests broad coverage)."""
+    return {
+        "name": "root",
+        "continuous": [
+            {"name": "a", "lo": 0.0, "hi": 1.0},
+            {"name": "b", "lo": 0.0, "hi": 1.0},
+        ],
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "left": {
+                        "name": "L1_left",
+                        "continuous": [
+                            {"name": "x", "lo": 0.0, "hi": 1.0},
+                            {"name": "y", "lo": 0.0, "hi": 1.0},
+                        ],
+                    },
+                    "right": {
+                        "name": "L1_right",
+                        "continuous": [
+                            {"name": "x", "lo": 0.0, "hi": 1.0},
+                            {"name": "y", "lo": 0.0, "hi": 1.0},
+                            {"name": "z", "lo": 0.0, "hi": 1.0},
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+
+class TestAddTreeDeltaKernel(BotorchTestCase):
+    def test_basic_equality(self) -> None:
+        kern = AddTreeDeltaKernel(active_dims=(0,))
+        x1 = torch.tensor([[0.0], [1.0], [-1.0]], dtype=torch.float64)
+        K = kern(x1).to_dense()
+        expected = torch.tensor(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            dtype=torch.float64,
+        )
+        self.assertTrue(torch.allclose(K, expected))
+
+    def test_diag(self) -> None:
+        kern = AddTreeDeltaKernel(active_dims=(0,))
+        x1 = torch.tensor([[0.0], [1.0], [-1.0]], dtype=torch.float64)
+        K_diag = kern(x1, diag=True).to_dense()
+        self.assertTrue(torch.allclose(K_diag, torch.ones(3, dtype=torch.float64)))
+
+    def test_active_dims_slicing(self) -> None:
+        kern = AddTreeDeltaKernel(active_dims=(1,))
+        x1 = torch.tensor([[0.0, 5.0], [1.0, 5.0], [9.0, 6.0]], dtype=torch.float64)
+        K = kern(x1).to_dense()
+        expected = torch.tensor(
+            [[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            dtype=torch.float64,
+        )
+        self.assertTrue(torch.allclose(K, expected))
+
+    def test_no_learnable_parameters(self) -> None:
+        kern = AddTreeDeltaKernel(active_dims=(0,))
+        self.assertEqual(len(list(kern.parameters())), 0)
+
+
+class TestBuildAddTreeKernel(BotorchTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        torch.set_default_dtype(torch.float64)
+        self.space = AddTreeSpace.from_dict(_binary_with_root_continuous_spec())
+
+    def test_kernel_shape_and_psd(self) -> None:
+        kern = build_addtree_kernel(self.space)
+
+        rng = np.random.default_rng(42)
+        params_list = [
+            {
+                "L1": "left",
+                "root.a": rng.random(),
+                "root.b": rng.random(),
+                "L1_left.x": rng.random(),
+                "L1_left.y": rng.random(),
+            },
+            {
+                "L1": "left",
+                "root.a": rng.random(),
+                "root.b": rng.random(),
+                "L1_left.x": rng.random(),
+                "L1_left.y": rng.random(),
+            },
+            {
+                "L1": "right",
+                "root.a": rng.random(),
+                "root.b": rng.random(),
+                "L1_right.x": rng.random(),
+                "L1_right.y": rng.random(),
+                "L1_right.z": rng.random(),
+            },
+            {
+                "L1": "right",
+                "root.a": rng.random(),
+                "root.b": rng.random(),
+                "L1_right.x": rng.random(),
+                "L1_right.y": rng.random(),
+                "L1_right.z": rng.random(),
+            },
+        ]
+        X = torch.stack([encode(self.space, p) for p in params_list])
+        K = kern(X).to_dense().detach()
+        self.assertEqual(K.shape, (len(params_list), len(params_list)))
+        self.assertTrue(torch.allclose(K, K.T, atol=1e-12))
+        torch.linalg.cholesky(K + 1e-6 * torch.eye(len(params_list), dtype=K.dtype))
+
+    def test_diagonal_dominates(self) -> None:
+        # Same encoded point twice -> K[0,0] = outputscale * (number of nodes)
+        # because every Delta is 1 and every RBF on identical data is 1.
+        kern = build_addtree_kernel(self.space)
+        p = {
+            "L1": "left",
+            "root.a": 0.5,
+            "root.b": 0.6,
+            "L1_left.x": 0.7,
+            "L1_left.y": 0.8,
+        }
+        v = encode(self.space, p)
+        X = torch.stack([v, v])
+        K = kern(X).to_dense().detach()
+        outputscale = kern.outputscale.item()
+        # 3 BFS nodes: root, L1_left, L1_right; for two identical points
+        # the kernel sums Delta*RBF for each node. For path "left", node
+        # L1_right has its data slots == sentinel for both rows
+        # and its delta is 1 (sentinel == sentinel), and its RBF returns
+        # 1 (data is identical). So K[0,0] == outputscale * 3.
+        self.assertAlmostEqual(K[0, 0].item(), 3.0 * outputscale, places=5)
+
+    def test_path_separation(self) -> None:
+        # Two different paths should have lower similarity than self-similarity.
+        kern = build_addtree_kernel(self.space)
+        p_left = {
+            "L1": "left",
+            "root.a": 0.5,
+            "root.b": 0.6,
+            "L1_left.x": 0.7,
+            "L1_left.y": 0.8,
+        }
+        p_right = {
+            "L1": "right",
+            "root.a": 0.5,
+            "root.b": 0.6,
+            "L1_right.x": 0.7,
+            "L1_right.y": 0.8,
+            "L1_right.z": 0.9,
+        }
+        X = torch.stack([encode(self.space, p_left), encode(self.space, p_right)])
+        K = kern(X).to_dense().detach()
+        self.assertGreater(K[0, 0].item(), K[0, 1].item())
+
+    def test_lengthscale_bounds_match_paper(self) -> None:
+        # The metric-bounds from the paper map to plain-lengthscale
+        # interval [exp(-3.5), exp(2)].
+        kern = build_addtree_kernel(self.space)
+        rbf_kernels = [m for m in kern.modules() if isinstance(m, RBFKernel)]
+        self.assertGreater(len(rbf_kernels), 0)
+        constraint = rbf_kernels[0].raw_lengthscale_constraint
+        self.assertAlmostEqual(
+            constraint.lower_bound.item(),
+            math.exp(-3.5),
+            places=5,
+        )
+        self.assertAlmostEqual(
+            constraint.upper_bound.item(),
+            math.exp(2.0),
+            places=5,
+        )

--- a/test_community/models/test_addtree_model.py
+++ b/test_community/models/test_addtree_model.py
@@ -1,0 +1,187 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Tests for :class:`AddTreeGP` and :func:`optimize_addtree_acqf`."""
+
+import numpy as np
+import torch
+from botorch import fit_gpytorch_mll
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.acquisition.addtree import optimize_addtree_acqf
+from botorch_community.models.addtree.encoding import decode, encode
+from botorch_community.models.addtree.model import AddTreeGP
+from botorch_community.models.addtree.space import AddTreeSpace
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+
+def _jenatton_small_spec() -> dict:
+    leaf = lambda name: {  # noqa: E731
+        "name": name,
+        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+    }
+    return {
+        "name": "root",
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "left": {
+                        "name": "L1_left",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_ll"),
+                                    "right": leaf("L2_lr"),
+                                },
+                            }
+                        ],
+                    },
+                    "right": {
+                        "name": "L1_right",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_rl"),
+                                    "right": leaf("L2_rr"),
+                                },
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _make_train_data(space: AddTreeSpace, n: int, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    Xs, Ys = [], []
+    choices = ["left", "right"]
+    for _ in range(n):
+        L1 = rng.choice(choices)
+        L2 = rng.choice(choices)
+        p = {
+            "L1": L1,
+            f"L1_{L1}.v": float(rng.random()),
+            "L2": L2,
+            f"L2_{L1[0]}{L2[0]}.v": float(rng.random()),
+        }
+        Xs.append(encode(space, p))
+        # Toy objective: sum of squared on-path continuous values.
+        Ys.append(-sum(p[k] ** 2 for k in p if k.endswith(".v")))
+    return torch.stack(Xs), torch.tensor(Ys, dtype=torch.float64).unsqueeze(-1)
+
+
+class TestAddTreeGP(BotorchTestCase):
+    def test_init_validates_dim(self) -> None:
+        torch.set_default_dtype(torch.float64)
+        space = AddTreeSpace.from_dict(_jenatton_small_spec())
+        bad_X = torch.zeros(3, space.dim - 1, dtype=torch.float64)
+        bad_Y = torch.zeros(3, 1, dtype=torch.float64)
+        with self.assertRaises(ValueError):
+            AddTreeGP(space, bad_X, bad_Y)
+
+    def test_init_rejects_non_space(self) -> None:
+        torch.set_default_dtype(torch.float64)
+        bad_X = torch.zeros(3, 5, dtype=torch.float64)
+        bad_Y = torch.zeros(3, 1, dtype=torch.float64)
+        with self.assertRaises(TypeError):
+            AddTreeGP("not a space", bad_X, bad_Y)  # type: ignore[arg-type]
+
+    def test_fit_runs(self) -> None:
+        torch.set_default_dtype(torch.float64)
+        torch.manual_seed(0)
+        space = AddTreeSpace.from_dict(_jenatton_small_spec())
+        train_X, train_Y = _make_train_data(space, n=8, seed=0)
+        model = AddTreeGP(space, train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(model.likelihood, model)
+        fit_gpytorch_mll(mll)
+        # Should now be able to predict.
+        model.eval()
+        with torch.no_grad():
+            posterior = model.posterior(train_X)
+            self.assertEqual(posterior.mean.shape, train_Y.shape)
+
+    def test_addtree_space_property(self) -> None:
+        torch.set_default_dtype(torch.float64)
+        space = AddTreeSpace.from_dict(_jenatton_small_spec())
+        train_X, train_Y = _make_train_data(space, n=5, seed=1)
+        model = AddTreeGP(space, train_X, train_Y)
+        self.assertIs(model.addtree_space, space)
+
+
+class TestOptimizeAddTreeAcqf(BotorchTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        torch.set_default_dtype(torch.float64)
+        torch.manual_seed(0)
+        self.space = AddTreeSpace.from_dict(_jenatton_small_spec())
+        train_X, train_Y = _make_train_data(self.space, n=5, seed=0)
+        self.model = AddTreeGP(self.space, train_X, train_Y)
+        mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
+        fit_gpytorch_mll(mll)
+
+    def test_q1_returns_valid_encoding(self) -> None:
+        candidates, vals = optimize_addtree_acqf(
+            self.model,
+            beta=1.0,
+            q=1,
+            num_restarts=2,
+            raw_samples=64,
+        )
+        self.assertEqual(candidates.shape, (1, self.space.dim))
+        # Decoded user dict must round-trip.
+        p = decode(self.space, candidates[0])
+        self.assertIn("L1", p)
+        self.assertIn("L2", p)
+        # Re-encoding gives back the same vector.
+        x_re = encode(self.space, p, dtype=candidates.dtype, device=candidates.device)
+        self.assertTrue(torch.allclose(x_re, candidates[0], atol=1e-9))
+
+    def test_q2_supports_batch(self) -> None:
+        candidates, vals = optimize_addtree_acqf(
+            self.model,
+            beta=1.0,
+            q=2,
+            num_restarts=2,
+            raw_samples=64,
+        )
+        self.assertEqual(candidates.shape, (2, self.space.dim))
+        # Each candidate must be a valid encoding.
+        for i in range(2):
+            p = decode(self.space, candidates[i])
+            self.assertIn("L1", p)
+
+    def test_bo_loop_does_not_regress(self) -> None:
+        """A short BO loop should never decrease the running best."""
+        torch.manual_seed(1)
+        np.random.seed(1)
+        space = self.space
+        train_X, train_Y = _make_train_data(space, n=5, seed=1)
+        best_init = train_Y.max().item()
+
+        for _ in range(5):
+            model = AddTreeGP(space, train_X, train_Y)
+            fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))
+            candidates, _ = optimize_addtree_acqf(
+                model,
+                beta=2.0,
+                q=1,
+                num_restarts=2,
+                raw_samples=64,
+            )
+            x_new = candidates[0]
+            p = decode(space, x_new)
+            y = sum(p[k] ** 2 for k in p if k.endswith(".v"))
+            train_X = torch.cat([train_X, x_new.unsqueeze(0)])
+            train_Y = torch.cat(
+                [train_Y, torch.tensor([[-y]], dtype=torch.float64)],
+            )
+
+        self.assertGreaterEqual(train_Y.max().item(), best_init - 1e-6)

--- a/test_community/models/test_addtree_space.py
+++ b/test_community/models/test_addtree_space.py
@@ -1,0 +1,246 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""Tests for :class:`AddTreeSpace`."""
+
+import pytest
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.models.addtree.space import (
+    AddTreeSpace,
+    Choice,
+    Continuous,
+    make_node,
+    Node,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture specs
+# ---------------------------------------------------------------------------
+
+
+def _binary_spec() -> dict:
+    """A 1-level tree: root with 2 children, each holding one Continuous."""
+    return {
+        "name": "root",
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "left": {
+                        "name": "L1_left",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                    },
+                    "right": {
+                        "name": "L1_right",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _jenatton_small_spec() -> dict:
+    """The Jenatton-small two-level binary tree."""
+    leaf = lambda name: {  # noqa: E731
+        "name": name,
+        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+    }
+    return {
+        "name": "root",
+        "choices": [
+            {
+                "name": "L1",
+                "options": {
+                    "left": {
+                        "name": "L1_left",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_ll"),
+                                    "right": leaf("L2_lr"),
+                                },
+                            }
+                        ],
+                    },
+                    "right": {
+                        "name": "L1_right",
+                        "continuous": [{"name": "v", "lo": 0.0, "hi": 1.0}],
+                        "choices": [
+                            {
+                                "name": "L2",
+                                "options": {
+                                    "left": leaf("L2_rl"),
+                                    "right": leaf("L2_rr"),
+                                },
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddTreeSpace(BotorchTestCase):
+    def test_binary_dim_and_paths(self) -> None:
+        space = AddTreeSpace.from_dict(_binary_spec())
+        # 1 (root flag) + 1 (L1_left flag) + 1 (L1_left.v) + 1 (L1_right flag)
+        # + 1 (L1_right.v) = 5
+        self.assertEqual(space.dim, 5)
+        self.assertEqual(space.num_paths, 2)
+        self.assertEqual(space.path_ids, ("left", "right"))
+
+    def test_jenatton_dim_and_paths(self) -> None:
+        space = AddTreeSpace.from_dict(_jenatton_small_spec())
+        # 7 nodes, each with 1 flag + (0 or 1) cont -> 1 + 6*(1+1) = 13.
+        self.assertEqual(space.dim, 13)
+        self.assertEqual(space.num_paths, 4)
+        self.assertEqual(
+            space.path_ids,
+            ("left/left", "left/right", "right/left", "right/right"),
+        )
+
+    def test_bounds_shape_and_continuous_values(self) -> None:
+        space = AddTreeSpace.from_dict(_binary_spec())
+        self.assertEqual(tuple(space.bounds.shape), (2, space.dim))
+        # Every cont_dim has bounds [0, 1].
+        for d in space.cont_dims:
+            self.assertAlmostEqual(space.bounds[0, d].item(), 0.0)
+            self.assertAlmostEqual(space.bounds[1, d].item(), 1.0)
+
+    def test_fixed_features_list_pins_off_path_to_sentinel(self) -> None:
+        space = AddTreeSpace.from_dict(_binary_spec())
+        # path "left": L1_right flag (slot 3) and L1_right.v (slot 4) pinned to -1.
+        # path "right": L1_left flag (slot 1) and L1_left.v (slot 2) pinned to -1.
+        ff_left = dict(space.fixed_features_list[0])
+        ff_right = dict(space.fixed_features_list[1])
+        # Root flag is always pinned to 0 (root local_id == 0).
+        self.assertEqual(ff_left[0], 0.0)
+        self.assertEqual(ff_right[0], 0.0)
+        # On-path L1_left flag = 0 (first option), continuous slot is *not* fixed.
+        self.assertEqual(ff_left[1], 0.0)
+        self.assertNotIn(2, ff_left)  # L1_left.v is free to optimise
+        # Off-path L1_right slots pinned to sentinel.
+        self.assertEqual(ff_left[3], -1.0)
+        self.assertEqual(ff_left[4], -1.0)
+        # On-path right-side path: L1_right flag = 1 (second option).
+        self.assertEqual(ff_right[3], 1.0)
+        self.assertNotIn(4, ff_right)
+
+    def test_yaml_load(self) -> None:
+        pytest.importorskip("yaml")
+        import os
+        import tempfile
+
+        import yaml
+
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "spec.yaml")
+            with open(path, "w") as f:
+                yaml.safe_dump(_binary_spec(), f, sort_keys=False)
+            space = AddTreeSpace.from_yaml(path)
+            self.assertEqual(space.dim, 5)
+            self.assertEqual(space.path_ids, ("left", "right"))
+
+    def test_python_builder_equivalent_to_dict(self) -> None:
+        builder = Node(
+            name="root",
+            choice=Choice(
+                name="L1",
+                options=(
+                    (
+                        "left",
+                        make_node(
+                            "L1_left",
+                            continuous=[Continuous("v", 0.0, 1.0)],
+                        ),
+                    ),
+                    (
+                        "right",
+                        make_node(
+                            "L1_right",
+                            continuous=[Continuous("v", 0.0, 1.0)],
+                        ),
+                    ),
+                ),
+            ),
+        )
+        s_py = AddTreeSpace(builder)
+        s_d = AddTreeSpace.from_dict(_binary_spec())
+        self.assertEqual(s_py.dim, s_d.dim)
+        self.assertEqual(s_py.path_ids, s_d.path_ids)
+        self.assertEqual(s_py.cat_dims, s_d.cat_dims)
+        self.assertEqual(s_py.cont_dims, s_d.cont_dims)
+        # fixed_features_list dicts are equal element-wise.
+        for a, b in zip(s_py.fixed_features_list, s_d.fixed_features_list):
+            self.assertEqual(a, b)
+
+    def test_no_globals(self) -> None:
+        # Building two specs in the same process must not interfere.
+        s1 = AddTreeSpace.from_dict(_binary_spec())
+        s2 = AddTreeSpace.from_dict(_jenatton_small_spec())
+        self.assertEqual(s1.dim, 5)
+        self.assertEqual(s2.dim, 13)
+
+    def test_duplicate_node_name_rejected(self) -> None:
+        bad = {
+            "name": "root",
+            "choices": [
+                {
+                    "name": "L1",
+                    "options": {
+                        "left": {"name": "dup"},
+                        "right": {"name": "dup"},
+                    },
+                }
+            ],
+        }
+        with self.assertRaises(ValueError):
+            AddTreeSpace.from_dict(bad)
+
+    def test_invalid_continuous_bounds_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            Continuous(name="v", lo=1.0, hi=0.0)
+
+    def test_choice_must_have_options(self) -> None:
+        with self.assertRaises(ValueError):
+            Choice(name="empty", options=())
+
+    def test_multi_choice_per_node_rejected(self) -> None:
+        bad = {
+            "name": "root",
+            "choices": [
+                {"name": "A", "options": {"x": {"name": "a"}}},
+                {"name": "B", "options": {"y": {"name": "b"}}},
+            ],
+        }
+        with self.assertRaises(ValueError):
+            AddTreeSpace.from_dict(bad)
+
+    def test_per_continuous_bounds(self) -> None:
+        space = AddTreeSpace.from_dict(
+            {
+                "name": "root",
+                "continuous": [
+                    {"name": "x", "lo": -2.0, "hi": 5.0},
+                    {"name": "y", "lo": 0.5, "hi": 0.7},
+                ],
+            }
+        )
+        # cont_dims = (1, 2) (slot 0 is the root flag).
+        self.assertEqual(space.cont_dims, (1, 2))
+        self.assertAlmostEqual(space.bounds[0, 1].item(), -2.0)
+        self.assertAlmostEqual(space.bounds[1, 1].item(), 5.0)
+        self.assertAlmostEqual(space.bounds[0, 2].item(), 0.5)
+        self.assertAlmostEqual(space.bounds[1, 2].item(), 0.7)


### PR DESCRIPTION
Implements the AddTree covariance kernel and Bayesian-optimisation helpers from Ma & Blaschko, AISTATS 2020 (https://arxiv.org/abs/2006.11771), contributed under botorch_community.

Many real-world BO problems have *conditional* parameter spaces: a top-level categorical decision selects which sub-parameters apply, with arbitrary nesting. Examples include neural architecture search, algorithm-configuration tuning, and any pipeline whose downstream hyperparameters depend on an earlier choice. The AddTree kernel encodes the tree structure into the GP prior so the model shares information across paths whose continuous parameters live in distinct subspaces.

User-facing API
===============

A space is described declaratively, either as a Python literal::

    from botorch_community.models.addtree import (
        AddTreeSpace, AddTreeGP, encode, decode,
    )

    space = AddTreeSpace.from_dict({
        'name': 'root',
        'choices': [{
            'name': 'L1',
            'options': {
                'left':  {'name': 'L_left',
                          'continuous': [{'name': 'v', 'lo': 0., 'hi': 1.}]},
                'right': {'name': 'L_right',
                          'continuous': [{'name': 'v', 'lo': 0., 'hi': 1.}]},
            },
        }],
    })

or from a YAML file via AddTreeSpace.from_yaml(path), or from Node / Choice / Continuous dataclasses for programmatic construction.

The objective and BO loop work in a flat user-facing dict::

    p = decode(space, x)
    # -> {'L1': 'left', 'L_left.v': 0.42}

Inputs to the GP are BFS-encoded tensors produced by encode():

    train_X = torch.stack([encode(space, p) for p in observed_params])
    model = AddTreeGP(space, train_X, train_Y)
    fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))

Acquisition optimisation uses optimize_acqf_mixed under the hood, so both q=1 (UpperConfidenceBound) and q>1 (qUpperConfidenceBound) are supported with no user-side branching::

    from botorch_community.acquisition.addtree import optimize_addtree_acqf
    candidates, vals = optimize_addtree_acqf(model, beta=3.0, q=1)

What is added
=============

  - botorch_community/models/addtree/space.py       declarative spec
  - botorch_community/models/addtree/encoding.py    encode/decode
  - botorch_community/models/addtree/kernels.py     AddTreeDeltaKernel +
                                                     build_addtree_kernel
  - botorch_community/models/addtree/model.py       AddTreeGP
  - botorch_community/acquisition/addtree.py        optimize_addtree_acqf
                                                     (thin wrapper over
                                                     optimize_acqf_mixed)
  - examples/jenatton_small.py        two-level binary tree, target 0.1
  - examples/jenatton3_synthetic.py   three-level binary, target 0.05
  - test_community/models/test_addtree_*.py         36 tests

Validation
==========

  - All 36 unit tests pass.
  - ufmt + flake8 clean.
  - examples/jenatton_small.py reaches the global optimum (0.1) on seed=0 with the default n_init=10, n_iter=100, beta=3.
  - examples/jenatton3_synthetic.py reaches gap 0.0003 to the global optimum 0.05 on seed=0 with the default n_init=20, n_iter=60, beta=3 (BFS dim 29, 8 root-to-leaf paths).
  - On 10 random seeds of jenatton_small (n_iter=30, beta=1) the algorithm reaches the global optimum on 7/10 seeds, matching the upstream reference implementation's success rate.

Contributor: maxc01

<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/meta-pytorch/botorch, and link to your PR here.)
