### PR TITLE
Compute CategoricalKernel diagonal without materializing the pairwise matrix

### DIFF
--- a/botorch/models/kernels/categorical.py
+++ b/botorch/models/kernels/categorical.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from botorch.exceptions.errors import BotorchTensorDimensionError
 from gpytorch.kernels.kernel import Kernel
 from torch import Tensor
 
@@ -30,11 +31,14 @@ class CategoricalKernel(Kernel):
         last_dim_is_batch: bool = False,
     ) -> Tensor:
         if diag:
+            if x1.shape[-2] != x2.shape[-2]:
+                raise BotorchTensorDimensionError(
+                    "diag=True requires `x1` and `x2` to have the same number of "
+                    f"points, but got {x1.shape[-2]} and {x2.shape[-2]}."
+                )
             # Comparing rows directly avoids the `n1 x n2 x d` cross-product that would
-            # otherwise be built and then discarded. `torch.diagonal` yields
-            # `min(n1, n2)` entries for uneven inputs, so truncate to match.
-            n = min(x1.shape[-2], x2.shape[-2])
-            dists = (x1[..., :n, :] != x2[..., :n, :]) / self.lengthscale
+            # otherwise be built and then discarded.
+            dists = (x1 != x2) / self.lengthscale
             if last_dim_is_batch:
                 return torch.exp(-dists.transpose(-1, -2))
             return torch.exp(-dists.mean(-1))

--- a/botorch/models/kernels/categorical.py
+++ b/botorch/models/kernels/categorical.py
@@ -29,13 +29,20 @@ class CategoricalKernel(Kernel):
         diag: bool = False,
         last_dim_is_batch: bool = False,
     ) -> Tensor:
+        if diag:
+            # Comparing rows directly avoids the `n1 x n2 x d` cross-product that would
+            # otherwise be built and then discarded. `torch.diagonal` yields
+            # `min(n1, n2)` entries for uneven inputs, so truncate to match.
+            n = min(x1.shape[-2], x2.shape[-2])
+            dists = (x1[..., :n, :] != x2[..., :n, :]) / self.lengthscale
+            if last_dim_is_batch:
+                return torch.exp(-dists.transpose(-1, -2))
+            return torch.exp(-dists.mean(-1))
+
         delta = x1.unsqueeze(-2) != x2.unsqueeze(-3)
         dists = delta / self.lengthscale.unsqueeze(-2)
         if last_dim_is_batch:
             dists = dists.transpose(-3, -1)
         else:
             dists = dists.mean(-1)
-        res = torch.exp(-dists)
-        if diag:
-            res = torch.diagonal(res, dim1=-1, dim2=-2)
-        return res
+        return torch.exp(-dists)

--- a/test/models/kernels/test_categorical.py
+++ b/test/models/kernels/test_categorical.py
@@ -8,6 +8,19 @@ import torch
 from botorch.models.kernels.categorical import CategoricalKernel
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+class LargestTensorRecorder(TorchDispatchMode):
+    """Records the element count of the largest tensor allocated in the block."""
+
+    max_numel = 0
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        out = func(*args, **(kwargs or {}))
+        if isinstance(out, torch.Tensor):
+            self.max_numel = max(self.max_numel, out.numel())
+        return out
 
 
 class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
@@ -87,6 +100,51 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
         # batch_dims + diag
         res = kernel(x1, x2, last_dim_is_batch=True).diagonal()
         self.assertAllClose(res, torch.diagonal(actual, dim1=-1, dim2=-2))
+
+    def test_diag_matches_dense_diagonal(self):
+        cases = {
+            "batched": {"batch_shape": torch.Size([2])},
+            "ard": {"ard_num_dims": 3},
+            "batched ard": {"batch_shape": torch.Size([2]), "ard_num_dims": 3},
+        }
+        for name, kwargs in cases.items():
+            for n1, n2 in [(4, 4), (5, 3), (1, 6)]:
+                for last_dim_is_batch in [False, True]:
+                    with self.subTest(name, n1=n1, n2=n2, ldib=last_dim_is_batch):
+                        kernel = CategoricalKernel(**kwargs).to(dtype=torch.double)
+                        # randomized so a misaligned lengthscale axis cannot cancel out
+                        with torch.no_grad():
+                            kernel.raw_lengthscale.copy_(
+                                torch.rand_like(kernel.raw_lengthscale)
+                            )
+                        batch = kwargs.get("batch_shape", torch.Size([]))
+                        x1 = torch.randint(3, size=(*batch, n1, 3)).to(torch.double)
+                        x2 = torch.randint(3, size=(*batch, n2, 3)).to(torch.double)
+
+                        dense = kernel.forward(
+                            x1, x2, last_dim_is_batch=last_dim_is_batch
+                        )
+                        expected = torch.diagonal(dense, dim1=-1, dim2=-2)
+                        res = kernel.forward(
+                            x1, x2, diag=True, last_dim_is_batch=last_dim_is_batch
+                        )
+                        self.assertEqual(res.shape, expected.shape)
+                        self.assertAllClose(res, expected)
+
+    def test_diag_does_not_materialize_pairwise_matrix(self):
+        # the diagonal should stay linear in n rather than allocating `n x n x d`
+        n, d = 512, 3
+        kernel = CategoricalKernel(ard_num_dims=d).to(dtype=torch.double)
+        x1 = torch.randint(3, size=(n, d)).to(dtype=torch.double)
+        x2 = torch.randint(3, size=(n, d)).to(dtype=torch.double)
+
+        recorder = LargestTensorRecorder()
+        with recorder:
+            kernel.forward(x1, x2, diag=True)
+
+        budget = 4 * n * d
+        self.assertLess(budget, n * n)
+        self.assertLessEqual(recorder.max_numel, budget)
 
     def test_ard_batch(self):
         x1 = torch.tensor(

--- a/test/models/kernels/test_categorical.py
+++ b/test/models/kernels/test_categorical.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from botorch.exceptions.errors import BotorchTensorDimensionError
 from botorch.models.kernels.categorical import CategoricalKernel
 from botorch.utils.testing import BotorchTestCase
 from gpytorch.test.base_kernel_test_case import BaseKernelTestCase
@@ -108,9 +109,9 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
             "batched ard": {"batch_shape": torch.Size([2]), "ard_num_dims": 3},
         }
         for name, kwargs in cases.items():
