### PR TITLE
Open-source integrated white noise kernels (#3330)

### DIFF
--- a/botorch/models/kernels/__init__.py
+++ b/botorch/models/kernels/__init__.py
@@ -8,6 +8,7 @@ from botorch.models.kernels.categorical import CategoricalKernel
 from botorch.models.kernels.downsampling import DownsamplingKernel
 from botorch.models.kernels.exponential_decay import ExponentialDecayKernel
 from botorch.models.kernels.infinite_width_bnn import InfiniteWidthBNNKernel
+from botorch.models.kernels.integrated_white_noise import IntegratedWhiteNoiseKernel
 from botorch.models.kernels.linear_truncated_fidelity import (
     LinearTruncatedFidelityKernel,
 )
@@ -18,5 +19,6 @@ __all__ = [
     "DownsamplingKernel",
     "ExponentialDecayKernel",
     "InfiniteWidthBNNKernel",
+    "IntegratedWhiteNoiseKernel",
     "LinearTruncatedFidelityKernel",
 ]

--- a/botorch/models/kernels/integrated_white_noise.py
+++ b/botorch/models/kernels/integrated_white_noise.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Module for the integrated white noise covariance kernel.
+
+This module provides a single kernel parameterized by the ``order`` of
+integration, corresponding to repeatedly integrated white noise (equivalently,
+integrated Brownian motion). For inputs s, t >= 0 the covariance of white noise
+integrated ``order`` times has the closed form
+
+.. math::
+
+    k_p(s, t) = \frac{1}{((p-1)!)^2}
+        \sum_{j=0}^{p-1} \binom{p-1}{j}
+        \frac{(\max - \min)^{p-1-j} \, \min^{p+j}}{p + j}
+
+where :math:`p` is the order, :math:`\min = \min(s, t)` and
+:math:`\max = \max(s, t)`. The first three orders recover the familiar forms:
+
+- ``order=1`` (Wiener process / Brownian motion):
+    k(s, t) = min(s, t)
+- ``order=2`` (integrated Brownian motion):
+    k(s, t) = min(s, t)^2 * (3 * max(s, t) - min(s, t)) / 6
+- ``order=3`` (twice integrated Brownian motion):
+    k(s, t) = min(s, t)^3 * (min^2 - 5 * min * max + 10 * max^2) / 120
+
+All inputs are assumed non-negative (representing time indices).
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from gpytorch.kernels import Kernel
+from torch import Tensor
+
+
+class IntegratedWhiteNoiseKernel(Kernel):
+    r"""
+    Computes a covariance matrix based on the integrated white noise kernel
+    between inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`.
+
+    This is the covariance of white noise integrated ``order`` (:math:`p`)
+    times, equivalently :math:`(p-1)`-times integrated Brownian motion. For
+    :math:`s, t \ge 0`,
+
+    .. math::
+
+        k_p(s, t) = \frac{1}{((p-1)!)^2}
+            \sum_{j=0}^{p-1} \binom{p-1}{j}
+            \frac{(\max - \min)^{p-1-j} \, \min^{p+j}}{p + j}
+
+    where :math:`\min = \min(s, t)` and :math:`\max = \max(s, t)`. The first
+    three orders recover the familiar closed forms:
+
+    - :math:`p = 1`: :math:`k(s, t) = \min(s, t)` (Wiener process / Brownian
+      motion).
+    - :math:`p = 2`: :math:`k(s, t) = \min^2 (3 \max - \min) / 6` (integrated
+      Brownian motion, :math:`X(t) = \int_0^t B(u) \, du`).
+    - :math:`p = 3`:
+      :math:`k(s, t) = \min^3 (\min^2 - 5 \min \max + 10 \max^2) / 120`
+      (twice integrated Brownian motion).
+
+    .. note::
+
+        This kernel assumes non-negative inputs (representing time indices).
+        For inputs with negative values, the behavior may not correspond to
+        integrated white noise.
+
+    .. note::
+
+        This kernel does not have a `lengthscale` parameter. To add a scaling
+        parameter, decorate this kernel with a
+        :class:`gpytorch.kernels.ScaleKernel`.
+
+    Example:
+        >>> x = torch.rand(10, 1)  # 10 time points in [0, 1]
+        >>> # Non-batch: Simple option
+        >>> covar_module = gpytorch.kernels.ScaleKernel(
+        ...     IntegratedWhiteNoiseKernel(order=2)
+        ... )
+        >>> covar = covar_module(x)  # Output: LazyTensor of size (10 x 10)
+        >>>
+        >>> batch_x = torch.rand(2, 10, 1)  # Batch of time points
+        >>> # Batch: Simple option
+        >>> covar_module = gpytorch.kernels.ScaleKernel(
+        ...     IntegratedWhiteNoiseKernel(order=2)
+        ... )
+        >>> covar = covar_module(batch_x)  # Output: LazyTensor of size (2 x 10 x 10)
+    """
+
+    is_stationary = False
+    has_lengthscale = False
+
+    def __init__(self, order: int = 1, **kwargs) -> None:
+        r"""Initialize the kernel.
+
+        Args:
+            order: The order of integration :math:`p \ge 1`. ``order=1`` is
+                Brownian motion (Wiener process), ``order=2`` is integrated
+                Brownian motion, and so on.
+            kwargs: Keyword arguments passed to
+                :class:`gpytorch.kernels.Kernel` (e.g. ``batch_shape``,
+                ``active_dims``).
+        """
+        # bool is a subclass of int, so reject it explicitly.
+        if isinstance(order, bool) or not isinstance(order, int) or order < 1:
+            raise ValueError(
+                f"IntegratedWhiteNoiseKernel requires an integer order >= 1, but "
+                f"got order={order!r}."
+            )
+        super().__init__(**kwargs)
+        self.order = order
+        # Precompute the constant denominator ((p-1)!)^2 and the per-term
+        # (binomial coefficient, exponents, divisor) tuples for j = 0..p-1.
+        # Dividing by the denominator is numerically more stable than
+        # multiplying by its floating-point reciprocal.
+        self._denominator: int = math.factorial(order - 1) ** 2
+        self._terms: list[tuple[int, int, int, int]] = [
+            (math.comb(order - 1, j), order - 1 - j, order + j, order + j)
+            for j in range(order)
+        ]
+
+    def forward(
+        self,
+        x1: Tensor,
+        x2: Tensor,
+        diag: bool = False,
+        **params,
+    ) -> Tensor:
+        r"""
+        Compute the integrated white noise covariance between x1 and x2.
+
+        Args:
+            x1: First set of data, shape `(... x n x 1)`.
+            x2: Second set of data, shape `(... x m x 1)`.
+            diag: If True, return only the diagonal of the covariance matrix.
+
+        Returns:
+            Tensor: The covariance matrix of shape `(... x n x m)` or diagonal
+                of shape `(... x n)` if diag=True.
+        """
+        # Validate that inputs are 1D (time indices)
+        if x1.shape[-1] != 1 or x2.shape[-1] != 1:
+            raise ValueError(
+                f"IntegratedWhiteNoiseKernel requires 1D inputs (last dimension "
+                f"must be 1), but got x1.shape[-1]={x1.shape[-1]} and "
+                f"x2.shape[-1]={x2.shape[-1]}. The integrated white noise "
+                f"covariance is only defined for scalar time indices."
+            )
+
+        # Squeeze the last dimension to get scalar time values
+        x1_squeezed = x1.squeeze(-1)
+        x2_squeezed = x2.squeeze(-1)
+
+        if diag:
+            # For diagonal, x1 and x2 should be equal, so min = max = x. Only the
+            # j = p-1 term survives: k(t, t) = t^(2p-1) / ((p-1)!^2 * (2p-1)).
+            return x1_squeezed ** (2 * self.order - 1) / (
+                self._denominator * (2 * self.order - 1)
+            )
+
+        # Compute pairwise min and max with shapes broadcasting to (..., n, m).
+        x1_expanded = x1_squeezed.unsqueeze(-1)
+        x2_expanded = x2_squeezed.unsqueeze(-2)
+        min_val = torch.minimum(x1_expanded, x2_expanded)
+        max_val = torch.maximum(x1_expanded, x2_expanded)
+        diff = max_val - min_val
+
+        result = torch.zeros_like(min_val)
+        for coeff, diff_exp, min_exp, divisor in self._terms:
+            result = result + coeff * diff**diff_exp * min_val**min_exp / divisor
+        return result / self._denominator

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -175,6 +175,9 @@ Kernels
 .. automodule:: botorch.models.kernels.heterogeneous_multitask
 .. autoclass:: MultiTaskConditionalKernel
 
+.. automodule:: botorch.models.kernels.integrated_white_noise
+.. autoclass:: IntegratedWhiteNoiseKernel
+
 Likelihoods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: botorch.models.likelihoods.pairwise

--- a/test/models/kernels/test_integrated_white_noise.py
+++ b/test/models/kernels/test_integrated_white_noise.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Unit tests for the integrated white noise kernel.
+"""
+
+import functools
+
+import torch
+from botorch.models.kernels.integrated_white_noise import IntegratedWhiteNoiseKernel
+from botorch.utils.testing import BotorchTestCase
+from gpytorch.kernels import Kernel, ScaleKernel
+
+
+class NonStationary1DKernelTestMixin:
+    """Mixin providing common test utilities for non-stationary 1D kernels."""
+
+    def _get_tkwargs(self, dtype: torch.dtype) -> dict[str, object]:
+        return {"device": self.device, "dtype": dtype}
+
+    def _assert_kernel_basic_attributes(self, kernel: Kernel) -> None:
+        self.assertFalse(kernel.is_stationary)
+        self.assertFalse(kernel.has_lengthscale)
+
+    def _assert_covariance_symmetry(
+        self, kernel: Kernel, tkwargs: dict[str, object]
+    ) -> None:
+        x_rand = torch.rand(10, 1, **tkwargs)
+        covar_sym = kernel(x_rand, x_rand).to_dense()
+        self.assertAllClose(covar_sym, covar_sym.T)
+
+    def _assert_positive_semi_definiteness(
+        self, kernel: Kernel, tkwargs: dict[str, object], tol: float = 0.0
+    ) -> None:
+        x_lin = torch.linspace(0.1, 1.0, 10, **tkwargs).unsqueeze(-1)
+        covar_psd = kernel(x_lin, x_lin).to_dense()
+        eigenvalues = torch.linalg.eigvalsh(covar_psd)
+        self.assertTrue(torch.all(eigenvalues >= -tol))
+
+    def _assert_scale_kernel_works(
+        self, kernel_factory, tkwargs: dict[str, object]
+    ) -> None:
+        x_scale = torch.rand(10, 1, **tkwargs)
+        covar_module = ScaleKernel(kernel_factory())
+        covar_scaled = covar_module(x_scale)
+        self.assertEqual(covar_scaled.size(), torch.Size([10, 10]))
+
+    def _assert_batch_dimensions_work(
+        self, kernel: Kernel, tkwargs: dict[str, object]
+    ) -> None:
+        batch_x = torch.rand(2, 5, 1, **tkwargs)
+        covar_batch = kernel(batch_x, batch_x)
+        self.assertEqual(covar_batch.size(), torch.Size([2, 5, 5]))
+
+    def _assert_different_sizes_work(
+        self, kernel: Kernel, tkwargs: dict[str, object], n1: int, n2: int
+    ) -> None:
+        x1_diff = torch.rand(n1, 1, **tkwargs)
+        x2_diff = torch.rand(n2, 1, **tkwargs)
+        covar_diff = kernel(x1_diff, x2_diff).to_dense()
+        self.assertEqual(covar_diff.size(), torch.Size([n1, n2]))
+
+    def _assert_multi_dimensional_input_raises(
+        self, kernel: Kernel, tkwargs: dict[str, object]
+    ) -> None:
+        x_multi_dim = torch.rand(5, 3, **tkwargs)
+        with self.assertRaises(ValueError) as context:
+            kernel(x_multi_dim, x_multi_dim).to_dense()
+        self.assertIn("requires 1D inputs", str(context.exception))
+
+    def _test_common_kernel_properties(
+        self,
+        kernel: Kernel,
+        kernel_factory,
+        tkwargs: dict[str, object],
+        psd_tol: float = 0.0,
+    ) -> None:
+        """Test common properties shared by all non-stationary 1D kernels."""
+        self._assert_kernel_basic_attributes(kernel)
+        self._assert_covariance_symmetry(kernel, tkwargs)
+        self._assert_positive_semi_definiteness(kernel, tkwargs, tol=psd_tol)
+        self._assert_scale_kernel_works(kernel_factory, tkwargs)
+        self._assert_batch_dimensions_work(kernel, tkwargs)
+        self._assert_different_sizes_work(kernel, tkwargs, n1=2, n2=3)
+        self._assert_multi_dimensional_input_raises(kernel, tkwargs)
+
+
+class TestIntegratedWhiteNoiseKernel(NonStationary1DKernelTestMixin, BotorchTestCase):
+    def test_orders(self) -> None:
+        """Per-order closed-form values, diagonals, and common properties."""
+        for dtype in [torch.float32, torch.float64]:
+            for order in (1, 2, 3):
+                with self.subTest(dtype=dtype, order=order):
+                    self._test_order(dtype, order)
+
+    def _test_order(self, dtype: torch.dtype, order: int) -> None:
+        tkwargs = self._get_tkwargs(dtype)
+        kernel = IntegratedWhiteNoiseKernel(order=order)
+        factory = functools.partial(IntegratedWhiteNoiseKernel, order=order)
+        # PSD becomes ill-conditioned for higher orders; allow a small tolerance.
+        psd_tol = 0.0 if order == 1 else 1e-6
+        self._test_common_kernel_properties(kernel, factory, tkwargs, psd_tol=psd_tol)
+
+        x1 = torch.tensor([[1.0], [2.0], [3.0]], **tkwargs)
+        x2 = torch.tensor([[0.5], [2.0], [4.0]], **tkwargs)
+        x_diag = torch.tensor([[1.0], [2.0], [3.0], [4.0]], **tkwargs)
+
+        if order == 1:
+            # k(s, t) = min(s, t)
+            expected = torch.tensor(
+                [[0.5, 1.0, 1.0], [0.5, 2.0, 2.0], [0.5, 2.0, 3.0]], **tkwargs
+            )
+            expected_diag = torch.tensor([1.0, 2.0, 3.0, 4.0], **tkwargs)
+        elif order == 2:
+            # k(s, t) = min^2 * (3*max - min) / 6
+            expected = torch.tensor(
+                [
+                    [0.625 / 6, 5.0 / 6, 11.0 / 6],
+                    [1.375 / 6, 16.0 / 6, 40.0 / 6],
+                    [2.125 / 6, 28.0 / 6, 81.0 / 6],
+                ],
+                **tkwargs,
+            )
+            expected_diag = x_diag.squeeze(-1) ** 3 / 3
+        else:  # order == 3
+            # k(s, t) = min^3 * (min^2 - 5*min*max + 10*max^2) / 120
+            x1 = torch.tensor([[1.0], [2.0]], **tkwargs)
+            x2 = torch.tensor([[1.0], [3.0]], **tkwargs)
+            expected = torch.tensor(
+                [[6.0 / 120, 76.0 / 120], [31.0 / 120, 8.0 * 64.0 / 120]],
+                **tkwargs,
+            )
+            expected_diag = x_diag.squeeze(-1) ** 5 / 20
+
+        self.assertAllClose(kernel(x1, x2).to_dense(), expected)
+        self.assertAllClose(kernel(x_diag, x_diag, diag=True), expected_diag)
+
+        # t = 0 gives zero covariance for every order.
+        x_zero = torch.tensor([[0.0], [1.0]], **tkwargs)
+        covar_zero = kernel(x_zero, x_zero).to_dense()
+        self.assertAllClose(covar_zero[0], torch.zeros(2, **tkwargs))
+        self.assertAllClose(covar_zero[:, 0], torch.zeros(2, **tkwargs))
+
+    def test_invalid_order(self) -> None:
+        """Order must be an integer >= 1."""
+        for bad_order in (0, -1, 1.5, True):
+            with self.subTest(order=bad_order):
+                with self.assertRaises(ValueError) as context:
+                    IntegratedWhiteNoiseKernel(order=bad_order)
+                # Must not collide with the 1D-input validation message.
+                self.assertNotIn("requires 1D inputs", str(context.exception))
+
+    def test_higher_order_generalization(self) -> None:
+        """The general formula extends beyond the three hardcoded orders."""
+        tkwargs = self._get_tkwargs(torch.float64)
+        kernel = IntegratedWhiteNoiseKernel(order=4)
+        x = torch.linspace(0.1, 1.0, 10, **tkwargs).unsqueeze(-1)
+        covar = kernel(x, x).to_dense()
+        self.assertAllClose(covar, covar.T)
+        eigenvalues = torch.linalg.eigvalsh(covar)
+        # Order-4 Gram matrices are ill-conditioned; allow a looser float64 tol.
+        self.assertTrue(torch.all(eigenvalues >= -1e-4))
+        # Diagonal closed form: k(t, t) = t^7 / (3!^2 * 7) = t^7 / 252.
+        diag = kernel(x, x, diag=True)
+        self.assertAllClose(diag, x.squeeze(-1) ** 7 / 252)


### PR DESCRIPTION
Summary:

Adds an integrated-white-noise covariance kernel to the public `botorch.models.kernels` package so it can be used in open-source tutorials and by the community. These non-stationary 1D kernels previously lived in the internal `botorch_fb` module.

Instead of a separate class per integration order, a single `IntegratedWhiteNoiseKernel(order=p)` covers all orders via the closed form for the covariance of `p`-times integrated white noise (equivalently, integrated Brownian motion), for `s, t >= 0`:

  `k_p(s, t) = 1/((p-1)!)^2 * sum_{j=0}^{p-1} C(p-1, j) * (max - min)^(p-1-j) * min^(p+j) / (p + j)`

with `min = min(s, t)` and `max = max(s, t)`. This recovers the familiar closed forms — `order=1` gives `min(s, t)` (Wiener process / Brownian motion), `order=2` gives `min^2 (3 max - min) / 6` (integrated Brownian motion), `order=3` gives `min^3 (min^2 - 5 min max + 10 max^2) / 120` (twice integrated Brownian motion) — and extends to any `order >= 1` for free.

- New module `botorch/models/kernels/integrated_white_noise.py` with `IntegratedWhiteNoiseKernel` (default `order=1`, formerly `BrownianMotionKernel`). The first order's docstring references are renamed from "Brownian motion" to "integrated white noise" for naming consistency.
- Registers the kernel in the kernels package `__init__` and the Sphinx docs.
- Adds `test/models/kernels/test_integrated_white_noise.py`.
- Removes the internal `botorch_fb` sources (the only consumers were their own tests).

Reviewed By: SebastianAment

Differential Revision: D109472634


