### PR TITLE
Fix Gumbel max-value sampling for multiple batch dimensions

### DIFF
--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -996,8 +996,8 @@ def _sample_max_value_Gumbel(
     # Flatten all posterior batch dimensions for the scalar quantile searches.
     # mu, sigma are now n X num_batches, where num_batches is one for an
     # unbatched posterior.
-    mu = mu.squeeze(-1).reshape(-1, n).transpose(0, 1)
-    sigma = sigma.squeeze(-1).reshape(-1, n).transpose(0, 1)
+    mu = mu.reshape(-1, n).transpose(0, 1)
+    sigma = sigma.reshape(-1, n).transpose(0, 1)
 
     # bisect search to find the quantiles 25, 50, 75
     lo = (mu - 3 * sigma).min(dim=0).values

--- a/botorch/acquisition/max_value_entropy_search.py
+++ b/botorch/acquisition/max_value_entropy_search.py
@@ -938,8 +938,8 @@ def _sample_max_value_Thompson(
 
     Args:
         model: A fitted single-outcome model.
-        candidate_set: A ``n x d`` Tensor including ``n`` candidate points to
-            discretize the design space.
+        candidate_set: A ``batch_shape x n x d`` Tensor including ``n`` candidate
+            points per batch to discretize the design space.
         num_samples: Number of max value samples.
         posterior_transform: A PosteriorTransform. If using a multi-output model,
             a PosteriorTransform that transforms the multi-output posterior into a
@@ -947,7 +947,8 @@ def _sample_max_value_Thompson(
         maximize: If True, consider the problem a maximization problem.
 
     Returns:
-        A ``num_samples x 1`` Tensor of posterior max value samples.
+        A ``num_samples x batch_shape`` Tensor of posterior max value samples,
+        where ``batch_shape`` is ``(1,)`` for an unbatched posterior.
     """
     posterior = model.posterior(candidate_set, posterior_transform=posterior_transform)
     weight = 1.0 if maximize else -1.0
@@ -973,8 +974,8 @@ def _sample_max_value_Gumbel(
 
     Args:
         model: A fitted single-outcome model.
-        candidate_set: A ``n x d`` Tensor including ``n`` candidate points to
-            discretize the design space.
+        candidate_set: A ``batch_shape x n x d`` Tensor including ``n`` candidate
+            points per batch to discretize the design space.
         num_samples: Number of max value samples.
         posterior_transform: A PosteriorTransform. If using a multi-output model,
             a PosteriorTransform that transforms the multi-output posterior into a
@@ -982,27 +983,30 @@ def _sample_max_value_Gumbel(
         maximize: If True, consider the problem a maximization problem.
 
     Returns:
-        A ``num_samples x num_fantasies`` Tensor of posterior max value samples.
+        A ``num_samples x batch_shape`` Tensor of posterior max value samples,
+        where ``batch_shape`` is ``(1,)`` for an unbatched posterior.
     """
     # define the approximate CDF for the max value under the independence assumption
     posterior = model.posterior(candidate_set, posterior_transform=posterior_transform)
     weight = 1.0 if maximize else -1.0
     mu = weight * posterior.mean
     sigma = posterior.variance.clamp_min(1e-8).sqrt()
-    # mu, sigma is (num_fantasies) X n X 1
-    if len(mu.shape) == 3 and mu.shape[-1] == 1:
-        mu = mu.squeeze(-1).T
-        sigma = sigma.squeeze(-1).T
-    # mu, sigma is now n X num_fantasies or n X 1
+    batch_shape = mu.shape[:-2]
+    n = mu.shape[-2]
+    # Flatten all posterior batch dimensions for the scalar quantile searches.
+    # mu, sigma are now n X num_batches, where num_batches is one for an
+    # unbatched posterior.
+    mu = mu.squeeze(-1).reshape(-1, n).transpose(0, 1)
+    sigma = sigma.squeeze(-1).reshape(-1, n).transpose(0, 1)
 
     # bisect search to find the quantiles 25, 50, 75
     lo = (mu - 3 * sigma).min(dim=0).values
     hi = (mu + 5 * sigma).max(dim=0).values
-    num_fantasies = mu.shape[1]
+    num_batches = mu.shape[1]
     device = candidate_set.device
     dtype = candidate_set.dtype
-    quantiles = torch.zeros(num_fantasies, 3, device=device, dtype=dtype)
-    for i in range(num_fantasies):
+    quantiles = torch.zeros(num_batches, 3, device=device, dtype=dtype)
+    for i in range(num_batches):
         lo_, hi_ = lo[i], hi[i]
         N = norm(mu[:, i].numpy(force=True), sigma[:, i].numpy(force=True))
         quantiles[i, :] = torch.tensor(
@@ -1012,7 +1016,7 @@ def _sample_max_value_Gumbel(
             ]
         )
     q25, q50, q75 = quantiles[:, 0], quantiles[:, 1], quantiles[:, 2]
-    # q25, q50, q75 are 1 dimensional tensor with size of either 1 or num_fantasies
+    # q25, q50, q75 are one-dimensional tensors of size num_batches.
 
     # parameter fitting based on matching percentiles for the Gumbel distribution
     b = (q25 - q75) / (log(log(4.0 / 3.0)) - log(log(4.0)))
@@ -1023,4 +1027,5 @@ def _sample_max_value_Gumbel(
     eps = torch.rand(*sample_shape, device=device, dtype=dtype)
     max_values = a - b * eps.log().mul(-1.0).log()
 
-    return max_values  # num_samples x 1
+    output_batch_shape = batch_shape or torch.Size([1])
+    return max_values.reshape(num_samples, *output_batch_shape)

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -398,9 +398,15 @@ class TestMaxValueEntropySearch(BotorchTestCase):
                 train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
                 train_Y=torch.rand(10, 1, device=self.device, dtype=dtype),
             )
-            candidate_set = torch.rand(3, 10, 2, device=self.device, dtype=dtype)
-            samples = sampler(model=model, candidate_set=candidate_set, num_samples=5)
-            self.assertEqual(samples.shape, torch.Size([5, 3]))
+            for batch_shape in ((), (3,), (2, 3)):
+                candidate_set = torch.rand(
+                    *batch_shape, 10, 2, device=self.device, dtype=dtype
+                )
+                samples = sampler(
+                    model=model, candidate_set=candidate_set, num_samples=5
+                )
+                expected_batch_shape = batch_shape or (1,)
+                self.assertEqual(samples.shape, torch.Size([5, *expected_batch_shape]))
 
             # Test with multi-output model w/ transform.
             model = ModelListGP(model, model)
@@ -413,7 +419,7 @@ class TestMaxValueEntropySearch(BotorchTestCase):
                 num_samples=5,
                 posterior_transform=pt,
             )
-            self.assertEqual(samples.shape, torch.Size([5, 3]))
+            self.assertEqual(samples.shape, torch.Size([5, 2, 3]))
 
     def test_sample_max_value_Gumbel(self):
         self._test_max_value_sampler_base(sampler=_sample_max_value_Gumbel)

--- a/test/acquisition/test_max_value_entropy_search.py
+++ b/test/acquisition/test_max_value_entropy_search.py
@@ -424,5 +424,30 @@ class TestMaxValueEntropySearch(BotorchTestCase):
     def test_sample_max_value_Gumbel(self):
         self._test_max_value_sampler_base(sampler=_sample_max_value_Gumbel)
 
+    def test_sample_max_value_Gumbel_batched_matches_loop(self):
+        for dtype in (torch.float, torch.double):
+            torch.manual_seed(7)
+            model = SingleTaskGP(
+                train_X=torch.rand(10, 2, device=self.device, dtype=dtype),
+                train_Y=torch.rand(10, 1, device=self.device, dtype=dtype),
+            )
+            candidate_set = torch.rand(2, 3, 10, 2, device=self.device, dtype=dtype)
+
+            torch.manual_seed(11)
+            batched_samples = _sample_max_value_Gumbel(
+                model=model, candidate_set=candidate_set, num_samples=5
+            )
+            loop_samples = []
+            for candidates in candidate_set.reshape(-1, 10, 2):
+                torch.manual_seed(11)
+                loop_samples.append(
+                    _sample_max_value_Gumbel(
+                        model=model, candidate_set=candidates, num_samples=5
+                    )[:, 0]
+                )
+            expected = torch.stack(loop_samples, dim=-1).reshape(5, 2, 3)
+
+            self.assertAllClose(batched_samples, expected)
+
     def test_sample_max_value_Thompson(self):
         self._test_max_value_sampler_base(sampler=_sample_max_value_Thompson)


### PR DESCRIPTION
## Motivation

Fixes #3352.

The Gumbel max-value sampler only transposed posterior means and variances when they were exactly rank 3, then treated `mu.shape[1]` as the sole batch dimension. With two or more posterior batch dimensions, SciPy's scalar root finder received array-valued bounds and raised `RuntimeError: Unable to parse arguments`.

This change flattens all posterior batch dimensions for the scalar quantile searches and restores the original batch shape on the sampled values. It also extends the shared sampler regression to unbatched, one-dimensional-batch, and two-dimensional-batch candidate sets. Thompson and Gumbel sampling now expose the same output-shape behavior.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- `python -m pytest test/acquisition/test_max_value_entropy_search.py -q` ? 8 passed
- `python -m ufmt check botorch/acquisition/max_value_entropy_search.py test/acquisition/test_max_value_entropy_search.py` ? 2 files already formatted
- `python -m flake8 botorch/acquisition/max_value_entropy_search.py test/acquisition/test_max_value_entropy_search.py` ? passed
- `git diff --check` ? passed
- Manual CPU comparison: a posterior with batch shape `(2, 3)` now returns finite Gumbel and Thompson samples with shape `(5, 2, 3)`; each Gumbel batch slice matches an independent call under the same seed.

The pristine `main` reproduction fails in `_sample_max_value_Gumbel` with `RuntimeError: Unable to parse arguments` while the Thompson sampler returns `(5, 2, 3)`.

## Related PRs

None. Targeted issue, pull request, and commit searches found no existing report or fix for multiple Gumbel posterior batch dimensions. The original implementation came from #298 and the later sampler refactor was #734; neither discusses this case.

## AI assistance

This pull request was prepared with OpenAI Codex assistance. I reviewed the reproduction, implementation, relevant project history, and reported test results before submission.
