### PR TITLE
Skip empirical_gaussian_processes tutorial to avoid nightly timeout

### DIFF
--- a/scripts/run_tutorials.py
+++ b/scripts/run_tutorials.py
@@ -18,7 +18,11 @@ from memory_profiler import memory_usage
 
 
 # Ignored in smoke tests and full runs
-IGNORE_ALWAYS = {"optimization_issue_diagnostics.ipynb"}
+IGNORE_ALWAYS = {
+    "optimization_issue_diagnostics.ipynb",
+    # Times out the nightly cron job.
+    "empirical_gaussian_processes.ipynb",
+}
 RUN_IF_SMOKE_TEST_IGNORE_IF_STANDARD = {"robot.ipynb"}  # only used in smoke tests
 
 


### PR DESCRIPTION
The `empirical_gaussian_processes.ipynb` tutorial exceeds the allowed 30 minute runtime and fails the nightly cron job. This adds it to the `IGNORE_ALWAYS` set in `scripts/run_tutorials.py` so it is skipped in both smoke tests and full runs.

Alternatively, we could move it to community notebooks, so it is persisted with a date reflecting when the notebook was last run to generate its outputs.