### PR TITLE
Fix qLogEHVI IndexError on empty box decompositions

### DIFF
--- a/botorch/acquisition/multi_objective/logei.py
+++ b/botorch/acquisition/multi_objective/logei.py
@@ -322,6 +322,9 @@ class qLogExpectedHypervolumeImprovement(
             and self.fat
             and obj.device.type == "cpu"
             and q <= _FUSED_MAX_I
+            # An approximate box decomposition can have zero cells; there is
+            # nothing to fuse then and the Python path handles it directly.
+            and self.cell_lower_bounds.shape[-2] > 0
         )
 
         if use_fused and cell_batch_ndim > 0:

--- a/botorch/optim/initializers.py
+++ b/botorch/optim/initializers.py
@@ -1004,10 +1004,13 @@ def initialize_q_batch(
         return X, acq_vals
 
     Ystd = acq_vals.std(dim=0)
-    if torch.any(Ystd == 0):
+    if torch.any(Ystd == 0) or not torch.isfinite(Ystd).all():
+        # A non-finite std indicates non-finite acquisition values, for example when
+        # the acquisition function evaluates to -inf for all raw samples. Sampling
+        # probabilities proportional to exp(eta * Z) are not defined in either case.
         warnings.warn(
-            "All acquisition values for raw samples points are the same for "
-            "at least one batch. Choosing initial conditions at random.",
+            "All acquisition values for raw samples points are the same or not "
+            "finite for at least one batch. Choosing initial conditions at random.",
             BadInitialCandidatesWarning,
             stacklevel=3,
         )

--- a/botorch/utils/safe_math.py
+++ b/botorch/utils/safe_math.py
@@ -162,8 +162,15 @@ def _inf_max_helper(
 
     Returns:
         The Tensor representing the smooth approximation to the maximum over the
-        specified dimensions.
+        specified dimensions. If the reduced dimensions of ``x`` have zero size,
+        the result is ``-inf``, consistent with the maximum over an empty set.
     """
+    dims = (dim,) if isinstance(dim, int) else tuple(dim)
+    if any(x.shape[d] == 0 for d in dims):
+        # The maximum over an empty set is -inf, which also matches the behavior of
+        # torch.logsumexp over a zero-size dimension. The sum keeps the result
+        # connected to the autograd graph, so gradients w.r.t. x remain defined.
+        return x.sum(dim=dim, keepdim=keepdim) - torch.inf
     M = x.amax(dim=dim, keepdim=True)
     is_inf_max = torch.logical_and(*torch.broadcast_tensors(M.isinf(), x == M))
     has_inf_max = _any(is_inf_max, dim=dim, keepdim=True)

--- a/test/acquisition/multi_objective/test_logei.py
+++ b/test/acquisition/multi_objective/test_logei.py
@@ -153,6 +153,43 @@ class TestLogQExpectedHypervolumeImprovement(BotorchTestCase):
         else:  # This is an interesting difference between the exp and the fat tail.
             self.assertEqual(0, exp_log_res)
 
+    def test_q_log_expected_hypervolume_improvement_empty_partitioning(self):
+        # An approximate box decomposition (alpha > 0) can prune all hypercells
+        # when there are many objectives and few observations. The hypervolume
+        # improvement over an empty cell set is zero, so the log acquisition
+        # value is -inf rather than an IndexError, see
+        # https://github.com/meta-pytorch/botorch/issues/3335.
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        Y = torch.tensor(
+            [
+                [-0.0290, -0.6380, -0.3541, -0.3603, -0.0456, -0.9788, -0.1836],
+                [-0.8259, -0.8002, -0.6951, -0.7300, -0.8310, -0.6017, -0.3212],
+                [-0.0013, -0.3934, -0.2733, -0.0116, -0.0056, -0.4870, -0.5419],
+            ],
+            **tkwargs,
+        )
+        ref_point = Y.min(dim=0).values - 1e-8
+        partitioning = NondominatedPartitioning(ref_point=ref_point, Y=Y, alpha=0.1)
+        # all cells of the approximate decomposition are pruned for this input
+        self.assertEqual(partitioning.get_hypercell_bounds().shape[-2], 0)
+
+        samples = torch.zeros(1, 1, 7, **tkwargs)
+        mm = MockModel(MockPosterior(samples=samples))
+        X = torch.zeros(1, 1, **tkwargs)
+        for fat in (True, False):
+            with self.subTest(fat=fat):
+                acqf = qLogExpectedHypervolumeImprovement(
+                    model=mm,
+                    ref_point=ref_point.tolist(),
+                    partitioning=partitioning,
+                    sampler=IIDNormalSampler(sample_shape=torch.Size([1])),
+                    fat=fat,
+                )
+                res = acqf(X)
+                self.assertTrue(res.isneginf().all())
+                # zero hypervolume improvement upon exponentiation
+                self.assertEqual(res.exp().item(), 0.0)
+
 
 @unittest.skipIf(_fused_C is None, "C++ extension not available")
 class TestFusedKernelCorrectness(BotorchTestCase):

--- a/test/optim/test_initializers.py
+++ b/test/optim/test_initializers.py
@@ -164,6 +164,14 @@ class TestInitializeQBatch(BotorchTestCase):
             with self.assertRaises(RuntimeError):
                 initialize_q_batch(X=X, acq_vals=acq_vals, n=10)
 
+            # ensure a warning rather than an error for non-finite values, e.g. when
+            # the acquisition function evaluates to -inf for all raw samples, see
+            # https://github.com/meta-pytorch/botorch/issues/3335
+            acq_vals = torch.full((5,), -torch.inf, device=self.device, dtype=dtype)
+            with self.assertWarns(BadInitialCandidatesWarning):
+                ics, _ = initialize_q_batch(X=X, acq_vals=acq_vals, n=2)
+            self.assertEqual(ics.shape, torch.Size([2, *batch_shape, 3, 4]))
+
     def test_initialize_q_batch_topn(self):
         for dtype in (torch.float, torch.double):
             # basic test

--- a/test/utils/test_safe_math.py
+++ b/test/utils/test_safe_math.py
@@ -32,6 +32,7 @@ from botorch.utils.safe_math import (
     logexpit,
     logmeanexp,
     logplusexp,
+    logsumexp,
     sigmoid,
     smooth_amax,
 )
@@ -281,6 +282,35 @@ class TestLogMeanExp(BotorchTestCase):
                 logmeanexp(X.log(), dim=(0, -1), keepdim=True).exp(),
                 X.mean(dim=(0, -1), keepdim=True),
             )
+
+
+class TestEmptyReductionDims(BotorchTestCase):
+    def test_empty_reduction_dims(self):
+        # The maximum over an empty set is -inf. logsumexp and the fat maximum
+        # approximations follow torch.logsumexp for zero-size reduction dims
+        # instead of erroring, see
+        # https://github.com/meta-pytorch/botorch/issues/3335.
+        for dtype in (torch.float32, torch.float64):
+            X = torch.empty(3, 0, 2, dtype=dtype, device=self.device)
+            for fun, dim, keepdim in product(
+                (logsumexp, fatmax, smooth_amax), (1, (1, -1), (0, 1)), (True, False)
+            ):
+                with self.subTest(fun=fun, dim=dim, keepdim=keepdim):
+                    res = fun(X, dim=dim, keepdim=keepdim)
+                    self.assertEqual(res.shape, X.sum(dim=dim, keepdim=keepdim).shape)
+                    self.assertTrue(res.isneginf().all())
+
+            # exact agreement with torch.logsumexp
+            self.assertTrue(torch.equal(logsumexp(X, dim=1), torch.logsumexp(X, dim=1)))
+
+            # reducing a non-empty dim of an otherwise empty tensor is unaffected
+            self.assertEqual(logsumexp(X, dim=-1).shape, torch.Size([3, 0]))
+
+            # gradients remain defined
+            X = torch.empty(2, 0, dtype=dtype, device=self.device, requires_grad=True)
+            logsumexp(X, dim=-1).sum().backward()
+            self.assertEqual(X.grad.shape, X.shape)
+            self.assertTrue(torch.isfinite(X.grad).all())
 
 
 class TestSmoothNonLinearities(BotorchTestCase):


### PR DESCRIPTION
## Motivation

Fixes #3335.

qLogExpectedHypervolumeImprovement raises `IndexError: amax(): Expected reduction dim -1 to have non-zero size` when the box decomposition it receives has zero hypercells. This happens with an approximate decomposition (alpha > 0) when there are many objectives and few observed points, so every cell overlapping the pareto front gets pruned. The legacy qExpectedHypervolumeImprovement returns 0 for the same input.

The root cause is in `safe_math._inf_max_helper`, which backs `logsumexp`, `fatmax` and `smooth_amax`: the amax pre step does not accept zero size reduction dims, while plain `torch.logsumexp` returns -inf for them.

## Changes

- `safe_math._inf_max_helper` returns -inf for zero size reduction dims, keeping the result connected to the autograd graph so gradients stay defined. This restores parity with `torch.logsumexp` and is the correct limit for the smooth max approximations, since the maximum over an empty set is -inf.
- `initialize_q_batch` falls back to random initial conditions with `BadInitialCandidatesWarning` when acquisition values are non finite, instead of crashing in `torch.multinomial` on nan sampling weights. Without this, `optimize_acqf` still failed downstream whenever the acquisition function evaluates to -inf for all raw samples.
- The fused C++ kernel dispatch in `_compute_log_qehvi` skips the zero cell case. There is nothing to fuse and the Python path handles it directly.

With these three pieces the full `optimize_acqf` pipeline degrades gracefully on an empty decomposition: qLogEHVI evaluates to -inf, the initializer warns and picks random initial conditions, and finite candidates come back, matching what users get from the legacy qEHVI today.

## Test plan

- New `TestEmptyReductionDims` in test_safe_math.py: logsumexp, fatmax and smooth_amax on zero size dims, int and tuple dims, keepdim on and off, exact agreement with `torch.logsumexp`, and finite gradients.
- New case in `test_initialize_q_batch`: all -inf acquisition values warn and return random initial conditions instead of raising.
- New regression test in test_logei.py: a deterministic 7 objective, 3 point input whose approximate decomposition (alpha=0.1) prunes every cell; qLogEHVI evaluates to -inf for both fat=True and fat=False.
- ufmt and flake8 clean on all changed files. `test_gen_value_function_initial_conditions` fails for me on current main with and without this change when running the whole file, so it appears unrelated.
