### PR TITLE
Allow scipy 1.18 in batched L-BFGS-B fast path

### DIFF
--- a/botorch/generation/gen.py
+++ b/botorch/generation/gen.py
@@ -44,7 +44,7 @@ from torch import Tensor
 from torch.optim import Optimizer
 
 SCIPY_MIN_VERSION: int = 13
-SCIPY_UNTESTED_VERSION: int = 18
+SCIPY_UNTESTED_VERSION: int = 19
 
 if check_scipy_version_at_least(
     minor=SCIPY_MIN_VERSION

--- a/botorch/optim/batched_lbfgs_b.py
+++ b/botorch/optim/batched_lbfgs_b.py
@@ -9,7 +9,7 @@ This yields optimization speedups for acquisition function optimization,
 where multiple independent problems with the same structure are optimized in parallel.
 
 This file is written such that it explicitly supports all scipy versions
-from 1.13 to 1.15 (likely 1.16, too, based on its pre-release version).
+from 1.13 to 1.18.
 This file might break for higher versions, as it uses internal APIs.
 There is a major revision of the core optimization code in 1.15, as it is
 ported from FORTRAN to C, we handle the API changes, though, and are


### PR DESCRIPTION
## Summary

Allows scipy 1.18.x to use the batched L-BFGS-B implementation rather than falling back to the less-optimized path.

- Bump `SCIPY_UNTESTED_VERSION` from `18` to `19` in `botorch/generation/gen.py`. The batched path is gated to `1.{SCIPY_MIN_VERSION} <= scipy < 1.{SCIPY_UNTESTED_VERSION}`, so scipy 1.18 was previously treated as untested and routed to the fallback.
- Update the module docstring in `botorch/optim/batched_lbfgs_b.py` to reflect the supported range (1.13 to 1.18).

The FORTRAN→C transition (scipy 1.15) still falls within the supported range, so both interface code paths remain live and are unchanged.

## Test Plan

Verified against an actual scipy 1.18.0 install:

```
python -m pytest test/optim/test_batched_lbfgs_b.py test/optim/test_fit.py test/generation/test_gen.py
# 53 passed, 115 subtests passed
```

All suites also pass on scipy 1.17.0.