### PR TITLE
Add `mean_module` as `__init__` argument for `SingleTaskMultiFidelityGP`

### DIFF
--- a/botorch/models/gp_regression_fidelity.py
+++ b/botorch/models/gp_regression_fidelity.py
@@ -26,7 +26,7 @@ without having to do too many expensive high-fidelity evaluations.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 
 import torch
 from botorch.exceptions.errors import UnsupportedError
@@ -44,6 +44,7 @@ from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.kernels.kernel import ProductKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.means.mean import Mean
 from gpytorch.module import Module
 from gpytorch.priors.torch_priors import GammaPrior
 from torch import Tensor
@@ -77,6 +78,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         likelihood: Likelihood | None = None,
         outcome_transform: OutcomeTransform | _DefaultType | None = DEFAULT,
         input_transform: InputTransform | None = None,
+        mean_module: Mean | None = None,
     ) -> None:
         r"""
         Args:
@@ -107,6 +109,8 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
                 Pass down ``None`` to use no outcome transform.
             input_transform: An input transform that is applied in the model's
                     forward pass.
+            mean_module: The mean function to be used. If omitted, use a
+                ``ConstantMean``.
         """
         self._init_args = {
             "iteration_fidelity": iteration_fidelity,
@@ -114,6 +118,7 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             "linear_truncated": linear_truncated,
             "nu": nu,
             "outcome_transform": outcome_transform,
+            "mean_module": mean_module,
         }
         if iteration_fidelity is None and (
             data_fidelities is None or len(data_fidelities) == 0
@@ -142,14 +147,22 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
             train_Yvar=train_Yvar,
             likelihood=likelihood,
             covar_module=covar_module,
+            mean_module=mean_module,
             outcome_transform=outcome_transform,
             input_transform=input_transform,
         )
         # Used for subsetting along the output dimension. See Model.subset_output.
         self._subset_batch_dict = {
-            "mean_module.raw_constant": -1,
             **subset_batch_dict,
         }
+        raw_mean_constant = dict(self.mean_module.named_parameters()).get(
+            "raw_constant"
+        )
+        if (
+            raw_mean_constant is not None
+            and raw_mean_constant.shape == self._aug_batch_shape
+        ):
+            self._subset_batch_dict["mean_module.raw_constant"] = -1
         if linear_truncated:
             self._subset_batch_dict["covar_module.raw_outputscale"] = -1
         if train_Yvar is None:
@@ -171,6 +184,21 @@ class SingleTaskMultiFidelityGP(SingleTaskGP):
         inputs = super().construct_inputs(training_data=training_data)
         inputs["data_fidelities"] = fidelity_features
         return inputs