-            for n1, n2 in [(4, 4), (5, 3), (1, 6)]:
+            for n in [1, 4]:
                 for last_dim_is_batch in [False, True]:
-                    with self.subTest(name, n1=n1, n2=n2, ldib=last_dim_is_batch):
+                    with self.subTest(name, n=n, ldib=last_dim_is_batch):
                         kernel = CategoricalKernel(**kwargs).to(dtype=torch.double)
                         # randomized so a misaligned lengthscale axis cannot cancel out
                         with torch.no_grad():
@@ -118,8 +119,8 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
                                 torch.rand_like(kernel.raw_lengthscale)
                             )
                         batch = kwargs.get("batch_shape", torch.Size([]))
-                        x1 = torch.randint(3, size=(*batch, n1, 3)).to(torch.double)
-                        x2 = torch.randint(3, size=(*batch, n2, 3)).to(torch.double)
+                        x1 = torch.randint(3, size=(*batch, n, 3)).to(torch.double)
+                        x2 = torch.randint(3, size=(*batch, n, 3)).to(torch.double)
 
                         dense = kernel.forward(
                             x1, x2, last_dim_is_batch=last_dim_is_batch
@@ -130,6 +131,15 @@ class TestCategoricalKernel(BotorchTestCase, BaseKernelTestCase):
                         )
                         self.assertEqual(res.shape, expected.shape)
                         self.assertAllClose(res, expected)
+
+    def test_diag_raises_on_mismatched_shapes(self):
+        kernel = CategoricalKernel(ard_num_dims=3).to(dtype=torch.double)
+        x1 = torch.randint(3, size=(5, 3)).to(dtype=torch.double)
+        x2 = torch.randint(3, size=(4, 3)).to(dtype=torch.double)
+        with self.assertRaisesRegex(BotorchTensorDimensionError, "5 and 4"):
+            kernel.forward(x1, x2, diag=True)
+        # the full matrix is well defined for uneven inputs
+        self.assertEqual(kernel.forward(x1, x2).shape, torch.Size([5, 4]))
 
     def test_diag_does_not_materialize_pairwise_matrix(self):
         # the diagonal should stay linear in n rather than allocating `n x n x d`


### PR DESCRIPTION
## Motivation

`CategoricalKernel.forward` builds the full `n1 x n2 x d` comparison tensor and only
reduces it to the diagonal at the end, so asking for `n` diagonal values costs `n^2 * d`
elements. `diag=True` is exactly what `LazyEvaluatedKernelTensor._diagonal` requests, so
this sits on the hot path for posterior variances on models with categorical features.

Comparing the rows elementwise gives the same values from an `n x d` intermediate. Peak
allocation drops by a factor of `n`:

| n (d=3, float64) | peak before | peak after | time before | time after |
|---|---|---|---|---|
| 1000 | 22.89 MB | 0.023 MB | 8.22 ms | 0.019 ms |
| 5000 | 572.20 MB | 0.114 MB | 247.01 ms | 0.132 ms |

The dense (`diag=False`) branch is untouched — it needs every entry.

`diag=True` with differing row counts now raises `BotorchTensorDimensionError` rather
than silently returning the `min(n1, n2)` entries `torch.diagonal` used to produce
(per review). That path was already broken: GPyTorch's
`LazyEvaluatedKernelTensor._diagonal` expects `n1` entries back, so the old result would
fail its debug shape check anyway.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. `ufmt` and `flake8` are clean.

## Test Plan

`pytest test/models/` — 422 passed (the one failure, `test_with_different_batch_shapes`,
is a missing-JAX `ImportError` that reproduces on an unmodified checkout).

Three tests added:

- `test_diag_matches_dense_diagonal` — compares `diag=True` against `torch.diagonal` of
  the dense result across batched/ARD kernels and both `last_dim_is_batch` values.
  Lengthscales are randomized so a misaligned lengthscale axis cannot cancel out.
- `test_diag_raises_on_mismatched_shapes` — covers the new error, and checks the dense
  path still accepts uneven inputs.
- `test_diag_does_not_materialize_pairwise_matrix` — bounds the largest tensor allocated
  during a diagonal request. Fails on the current implementation
  (`786432 not less than or equal to 6144`), so it guards against regressing to the
  dense path.

I also fuzzed the new implementation against the old one over 724 configurations (batch
shapes, row counts, `d`, float32/float64, ARD, and both flags): outputs are bitwise
identical (`torch.equal`) in value and shape.

## Related PRs

None.
