### PR TITLE
Fix fused C++ kernel crash for q > 16 in qLogEHVI/qLogNEHVI

### DIFF
--- a/botorch/acquisition/multi_objective/logei.py
+++ b/botorch/acquisition/multi_objective/logei.py
@@ -59,6 +59,7 @@ from torch import Tensor
 
 _C = None  # Fused C++ kernel module, loaded lazily by _try_load_fused_kernel().
 _load_attempted = False  # Sentinel to avoid retrying after a failed load.
+_FUSED_MAX_I = 32  # Must match MAX_I in logei_fused.cpp.
 
 
 def _try_load_fused_kernel() -> None:
@@ -316,7 +317,12 @@ class qLogExpectedHypervolumeImprovement(
         # When obj has extra t-batch dims that broadcast against the cell
         # bounds, we expand cell bounds to match before flattening.
         cell_batch_ndim = self.cell_lower_bounds.ndim - 2
-        use_fused = _C is not None and self.fat and obj.device.type == "cpu"
+        use_fused = (
+            _C is not None
+            and self.fat
+            and obj.device.type == "cpu"
+            and q <= _FUSED_MAX_I
+        )
 
         if use_fused and cell_batch_ndim > 0:
             # Expand cell bounds to match obj batch shape for 1:1 mapping.

--- a/botorch/csrc/logei_fused.cpp
+++ b/botorch/csrc/logei_fused.cpp
@@ -28,9 +28,9 @@ namespace {
 constexpr double ALPHA_RELU = 0.1;
 
 // Static upper bounds for stack-allocated scratch arrays.
-// MAX_I: maximum subset size (q choose i).
+// MAX_I: maximum subset size (the `i` in the inclusion-exclusion loop).
 // MAX_M: maximum number of objectives.
-constexpr int MAX_I = 16;
+constexpr int MAX_I = 32;
 constexpr int MAX_M = 8;
 
 // Numerically stable softplus: log(1 + exp(y)).

--- a/test/acquisition/multi_objective/test_logei.py
+++ b/test/acquisition/multi_objective/test_logei.py
@@ -380,3 +380,47 @@ class TestFusedKernelCorrectness(BotorchTestCase):
         finally:
             logei_module._C = saved
         self.assertAllClose(val_fused, val_python, atol=1e-6, rtol=0)
+
+    def test_fused_kernel_fallback_large_q(self) -> None:
+        """Verify that q > _FUSED_MAX_I gracefully falls back to Python path."""
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d = 2
+        m = 2
+        q = 4
+
+        torch.manual_seed(0)
+        train_X = torch.rand(10, d, **tkwargs)
+        train_Y = torch.randn(10, m, **tkwargs)
+        model = SingleTaskGP(train_X, train_Y)
+        ref_point = train_Y.min(dim=0).values - 0.1
+        partitioning = NondominatedPartitioning(ref_point=ref_point, Y=train_Y[:3])
+        sampler = SobolQMCNormalSampler(sample_shape=torch.Size([4]))
+        acqf = qLogExpectedHypervolumeImprovement(
+            model=model,
+            ref_point=ref_point.tolist(),
+            partitioning=partitioning,
+            sampler=sampler,
+        )
+        test_X = torch.rand(q, d, **tkwargs).requires_grad_(True)
+
+        # With _FUSED_MAX_I artificially set below q, should use Python path.
+        saved_max_i = logei_module._FUSED_MAX_I
+        logei_module._FUSED_MAX_I = q - 1
+        try:
+            torch.manual_seed(42)
+            val_fallback = acqf(test_X)
+            val_fallback.sum().backward()
+            grad_fallback = test_X.grad.clone()
+            test_X.grad = None
+        finally:
+            logei_module._FUSED_MAX_I = saved_max_i
+
+        # With fused kernel available (q is within the real limit), should match.
+        torch.manual_seed(42)
+        val_fused = acqf(test_X)
+        val_fused.sum().backward()
+        grad_fused = test_X.grad.clone()
+        test_X.grad = None
+
+        self.assertAllClose(val_fallback, val_fused, atol=1e-6, rtol=1e-6)
+        self.assertAllClose(grad_fallback, grad_fused, atol=1e-6, rtol=1e-6)


### PR DESCRIPTION
Summary:
The fused C++ kernel in `logei_fused.cpp` uses stack-allocated arrays sized by `MAX_I = 16`. When `q` (the number of candidate points) exceeds 16, the `TORCH_CHECK` at the kernel entry throws a hard error instead of gracefully falling back to the pure-Python implementation.

This diff fixes the dispatch by:
1. Adding a `q <= _FUSED_MAX_I` guard to the `use_fused` check in `_compute_log_qehvi`, so that large `q` values transparently fall back to the pure-Python path.
2. Increasing `MAX_I` from 16 to 32 in the C++ kernel, broadening the range of `q` the fused kernel can handle. The stack cost per thread goes from ~5KB to ~10KB, well within limits.

There is no fundamental reason for the limit of 16 — it is purely a compile-time stack allocation size. The real scaling bottleneck is the 2^q subsets in the inclusion-exclusion loop, not the kernel itself.

Differential Revision: D109445863