+
+    def subset_output(self, idcs: list[int]) -> SingleTaskMultiFidelityGP:
+        if self.num_outputs != len(idcs) or idcs != list(range(self.num_outputs)):
+            for name, parameter in self.mean_module.named_parameters():
+                if f"mean_module.{name}" in self._subset_batch_dict:
+                    continue
+                if (
+                    parameter.shape[: len(self._aug_batch_shape)]
+                    == self._aug_batch_shape
+                ):
+                    raise UnsupportedError(
+                        "`subset_output` is not supported for custom mean modules "
+                        "with output-batched parameters."
+                    )
+        return cast(SingleTaskMultiFidelityGP, super().subset_output(idcs=idcs))
 
 
 def _setup_multifidelity_covar_module(

--- a/test/models/test_gp_regression_fidelity.py
+++ b/test/models/test_gp_regression_fidelity.py
@@ -22,7 +22,7 @@ from gpytorch.kernels.linear_kernel import LinearKernel
 from gpytorch.kernels.rbf_kernel import RBFKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.likelihoods import FixedNoiseGaussianLikelihood
-from gpytorch.means import ConstantMean
+from gpytorch.means import ConstantMean, LinearMean, ZeroMean
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from torch import Tensor
 
@@ -493,6 +493,86 @@ class TestSingleTaskMultiFidelityGP(BotorchTestCase):
         model_kwargs.update({"linear_truncated": True})
         with self.assertRaises(ValueError):
             model = SingleTaskMultiFidelityGP(**model_kwargs, covar_module=covar_module)
+
+    def test_custom_mean_module(self):
+        iteration_fidelity, data_fidelities = self.FIDELITY_TEST_PAIRS[0]
+        batch_shape = torch.Size([2])
+        m = 2
+        tkwargs = {"device": self.device, "dtype": torch.double}
+
+        _, model_kwargs = self._get_model_and_data(
+            iteration_fidelity=iteration_fidelity,
+            data_fidelities=data_fidelities,
+            batch_shape=batch_shape,
+            m=m,
+            lin_truncated=False,
+            **tkwargs,
+        )
+        mean_module = ZeroMean().to(**tkwargs)
+        model = SingleTaskMultiFidelityGP(**model_kwargs, mean_module=mean_module)
+        self.assertIs(model.mean_module, mean_module)
+
+        X = torch.rand(batch_shape + torch.Size([3, 2]), **tkwargs)
+        posterior = model.posterior(X)
+        self.assertEqual(posterior.mean.shape, batch_shape + torch.Size([3, m]))
+
+    def test_subset_output_with_custom_mean_module(self):
+        iteration_fidelity, data_fidelities = self.FIDELITY_TEST_PAIRS[0]
+        batch_shape = torch.Size([2])
+        m = 2
+        tkwargs = {"device": self.device, "dtype": torch.double}
+
+        for lin_truncated, mean_module_factory in itertools.product(
+            (False, True),
+            (
+                ZeroMean,
+                lambda: ConstantMean(batch_shape=batch_shape + torch.Size([m])),
+            ),
+        ):
+            _, model_kwargs = self._get_model_and_data(
+                iteration_fidelity=iteration_fidelity,
+                data_fidelities=data_fidelities,
+                batch_shape=batch_shape,
+                m=m,
+                lin_truncated=lin_truncated,
+                **tkwargs,
+            )
+
+            model = SingleTaskMultiFidelityGP(
+                **model_kwargs, mean_module=mean_module_factory().to(**tkwargs)
+            )
+
+            X = torch.rand(batch_shape + torch.Size([3, 2]), **tkwargs)
+            posterior = model.posterior(X)
+            subset_model = model.subset_output([0])
+            subset_posterior = subset_model.posterior(X)
+            self.assertAllClose(subset_posterior.mean, posterior.mean[..., [0]])
+            self.assertAllClose(subset_posterior.variance, posterior.variance[..., [0]])
+
+    def test_subset_output_with_unsupported_custom_mean_module(self):
+        iteration_fidelity, data_fidelities = self.FIDELITY_TEST_PAIRS[0]
+        batch_shape = torch.Size([2])
+        m = 2
+        tkwargs = {"device": self.device, "dtype": torch.double}
+
+        _, model_kwargs = self._get_model_and_data(
+            iteration_fidelity=iteration_fidelity,
+            data_fidelities=data_fidelities,
+            batch_shape=batch_shape,
+            m=m,
+            lin_truncated=False,
+            **tkwargs,
+        )
+        mean_module = LinearMean(
+            input_size=2, batch_shape=batch_shape + torch.Size([m])
+        ).to(**tkwargs)
+        model = SingleTaskMultiFidelityGP(**model_kwargs, mean_module=mean_module)
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "`subset_output` is not supported for custom mean modules with "
+            "output-batched parameters.",
+        ):
+            model.subset_output([0])
 
 
 class TestFixedNoiseSingleTaskMultiFidelityGP(TestSingleTaskMultiFidelityGP):


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR implements #3325 by adding a `mean_module` argument to the `__init__` of the `SingleTaskMultiFidelityGP`, as well as corresponding tests. As mentioned in that issue, this argument seems to have simply been overlooked and "forgotten" so far. As a consequence, the fallback of a `ConstantMean` was used. The changes in this PR now allow to use different mean modules.

In addition to the addition of the argument, the following parts were changed:
- The code only adds `"mean_module.raw_constant": -1` to the `_subset_batch_dict` if the provided `mean_module` actually has a parameter of that name and its shape is equal to `_aug_batch_shape`.
- The code overrides `subset_outputs`. This is necessary due to users now potentially hading over custom mean modules.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Three new tests were being added:
- Providing a custom mean module works
- Explicit test for the `subset_output` override, once with a mean with and once with a mean without parameters
- Test for verifying that an error is thrown when a custom mean module with output-specific parameters is used for which the model does not know how to subset them safely.

In addition, pre-commit hooks were run.

## Related PRs

None.

## Further comments

The argument is added as the last argument to not break anything relying on the positions of the arguments: If `mean_module` would be added at another point of the signature (e.g. next to the `cover_module`), this would be a breaking change. One could even add it as a dedicated Keyword-only argument to be even safer.

For transparency: AI was used in the creation of this code, but everything was checked and verified by myself.