### PR TITLE
Add GIT-BO with SingleTaskGP and PFNv2 surrogates

### DIFF
--- a/botorch_community/acquisition/__init__.py
+++ b/botorch_community/acquisition/__init__.py
@@ -11,6 +11,13 @@ from botorch_community.acquisition.bayesian_active_learning import (
     qHyperparameterInformedPredictiveExploration,
     qStatisticalDistanceActiveLearning,
 )
+from botorch_community.acquisition.gitbo import (
+    compute_active_subspace,
+    gitbo_step,
+    GITBOStepResult,
+    quantile_ucb,
+    sample_subspace_candidates,
+)
 
 # NOTE: This import is needed to register the input constructors.
 from botorch_community.acquisition.input_constructors import (  # noqa F401
@@ -24,6 +31,9 @@ from botorch_community.acquisition.rei import (
 from botorch_community.acquisition.scorebo import qSelfCorrectingBayesianOptimization
 
 __all__ = [
+    "compute_active_subspace",
+    "gitbo_step",
+    "GITBOStepResult",
     "LocalEntropySearch",
     "LogRegionalExpectedImprovement",
     "qAlphaEntropySearch",
@@ -34,4 +44,6 @@ __all__ = [
     "qLogRegionalExpectedImprovement",
     "qSelfCorrectingBayesianOptimization",
     "qStatisticalDistanceActiveLearning",
+    "quantile_ucb",
+    "sample_subspace_candidates",
 ]

--- a/botorch_community/acquisition/gitbo.py
+++ b/botorch_community/acquisition/gitbo.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Gradient-Informed Bayesian Optimization (GIT-BO).
+
+GIT-BO [yu2025gitbo]_ is a high-dimensional Bayesian optimization strategy
+that aligns the search with a low-dimensional *active subspace*
+[constantine2014active]_ estimated from the surrogate model's own
+predictive-mean input gradients. Each iteration:
+
+1. A large discrete candidate set is scored with a quantile-based UCB
+   acquisition (the posterior quantile at level ``quantile``; for a Gaussian
+   posterior this equals the classic UCB ``mu + sqrt(beta) * sigma`` with
+   ``beta = z_quantile**2``).
+2. During the same forward pass, the Jacobian ``G`` of the posterior mean
+   with respect to the candidate inputs is obtained with a single
+   ``torch.autograd.grad`` call.
+3. On the next iteration, the empirical second-moment matrix
+   ``H = G^T G / N`` is eigendecomposed and new candidates are sampled
+   inside the span of the top eigenvectors (the gradient-informed
+   subspace), centered at the mean of the evaluated points.
+
+The first iteration (no gradient information yet) falls back to quasi-random
+Sobol candidates over the full design space.
+
+The implementation is surrogate-agnostic: any BoTorch ``Model`` whose
+posterior mean is differentiable with respect to the test inputs can be used,
+including ``SingleTaskGP`` and the community ``PFNModel``
+(``botorch_community.models.prior_fitted_network``). The scoring is
+deliberately implemented as plain functions rather than an
+``AcquisitionFunction`` subclass: GIT-BO evaluates a fixed discrete candidate
+set pointwise (it is not optimized with ``optimize_acqf``), and the
+input-gradient Jacobian is a second output that the ``forward(X) -> Tensor``
+acquisition interface cannot express.
+
+References
+
+.. [yu2025gitbo]
+    R. T.-Y. Yu, C. Picard, F. Ahmed. GIT-BO: High-Dimensional Bayesian
+    Optimization with Tabular Foundation Models. International Conference
+    on Learning Representations, 2026. arXiv:2505.20685.
+.. [constantine2014active]
+    P. G. Constantine, E. Dow, Q. Wang. Active Subspace Methods in Theory
+    and Practice: Applications to Kriging Surfaces. SIAM Journal on
+    Scientific Computing, 2014.
+
+Contributor: rosenyu304
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+from botorch.models.model import Model
+from botorch.utils.sampling import draw_sobol_samples
+from torch import Tensor
+
+
+class GITBOStepResult(NamedTuple):
+    """Result of one GIT-BO iteration.
+
+    Attributes:
+        candidate: A ``1 x d`` tensor with the candidate maximizing the
+            acquisition, to be evaluated next.
+        acq_values: A ``num_candidates``-dim tensor of quantile-UCB scores.
+        candidate_set: A ``num_candidates x d`` tensor of the scored points.
+        gradients: A ``num_candidates x d`` tensor with the posterior-mean
+            input gradients. Pass this to the next ``gitbo_step`` call to
+            construct the gradient-informed subspace.
+        subspace: A ``d x r`` tensor of subspace basis vectors used to sample
+            this step's candidates, or ``None`` on the Sobol (first) step.
+        eigenvalues: A ``d``-dim tensor of eigenvalues of ``H = G^T G / N``
+            in descending order, or ``None`` on the Sobol (first) step.
+    """
+
+    candidate: Tensor
+    acq_values: Tensor
+    candidate_set: Tensor
+    gradients: Tensor
+    subspace: Tensor | None
+    eigenvalues: Tensor | None
+
+
+def quantile_ucb(
+    model: Model,
+    X: Tensor,
+    quantile: float = 0.975,
+    compute_mean_gradients: bool = True,
+    eval_in_q_batch: bool = False,
+    batch_limit: int | None = None,
+) -> tuple[Tensor, Tensor | None]:
+    r"""Score candidates with a posterior-quantile UCB acquisition.
+
+    The score of a candidate ``x`` is the ``quantile``-level quantile of the
+    posterior over ``f(x)``. For a Gaussian posterior this is exactly the
+    classic UCB ``mu + sqrt(beta) * sigma`` with ``beta = z_quantile**2``
+    (e.g. ``quantile=0.975`` corresponds to ``beta ~= 3.84``). Posteriors
+    that implement ``quantile`` (e.g. ``GPyTorchPosterior``) or ``icdf``
+    (e.g. ``BoundedRiemannPosterior``) are supported.
+
+    As a side product, the Jacobian of the posterior mean with respect to
+    ``X`` is computed with a single ``torch.autograd.grad`` call. This is
+    valid because each candidate is evaluated as an independent test point,
+    so the gradient of the summed means recovers the per-candidate rows.
+
+    Args:
+        model: A fitted single-outcome model. Its posterior mean must be
+            differentiable with respect to the test inputs if
+            ``compute_mean_gradients=True``.
+        X: A ``num_candidates x d`` tensor of candidate points.
+        quantile: The quantile level in (0, 1) used as the UCB score.
+        compute_mean_gradients: If ``True``, also return the
+            ``num_candidates x d`` posterior-mean input gradients.
+        eval_in_q_batch: If ``True``, evaluate the posterior on ``X``
+            directly so all candidates form one q-batch. This is the
+            memory-efficient layout for PFN models, which then encode the
+            training context only once. If ``False``, the posterior is
+            evaluated on ``X.unsqueeze(-2)`` (``num_candidates x 1 x d``),
+            the appropriate layout for GP models, where it yields
+            independent ``q=1`` marginal posteriors.
+        batch_limit: If given, candidates are pushed through the posterior
+            in chunks of at most ``batch_limit`` points to bound memory.
+
+    Returns:
+        A two-element tuple containing:
+
+        - A ``num_candidates``-dim tensor of acquisition scores (detached).
+        - A ``num_candidates x d`` tensor of posterior-mean gradients, or
+          ``None`` if ``compute_mean_gradients=False``.
+    """
+    if X.dim() != 2:
+        raise ValueError(f"X must be `num_candidates x d`, got shape {X.shape}.")
+    if not 0.0 < quantile < 1.0:
+        raise ValueError(f"quantile must be in (0, 1), got {quantile}.")
+    num_candidates = X.shape[0]
+    chunk_size = num_candidates if batch_limit is None else batch_limit
+    if chunk_size < 1:
+        raise ValueError(f"batch_limit must be positive, got {batch_limit}.")
+
+    all_scores, all_grads = [], []
+    for X_chunk in X.split(chunk_size):
+        X_eval = X_chunk.detach().clone().requires_grad_(compute_mean_gradients)
+        with torch.enable_grad() if compute_mean_gradients else torch.no_grad():
+            posterior = model.posterior(
+                X_eval if eval_in_q_batch else X_eval.unsqueeze(-2)
+            )
+            mean = posterior.mean
+            if compute_mean_gradients:
+                grad = torch.autograd.grad(mean.sum(), X_eval)[0]
+                all_grads.append(grad.detach())
+        with torch.no_grad():
+            all_scores.append(_posterior_quantile(posterior, quantile).reshape(-1))
+    scores = torch.cat(all_scores)
+    gradients = torch.cat(all_grads) if compute_mean_gradients else None
+    return scores, gradients
+
+
+def _posterior_quantile(posterior, quantile: float) -> Tensor:
+    """Evaluate the marginal posterior quantile, via `quantile` or `icdf`."""
+    q = torch.tensor(quantile, dtype=posterior.dtype, device=posterior.device)
+    try:
+        return posterior.quantile(q)
+    except (NotImplementedError, AttributeError):
+        return posterior.icdf(quantile)
+
+
+def compute_active_subspace(
+    gradients: Tensor,
+    rank: int | float = 15,
+) -> tuple[Tensor, Tensor]:
+    r"""Compute the gradient-informed (active) subspace.
+
+    Forms the empirical second-moment matrix ``H = G^T G / N`` of the
+    posterior-mean gradients ``G`` and eigendecomposes it. The
+    eigendecomposition is performed in double precision for numerical
+    stability and the results are cast back to the input dtype.
+
+    Args:
+        gradients: An ``N x d`` tensor of posterior-mean input gradients.
+        rank: If an integer ``>= 1``, the fixed subspace dimension (clamped
+            to ``d``). If a float in ``(0, 1)``, the smallest rank whose
+            cumulative eigenvalue ratio reaches that fraction (recomputed on
+            every call). Non-integer values ``>= 1`` are truncated to
+            integers.
+
+    Returns:
+        A two-element tuple containing:
+
+        - A ``d x r`` tensor whose columns are the top eigenvectors of ``H``.
+        - A ``d``-dim tensor of all eigenvalues of ``H`` in descending order.
+    """
+    if gradients.dim() != 2:
+        raise ValueError(
+            f"gradients must be an `N x d` tensor, got shape {gradients.shape}."
+        )
+    if rank <= 0:
+        raise ValueError(f"rank must be positive, got {rank}.")
+    d = gradients.shape[-1]
+    G = gradients.to(dtype=torch.double)
+    H = G.transpose(-2, -1) @ G / G.shape[0]
+    eigenvalues, eigenvectors = torch.linalg.eigh(H)  # ascending
+    eigenvalues = eigenvalues.flip(-1).clamp_min(0.0)
+    eigenvectors = eigenvectors.flip(-1)
+    if rank < 1:  # percent-variance mode
+        total = eigenvalues.sum()
+        if total <= 0:
+            r = 1
+        else:
+            cumulative_ratio = eigenvalues.cumsum(-1) / total
+            r = int((cumulative_ratio < rank).sum().item()) + 1
+    else:
+        r = int(rank)
+    r = min(r, d)
+    return (
+        eigenvectors[:, :r].to(dtype=gradients.dtype),
+        eigenvalues.to(dtype=gradients.dtype),
+    )
+
+
+def sample_subspace_candidates(
+    subspace: Tensor,
+    origin: Tensor,
+    bounds: Tensor,
+    num_candidates: int = 5000,
+    scale: float = 0.2,
+) -> Tensor:
+    r"""Sample candidate points inside a low-dimensional subspace.
+
+    Candidates are ``x = origin + alpha @ subspace^T`` with subspace
+    coordinates ``alpha ~ Uniform(-scale, scale)^r``, and are then clamped
+    elementwise into ``bounds`` (out-of-box samples are projected onto the
+    box faces).
+
+    Args:
+        subspace: A ``d x r`` tensor of subspace basis vectors.
+        origin: A ``d``-dim tensor with the subspace origin. GIT-BO uses the
+            mean of all evaluated points.
+        bounds: A ``2 x d`` tensor of lower and upper box bounds.
+        num_candidates: The number of candidates to sample.
+        scale: The half-width of the uniform sampling box in subspace
+            coordinates. Since the basis vectors have unit norm, the maximal
+            displacement from the origin is ``scale * sqrt(r)``.
+
+    Returns:
+        A ``num_candidates x d`` tensor of candidate points.
+    """
+    r = subspace.shape[-1]
+    alpha = (
+        torch.rand(num_candidates, r, dtype=subspace.dtype, device=subspace.device) * 2
+        - 1
+    ) * scale
+    X = origin.unsqueeze(0) + alpha @ subspace.transpose(-2, -1)
+    return torch.clamp(X, bounds[0], bounds[1])
+
+
+def gitbo_step(
+    model: Model,
+    train_X: Tensor,
+    gradients: Tensor | None,
+    bounds: Tensor,
+    num_candidates: int = 5000,
+    rank: int | float = 15,
+    scale: float = 0.2,
+    quantile: float = 0.975,
+    eval_in_q_batch: bool = False,
+    batch_limit: int | None = None,
+) -> GITBOStepResult:
+    r"""Run one GIT-BO candidate-generation and scoring step.
+
+    If ``gradients`` is ``None`` (first iteration) or numerically zero, the
+    candidate set is drawn with scrambled Sobol sampling over ``bounds``.
+    Otherwise candidates are sampled in the gradient-informed subspace of
+    the previous step's gradients, centered at ``train_X.mean(0)``.
+
+    This function is stateless: the caller owns the training data and the
+    surrogate (fit or condition the model on all data before each call — the
+    model itself is not refit here) and carries ``result.gradients`` into
+    the next call, so the subspace always derives from the previous
+    iteration's gradients, as in [yu2025gitbo]_.
+
+    Args:
+        model: A fitted single-outcome model over the current training data.
+        train_X: An ``n x d`` tensor of evaluated points; its mean is the
+            subspace origin.
+        gradients: The ``gradients`` field of the previous step's result, or
+            ``None`` to draw Sobol candidates.
+        bounds: A ``2 x d`` tensor of box bounds for the design space.
+        num_candidates: The number of candidates to generate and score.
+        rank: Subspace rank; see ``compute_active_subspace``.
+        scale: Subspace sampling half-width; see
+            ``sample_subspace_candidates``.
+        quantile: Quantile level of the UCB score; see ``quantile_ucb``.
+        eval_in_q_batch: Posterior batching layout; see ``quantile_ucb``.
+            Use ``True`` for PFN models and ``False`` for GP models.
+        batch_limit: Optional chunk size for posterior evaluation; see
+            ``quantile_ucb``.
+
+    Returns:
+        A ``GITBOStepResult`` with the argmax candidate, the scores, the
+        candidate set, the new gradients, and the subspace used (if any).
+    """
+    if bounds.dim() != 2 or bounds.shape[0] != 2:
+        raise ValueError(f"bounds must be a `2 x d` tensor, got shape {bounds.shape}.")
+    subspace = eigenvalues = None
+    if gradients is None or not gradients.norm().item() > 0:
+        candidate_set = draw_sobol_samples(
+            bounds=bounds, n=num_candidates, q=1
+        ).squeeze(-2)
+    else:
+        subspace, eigenvalues = compute_active_subspace(gradients, rank=rank)
+        candidate_set = sample_subspace_candidates(
+            subspace=subspace,
+            origin=train_X.mean(dim=0),
+            bounds=bounds,
+            num_candidates=num_candidates,
+            scale=scale,
+        )
+    acq_values, new_gradients = quantile_ucb(
+        model=model,
+        X=candidate_set,
+        quantile=quantile,
+        compute_mean_gradients=True,
+        eval_in_q_batch=eval_in_q_batch,
+        batch_limit=batch_limit,
+    )
+    candidate = candidate_set[acq_values.argmax()].unsqueeze(0)
+    return GITBOStepResult(
+        candidate=candidate,
+        acq_values=acq_values,
+        candidate_set=candidate_set,
+        gradients=new_gradients,
+        subspace=subspace,
+        eigenvalues=eigenvalues,
+    )

--- a/botorch_community/models/tabpfn_v2.py
+++ b/botorch_community/models/tabpfn_v2.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+BoTorch model wrapper for the TabPFN v2 tabular foundation model.
+
+Built with PriorLabs-TabPFN.
+
+``TabPFNv2Model`` adapts the pretrained TabPFN v2 regressor
+[hollmann2025tabpfn]_ to the BoTorch ``Model`` interface by subclassing the
+community ``PFNModel``. TabPFN v2 differs architecturally from the
+``pfns4bo``-style PFNs that ``PFNModel`` targets (two-dimensional
+feature/sample attention, a 5000-bucket full-support bar distribution, and a
+``forward(x, y)`` interface that infers the train/test split from the length
+of ``y``), so this subclass overrides the prediction path:
+
+- the raw TabPFN v2 transformer is called sequence-first with the training
+  block followed by the test block, standardized targets, and no TabPFN
+  sklearn-style preprocessing/ensembling — inputs are expected in ``[0, 1]^d``
+  as in Bayesian optimization, which keeps the posterior differentiable with
+  respect to the test inputs (as required by, e.g., GIT-BO [yu2025gitbo]_);
+- target standardization is handled internally: ``train_Y`` is standardized
+  before the forward pass and the bar-distribution borders are mapped back to
+  the raw scale, so the returned ``BoundedRiemannPosterior`` lives in the
+  original units of ``train_Y``.
+
+The pretrained weights are downloaded from Hugging Face
+(``Prior-Labs/TabPFN-v2-reg``) on first use. They are distributed under the
+Prior Labs License (Apache 2.0 with an additional attribution provision);
+downloading requires accepting that license — see ``accept_license`` in
+``download_tabpfn_v2_regressor``. Requires the ``tabpfn`` and
+``huggingface_hub`` packages (``pip install tabpfn``).
+
+References
+
+.. [hollmann2025tabpfn]
+    N. Hollmann, S. Müller, L. Purucker, A. Krishnakumar, M. Körfer,
+    S. B. Hoo, R. T. Schirrmeister, F. Hutter. Accurate predictions on
+    small data with a tabular foundation model. Nature, 2025.
+.. [yu2025gitbo]
+    R. T.-Y. Yu, C. Picard, F. Ahmed. GIT-BO: High-Dimensional Bayesian
+    Optimization with Tabular Foundation Models. International Conference
+    on Learning Representations, 2026. arXiv:2505.20685.
+
+Contributor: rosenyu304
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from botorch.models.transforms.input import InputTransform
+from botorch_community.models.prior_fitted_network import PFNModel
+from botorch_community.models.utils.prior_fitted_network import (
+    ensure_license_accepted,
+    MODEL_LICENSES,
+)
+from torch import Tensor
+from torch.nn import Module
+
+TABPFN_V2_REG_REPO = "Prior-Labs/TabPFN-v2-reg"
+TABPFN_V2_REG_FILE = "tabpfn-v2-regressor.ckpt"
+
+
+def download_tabpfn_v2_regressor(
+    accept_license: bool = False,
+) -> tuple[Module, Module]:
+    """Download and load the pretrained TabPFN v2 regressor.
+
+    The checkpoint is fetched from Hugging Face
+    (``Prior-Labs/TabPFN-v2-reg``) with local caching via
+    ``huggingface_hub``. The weights are distributed under the Prior Labs
+    License (Apache 2.0 with an additional attribution provision), which
+    must be accepted before the download proceeds.
+
+    Args:
+        accept_license: Pass ``True`` to confirm the user accepts the model
+            license terms. Alternatively set the environment variable
+            ``BOTORCH_PFN_ACCEPT_LICENSE=1``. Without acceptance, a
+            ``RuntimeError`` with instructions is raised.
+
+    Returns:
+        A two-element tuple containing:
+
+        - The raw TabPFN v2 transformer module (in eval mode).
+        - The full-support bar distribution with the bucket ``borders``.
+    """
+    ensure_license_accepted(
+        MODEL_LICENSES[TABPFN_V2_REG_REPO], accept_license=accept_license
+    )
+    try:
+        from huggingface_hub import hf_hub_download
+        from tabpfn.model_loading import load_model
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "TabPFNv2Model requires the `tabpfn` and `huggingface_hub` "
+            "packages. Install them with `pip install tabpfn`."
+        ) from e
+    from pathlib import Path
+
+    path = hf_hub_download(repo_id=TABPFN_V2_REG_REPO, filename=TABPFN_V2_REG_FILE)
+    model, bar_distribution, _, _ = load_model(path=Path(path))
+    model.eval()
+    return model, bar_distribution
+
+
+class TabPFNv2Model(PFNModel):
+    """BoTorch model backed by the TabPFN v2 regressor.
+
+    Built with PriorLabs-TabPFN.
+    """
+
+    def __init__(
+        self,
+        train_X: Tensor,
+        train_Y: Tensor,
+        model: Module | None = None,
+        bar_distribution: Module | None = None,
+        train_Yvar: Tensor | None = None,
+        constant_model_kwargs: dict[str, Any] | None = None,
+        input_transform: InputTransform | None = None,
+        accept_license: bool = False,
+    ) -> None:
+        """Initialize a TabPFNv2Model.
+
+        Args:
+            train_X: A ``n x d`` tensor of training features (for BO, in the
+                unit cube).
+            train_Y: A ``n x 1`` tensor of training observations, in raw
+                units. Standardization is handled internally and the
+                posterior is returned in raw units.
+            model: An optional TabPFN v2 transformer. If ``None``, the
+                pretrained regressor is downloaded (see
+                ``download_tabpfn_v2_regressor``).
+            bar_distribution: The bar distribution matching ``model``.
+                Required if ``model`` is provided; ignored otherwise.
+            train_Yvar: Observed variance of train_Y. Currently ignored.
+            constant_model_kwargs: A dictionary of kwargs passed to the
+                transformer in each forward pass (e.g.
+                ``categorical_inds``).
+            input_transform: A BoTorch input transform.
+            accept_license: Pass ``True`` to accept the Prior Labs model
+                license when the pretrained weights need to be downloaded.
+        """
+        if model is None:
+            model, bar_distribution = download_tabpfn_v2_regressor(
+                accept_license=accept_license
+            )
+        elif bar_distribution is None:
+            raise ValueError(
+                "bar_distribution must be provided when model is provided."
+            )
+        super().__init__(
+            train_X=train_X,
+            train_Y=train_Y,
+            model=model,
+            train_Yvar=train_Yvar,
+            batch_first=False,
+            constant_model_kwargs=constant_model_kwargs,
+            input_transform=input_transform,
+        )
+        self.bar_distribution = bar_distribution
+        # Standardization constants for the (fixed) training targets; the
+        # bar-distribution borders are mapped back with these so the
+        # posterior lives in the raw units of train_Y.
+        self._y_mean = train_Y.mean()
+        self._y_std = train_Y.std().clamp_min(1e-9)
+
+    def pfn_predict(
+        self,
+        X: Tensor,
+        train_X: Tensor,
+        train_Y: Tensor,
+        **forward_kwargs,
+    ) -> Tensor:
+        """Predict bucket probabilities with the TabPFN v2 transformer.
+
+        Args:
+            X: Test points of shape ``(b, q, d)``.
+            train_X: Training features of shape ``(b, n, d)``.
+            train_Y: Training targets of shape ``(b, n, 1)``, raw units.
+            **forward_kwargs: Additional kwargs for the transformer.
+
+        Returns:
+            Probabilities of shape ``(b, q, num_buckets)`` over the
+            (standardized-space) bar-distribution buckets.
+        """
+        train_Y_std = (train_Y - self._y_mean) / self._y_std
+        # TabPFN v2 is sequence-first and infers the number of training
+        # points from the length of y.
+        x_full = torch.cat([train_X, X], dim=-2).transpose(0, 1)  # (n+q, b, d)
+        y_train = train_Y_std.transpose(0, 1)  # (n, b, 1)
+        logits = self.pfn(
+            x=x_full.float(),
+            y=y_train.float(),
+            only_return_standard_out=True,
+            **forward_kwargs,
+        )  # (q, b, num_buckets)
+        logits = logits.transpose(0, 1).to(X.dtype)  # (b, q, num_buckets)
+        return logits.softmax(dim=-1)
+
+    @property
+    def borders(self) -> Tensor:
+        """Bar-distribution borders, mapped back to the raw units of train_Y."""
+        borders = self.bar_distribution.borders.to(
+            dtype=self.train_X.dtype, device=self.train_X.device
+        )
+        return borders * self._y_std + self._y_mean

--- a/botorch_community/models/tabpfn_v2.py
+++ b/botorch_community/models/tabpfn_v2.py
@@ -66,7 +66,7 @@ TABPFN_V2_REG_REPO = "Prior-Labs/TabPFN-v2-reg"
 TABPFN_V2_REG_FILE = "tabpfn-v2-regressor.ckpt"
 
 
-def download_tabpfn_v2_regressor(
+def download_tabpfn_v2_regressor(  # pragma: no cover - requires network + tabpfn
     accept_license: bool = False,
 ) -> tuple[Module, Module]:
     """Download and load the pretrained TabPFN v2 regressor.

--- a/botorch_community/models/utils/prior_fitted_network.py
+++ b/botorch_community/models/utils/prior_fitted_network.py
@@ -166,7 +166,7 @@ def ensure_license_accepted(
             ``/tmp/botorch_pfn_models``.
     """
     notice = (
-        f"This model is distributed under the {license.name} license: " f"{license.url}"
+        f"This model is distributed under the {license.name} license: {license.url}"
     )
     if license.attribution is not None:
         notice += f' (attribution requirement: "{license.attribution}")'

--- a/botorch_community/models/utils/prior_fitted_network.py
+++ b/botorch_community/models/utils/prior_fitted_network.py
@@ -5,8 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import gzip
+import hashlib
 import io
 import os
+import sys
+from dataclasses import dataclass
 from enum import Enum
 
 from botorch.logging import logger
@@ -43,10 +46,167 @@ class ModelPaths(Enum):
     )
 
 
+DEFAULT_CACHE_DIR = "/tmp/botorch_pfn_models"
+ACCEPT_LICENSE_ENV_VAR = "BOTORCH_PFN_ACCEPT_LICENSE"
+
+
+@dataclass(frozen=True)
+class ModelLicense:
+    """License metadata for a downloadable pretrained model.
+
+    Args:
+        name: Human-readable license name, e.g. ``"Apache-2.0"``.
+        url: Canonical URL where the license can be read.
+        text_url: Optional URL of the raw license text; if given, a copy is
+            saved next to the downloaded weights.
+        requires_acceptance: If ``True``, the user must explicitly accept the
+            license before the model is downloaded (see
+            ``ensure_license_accepted``). If ``False``, only a notice is
+            logged.
+        attribution: Optional attribution string the license requires to be
+            displayed when the model is used or redistributed.
+    """
+
+    name: str
+    url: str
+    text_url: str | None = None
+    requires_acceptance: bool = False
+    attribution: str | None = None
+
+
+MODEL_LICENSES: dict[str, ModelLicense] = {
+    ModelPaths.pfns4bo_hebo.value: ModelLicense(
+        name="Apache-2.0",
+        url="https://github.com/automl/PFNs4BO/blob/main/LICENSE",
+        text_url="https://raw.githubusercontent.com/automl/PFNs4BO/main/LICENSE",
+    ),
+    ModelPaths.pfns4bo_bnn.value: ModelLicense(
+        name="Apache-2.0",
+        url="https://github.com/automl/PFNs4BO/blob/main/LICENSE",
+        text_url="https://raw.githubusercontent.com/automl/PFNs4BO/main/LICENSE",
+    ),
+    "Prior-Labs/TabPFN-v2-reg": ModelLicense(
+        name="Prior Labs License (Apache 2.0 with additional attribution)",
+        url="https://huggingface.co/Prior-Labs/TabPFN-v2-reg",
+        text_url="https://raw.githubusercontent.com/PriorLabs/TabPFN/main/LICENSE",
+        requires_acceptance=True,
+        attribution="Built with PriorLabs-TabPFN",
+    ),
+}
+
+
+def _acceptance_marker_path(license: ModelLicense, cache_dir: str) -> str:
+    key = hashlib.sha256(license.url.encode()).hexdigest()[:16]
+    return os.path.join(cache_dir, f".license_accepted_{key}")
+
+
+def save_license_copy(
+    license: ModelLicense,
+    cache_dir: str | None = None,
+    proxies: dict[str, str] | None = None,
+) -> str | None:
+    """Save a copy of the license text into the model cache directory.
+
+    Failures (e.g. no network) are logged and swallowed — the license URL is
+    always available in ``license.url``.
+
+    Args:
+        license: The license whose text to save.
+        cache_dir: The cache dir to use, defaulting to
+            ``/tmp/botorch_pfn_models``.
+        proxies: An optional dictionary mapping from network protocols to
+            proxy addresses.
+
+    Returns:
+        The path of the saved license file, or ``None`` if unavailable.
+    """
+    if license.text_url is None:
+        return None
+    cache_dir = cache_dir if cache_dir is not None else DEFAULT_CACHE_DIR
+    os.makedirs(cache_dir, exist_ok=True)
+    key = hashlib.sha256(license.url.encode()).hexdigest()[:16]
+    license_path = os.path.join(cache_dir, f"LICENSE_{key}.txt")
+    if os.path.exists(license_path):
+        return license_path
+    try:
+        response = requests.get(license.text_url, proxies=proxies or None)
+        response.raise_for_status()
+        with open(license_path, "w") as f:
+            f.write(response.text)
+        return license_path
+    except Exception as e:  # pragma: no cover - network-dependent
+        logger.warning(f"Could not save a copy of the model license: {e}")
+        return None
+
+
+def ensure_license_accepted(
+    license: ModelLicense,
+    accept_license: bool = False,
+    cache_dir: str | None = None,
+) -> None:
+    """Ensure the user has seen (and, if required, accepted) a model license.
+
+    For licenses with ``requires_acceptance=False`` this logs a notice and
+    returns. For licenses that require acceptance, acceptance can be given
+    (in order of precedence) by:
+
+    1. a previously recorded acceptance marker in ``cache_dir``;
+    2. passing ``accept_license=True``;
+    3. setting the environment variable ``BOTORCH_PFN_ACCEPT_LICENSE=1``;
+    4. answering an interactive prompt (only if run in a terminal).
+
+    Otherwise a ``RuntimeError`` is raised with instructions. Acceptance is
+    recorded in ``cache_dir`` so it is requested at most once per machine.
+
+    Args:
+        license: The license to display and check.
+        accept_license: If ``True``, the caller confirms the user accepts the
+            license terms.
+        cache_dir: Directory for the acceptance marker, defaulting to
+            ``/tmp/botorch_pfn_models``.
+    """
+    notice = (
+        f"This model is distributed under the {license.name} license: " f"{license.url}"
+    )
+    if license.attribution is not None:
+        notice += f' (attribution requirement: "{license.attribution}")'
+    if not license.requires_acceptance:
+        logger.info(notice)
+        return
+
+    cache_dir = cache_dir if cache_dir is not None else DEFAULT_CACHE_DIR
+    os.makedirs(cache_dir, exist_ok=True)
+    marker = _acceptance_marker_path(license, cache_dir)
+    if os.path.exists(marker):
+        return
+
+    accepted = accept_license or os.environ.get(ACCEPT_LICENSE_ENV_VAR, "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if not accepted and sys.stdin is not None and sys.stdin.isatty():
+        answer = input(
+            f"{notice}\nDo you accept the license terms? [y/N] "
+        )  # pragma: no cover - interactive
+        accepted = answer.strip().lower() in ("y", "yes")  # pragma: no cover
+    if not accepted:
+        raise RuntimeError(
+            f"{notice}\nDownloading this model requires accepting its "
+            f"license. Pass `accept_license=True`, or set the environment "
+            f"variable `{ACCEPT_LICENSE_ENV_VAR}=1`."
+        )
+    with open(marker, "w") as f:
+        f.write(license.url + "\n")
+    logger.info(notice)
+    save_license_copy(license, cache_dir=cache_dir)
+
+
 def download_model(
     model_path: str | ModelPaths,
     proxies: dict[str, str] | None = None,
     cache_dir: str | None = None,
+    accept_license: bool = False,
 ) -> nn.Module:
     """Download and load PFN model weights from a URL.
 
@@ -57,6 +217,9 @@ def download_model(
             to proxy addresses.
         cache_dir: The cache dir to use, if not specified we will use
             ``/tmp/botorch_pfn_models``
+        accept_license: If the model's license requires explicit acceptance
+            (see ``MODEL_LICENSES``), pass ``True`` to confirm the user
+            accepts the license terms.
 
     Returns:
         A PFN model.
@@ -64,9 +227,15 @@ def download_model(
     if isinstance(model_path, ModelPaths):
         model_path = model_path.value
 
-    cache_dir = cache_dir if cache_dir is not None else "/tmp/botorch_pfn_models"
+    cache_dir = cache_dir if cache_dir is not None else DEFAULT_CACHE_DIR
     os.makedirs(cache_dir, exist_ok=True)
     cache_path = os.path.join(cache_dir, model_path.split("/")[-1])
+
+    license = MODEL_LICENSES.get(model_path)
+    if license is not None:
+        ensure_license_accepted(
+            license, accept_license=accept_license, cache_dir=cache_dir
+        )
 
     if not os.path.exists(cache_path):
         # Download the model weights
@@ -80,6 +249,8 @@ def download_model(
         # Save the model to cache
         torch.save(model, cache_path)
         logger.debug("Model file saved at: ", cache_path)
+        if license is not None:
+            save_license_copy(license, cache_dir=cache_dir, proxies=proxies)
     else:
         # Load the model from cache
         model = torch.load(

--- a/notebooks_community/gitbo/gitbo.ipynb
+++ b/notebooks_community/gitbo/gitbo.ipynb
@@ -1,0 +1,481 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8b053fb1",
+   "metadata": {},
+   "source": [
+    "# Gradient-Informed Bayesian Optimization (GIT-BO)\n",
+    "\n",
+    "Contributor: rosenyu304\n",
+    "\n",
+    "This notebook demonstrates **GIT-BO** [1], a high-dimensional Bayesian optimization\n",
+    "strategy that aligns the search with a low-dimensional *active subspace* [2] estimated\n",
+    "from the surrogate model's own predictive-mean input gradients:\n",
+    "\n",
+    "1. A large discrete candidate set is scored with a **quantile-UCB** acquisition (the\n",
+    "   posterior quantile at level $\\tau$; for a Gaussian posterior this equals the classic\n",
+    "   UCB $\\mu + \\sqrt{\\beta}\\,\\sigma$ with $\\beta = z_\\tau^2$).\n",
+    "2. During the same forward pass, the Jacobian $G$ of the posterior mean w.r.t. the\n",
+    "   candidate inputs is obtained with a single `torch.autograd.grad` call.\n",
+    "3. On the next iteration, $H = G^\\top G / N$ is eigendecomposed and new candidates are\n",
+    "   sampled inside the span of the top eigenvectors, centered at the mean of the\n",
+    "   evaluated points.\n",
+    "\n",
+    "The implementation (`botorch_community.acquisition.gitbo`) is **surrogate-agnostic**:\n",
+    "any BoTorch `Model` with a posterior mean that is differentiable w.r.t. the test inputs\n",
+    "works. Here we benchmark GIT-BO with two surrogates — the **TabPFN v2** tabular\n",
+    "foundation model [3] (`TabPFNv2Model`, the surrogate used in the GIT-BO paper) and a\n",
+    "**`SingleTaskGP`** — against a standard `SingleTaskGP` +\n",
+    "`qLogNoisyExpectedImprovement` loop from the BoTorch tutorials.\n",
+    "\n",
+    "[1] R. T.-Y. Yu, C. Picard, F. Ahmed.\n",
+    "[GIT-BO: High-Dimensional Bayesian Optimization with Tabular Foundation Models](https://arxiv.org/abs/2505.20685).\n",
+    "ICLR, 2026.\n",
+    "\n",
+    "[2] P. G. Constantine, E. Dow, Q. Wang. Active Subspace Methods in Theory and\n",
+    "Practice. SIAM Journal on Scientific Computing, 2014.\n",
+    "\n",
+    "[3] N. Hollmann, S. Müller, L. Purucker, et al.\n",
+    "[Accurate predictions on small data with a tabular foundation model](https://www.nature.com/articles/s41586-024-08328-6).\n",
+    "Nature, 2025."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3ff361c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:16.029332Z",
+     "iopub.status.busy": "2026-08-08T02:14:16.029199Z",
+     "iopub.status.idle": "2026-08-08T02:14:17.512433Z",
+     "shell.execute_reply": "2026-08-08T02:14:17.511812Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "from botorch.fit import fit_gpytorch_mll\n",
+    "from botorch.models import SingleTaskGP\n",
+    "from botorch.models.transforms.outcome import Standardize\n",
+    "from botorch.test_functions import Ackley\n",
+    "from botorch.utils.transforms import unnormalize\n",
+    "from botorch_community.acquisition.gitbo import gitbo_step\n",
+    "from gpytorch.mlls import ExactMarginalLogLikelihood\n",
+    "\n",
+    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")\n",
+    "device = torch.device(\"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e322a326",
+   "metadata": {},
+   "source": [
+    "## Test problem: Ackley-30D\n",
+    "\n",
+    "We maximize the (negated) 30-dimensional `Ackley` function from\n",
+    "`botorch.test_functions` over $[0, 1]^{30}$, mapped to Ackley's native domain — a\n",
+    "classic multimodal high-dimensional BO benchmark in which **all 30 dimensions are\n",
+    "effective**. The global optimum value is $0$, attained at $x = 0.5$ in normalized\n",
+    "coordinates.\n",
+    "\n",
+    "In this regime GIT-BO does not rely on a sparse ground truth: the gradient-informed\n",
+    "subspace tracks the directions in which the surrogate's posterior mean currently\n",
+    "changes the most, concentrating candidates along the locally dominant descent\n",
+    "directions while a vanilla acquisition must search the full 30-dimensional box.\n",
+    "(TabPFN v2 natively supports high-dimensional tabular inputs; the GIT-BO paper [1]\n",
+    "benchmarks problems up to 500 dimensions.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "935baf15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:17.513691Z",
+     "iopub.status.busy": "2026-08-08T02:14:17.513567Z",
+     "iopub.status.idle": "2026-08-08T02:14:17.515805Z",
+     "shell.execute_reply": "2026-08-08T02:14:17.515477Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "DIM = 30\n",
+    "\n",
+    "ackley = Ackley(dim=DIM, negate=True)\n",
+    "\n",
+    "\n",
+    "def eval_objective(x):\n",
+    "    \"\"\"Evaluate Ackley on the unit cube (all DIM dimensions are effective).\"\"\"\n",
+    "    return ackley(unnormalize(x, ackley.bounds)).unsqueeze(-1)\n",
+    "\n",
+    "\n",
+    "bounds = torch.stack([torch.zeros(DIM), torch.ones(DIM)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16453274",
+   "metadata": {},
+   "source": [
+    "## Budgets\n",
+    "\n",
+    "To keep this notebook fast on CPU we use a reduced budget with the paper's default\n",
+    "subspace rank. The GIT-BO paper [1] uses `N_INIT=50`, 200 iterations, and 5000\n",
+    "candidates per iteration — increase the constants below to reproduce that setting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c89939a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:17.516848Z",
+     "iopub.status.busy": "2026-08-08T02:14:17.516775Z",
+     "iopub.status.idle": "2026-08-08T02:14:17.518422Z",
+     "shell.execute_reply": "2026-08-08T02:14:17.518124Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if SMOKE_TEST:\n",
+    "    N_INIT = 4\n",
+    "    N_ITER = 2\n",
+    "    NUM_CANDIDATES = 128\n",
+    "else:\n",
+    "    N_INIT = 20\n",
+    "    N_ITER = 50\n",
+    "    NUM_CANDIDATES = 2048\n",
+    "\n",
+    "RANK = 15  # GIT-BO paper default\n",
+    "SCALE = 0.2\n",
+    "QUANTILE = 0.975\n",
+    "SEED = 12345"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "601ce6eb",
+   "metadata": {},
+   "source": [
+    "## GIT-BO with a `SingleTaskGP` surrogate\n",
+    "\n",
+    "The loop is stateless: we refit the GP on all data each iteration, call `gitbo_step`,\n",
+    "and carry `result.gradients` into the next call (the subspace always derives from the\n",
+    "previous iteration's gradients; the first iteration falls back to Sobol candidates)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1280f78c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:17.519316Z",
+     "iopub.status.busy": "2026-08-08T02:14:17.519249Z",
+     "iopub.status.idle": "2026-08-08T02:14:17.521809Z",
+     "shell.execute_reply": "2026-08-08T02:14:17.521513Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def run_gitbo_gp(seed):\n",
+    "    torch.manual_seed(seed)\n",
+    "    tkwargs = {\"device\": device, \"dtype\": torch.double}\n",
+    "    train_X = torch.rand(N_INIT, DIM, **tkwargs)\n",
+    "    train_Y = eval_objective(train_X)\n",
+    "    gradients = None\n",
+    "    for _ in range(N_ITER):\n",
+    "        model = SingleTaskGP(train_X, train_Y, outcome_transform=Standardize(m=1))\n",
+    "        fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))\n",
+    "        result = gitbo_step(\n",
+    "            model=model,\n",
+    "            train_X=train_X,\n",
+    "            gradients=gradients,\n",
+    "            bounds=bounds.to(**tkwargs),\n",
+    "            num_candidates=NUM_CANDIDATES,\n",
+    "            rank=RANK,\n",
+    "            scale=SCALE,\n",
+    "            quantile=QUANTILE,\n",
+    "        )\n",
+    "        train_X = torch.cat([train_X, result.candidate])\n",
+    "        train_Y = torch.cat([train_Y, eval_objective(result.candidate)])\n",
+    "        gradients = result.gradients\n",
+    "    return train_Y.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6286f38",
+   "metadata": {},
+   "source": [
+    "## GIT-BO with the TabPFN v2 surrogate\n",
+    "\n",
+    "`TabPFNv2Model` (`botorch_community.models.tabpfn_v2`) wraps the pre-trained\n",
+    "**TabPFN v2** regressor [3] — the tabular foundation model used as the surrogate in\n",
+    "the GIT-BO paper [1]. The checkpoint is downloaded from Hugging Face **once** and the\n",
+    "same network is re-wrapped with the current training data each iteration —\n",
+    "prior-fitted networks condition on the data in-context, so there is nothing to refit.\n",
+    "Target standardization is handled inside the model and the posterior is returned in\n",
+    "the raw units of `train_Y`.\n",
+    "\n",
+    "> **License.** The TabPFN v2 weights are distributed under the\n",
+    "> [Prior Labs License](https://huggingface.co/Prior-Labs/TabPFN-v2-reg) (Apache 2.0\n",
+    "> with an additional attribution provision — *\"Built with PriorLabs-TabPFN\"*).\n",
+    "> Passing `accept_license=True` below (or setting the environment variable\n",
+    "> `BOTORCH_PFN_ACCEPT_LICENSE=1`) confirms that you accept those terms; the first\n",
+    "> download records your acceptance and saves a copy of the license next to the\n",
+    "> cached weights. Requires `pip install tabpfn`.\n",
+    "\n",
+    "We pass `eval_in_q_batch=True` to `gitbo_step`: all candidates are evaluated as one\n",
+    "q-batch, so the PFN encodes the training context only once per forward pass — the\n",
+    "memory-efficient layout for PFNs (whereas GPs use the independent-marginals\n",
+    "`num_candidates x 1 x d` layout)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "056b1db0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:17.522676Z",
+     "iopub.status.busy": "2026-08-08T02:14:17.522610Z",
+     "iopub.status.idle": "2026-08-08T02:14:17.580440Z",
+     "shell.execute_reply": "2026-08-08T02:14:17.579663Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from botorch_community.models.tabpfn_v2 import (\n",
+    "    download_tabpfn_v2_regressor,\n",
+    "    TabPFNv2Model,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def run_gitbo_tabpfn(seed):\n",
+    "    torch.manual_seed(seed)\n",
+    "    tkwargs = {\"device\": device, \"dtype\": torch.float32}\n",
+    "    # Executing this cell with accept_license=True confirms acceptance of the\n",
+    "    # Prior Labs License (see the note above).\n",
+    "    network, bar_distribution = download_tabpfn_v2_regressor(accept_license=True)\n",
+    "    train_X = torch.rand(N_INIT, DIM, **tkwargs)\n",
+    "    train_Y = eval_objective(train_X)\n",
+    "    gradients = None\n",
+    "    for _ in range(N_ITER):\n",
+    "        model = TabPFNv2Model(\n",
+    "            train_X, train_Y, model=network, bar_distribution=bar_distribution\n",
+    "        )\n",
+    "        result = gitbo_step(\n",
+    "            model=model,\n",
+    "            train_X=train_X,\n",
+    "            gradients=gradients,\n",
+    "            bounds=bounds.to(**tkwargs),\n",
+    "            num_candidates=NUM_CANDIDATES,\n",
+    "            rank=RANK,\n",
+    "            scale=SCALE,\n",
+    "            quantile=QUANTILE,\n",
+    "            eval_in_q_batch=True,\n",
+    "        )\n",
+    "        train_X = torch.cat([train_X, result.candidate])\n",
+    "        train_Y = torch.cat([train_Y, eval_objective(result.candidate)])\n",
+    "        gradients = result.gradients\n",
+    "    return train_Y.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a502132f",
+   "metadata": {},
+   "source": [
+    "## Baseline: `SingleTaskGP` + `qLogNoisyExpectedImprovement`\n",
+    "\n",
+    "The standard BoTorch tutorial loop: refit the GP each iteration and optimize\n",
+    "`qLogNEI` over the full 30-dimensional box with `optimize_acqf`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "473b7a01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:17.582159Z",
+     "iopub.status.busy": "2026-08-08T02:14:17.581956Z",
+     "iopub.status.idle": "2026-08-08T02:14:17.586272Z",
+     "shell.execute_reply": "2026-08-08T02:14:17.585760Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from botorch.acquisition.logei import qLogNoisyExpectedImprovement\n",
+    "from botorch.optim import optimize_acqf\n",
+    "\n",
+    "NUM_RESTARTS = 2 if SMOKE_TEST else 4\n",
+    "RAW_SAMPLES = 32 if SMOKE_TEST else 256\n",
+    "\n",
+    "\n",
+    "def run_qlognei(seed):\n",
+    "    torch.manual_seed(seed)\n",
+    "    tkwargs = {\"device\": device, \"dtype\": torch.double}\n",
+    "    train_X = torch.rand(N_INIT, DIM, **tkwargs)\n",
+    "    train_Y = eval_objective(train_X)\n",
+    "    for _ in range(N_ITER):\n",
+    "        model = SingleTaskGP(train_X, train_Y, outcome_transform=Standardize(m=1))\n",
+    "        fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))\n",
+    "        acqf = qLogNoisyExpectedImprovement(model=model, X_baseline=train_X)\n",
+    "        candidate, _ = optimize_acqf(\n",
+    "            acq_function=acqf,\n",
+    "            bounds=bounds.to(**tkwargs),\n",
+    "            q=1,\n",
+    "            num_restarts=NUM_RESTARTS,\n",
+    "            raw_samples=RAW_SAMPLES,\n",
+    "        )\n",
+    "        train_X = torch.cat([train_X, candidate])\n",
+    "        train_Y = torch.cat([train_Y, eval_objective(candidate)])\n",
+    "    return train_Y.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78601fd8",
+   "metadata": {},
+   "source": [
+    "## Run the three methods"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "27b94ea4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:14:17.587804Z",
+     "iopub.status.busy": "2026-08-08T02:14:17.587689Z",
+     "iopub.status.idle": "2026-08-08T02:18:21.868448Z",
+     "shell.execute_reply": "2026-08-08T02:18:21.868142Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GIT-BO (TabPFN v2): best value -13.3603 (104.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GIT-BO (GP): best value -13.2637 (70.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qLogNEI (GP): best value -18.6076 (69.2s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = {}\n",
+    "for name, runner in [\n",
+    "    (\"GIT-BO (TabPFN v2)\", run_gitbo_tabpfn),\n",
+    "    (\"GIT-BO (GP)\", run_gitbo_gp),\n",
+    "    (\"qLogNEI (GP)\", run_qlognei),\n",
+    "]:\n",
+    "    t0 = time.monotonic()\n",
+    "    results[name] = runner(SEED)\n",
+    "    print(f\"{name}: best value {results[name].max():.4f} \"\n",
+    "          f\"({time.monotonic() - t0:.1f}s)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b7201ad0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T02:18:21.869507Z",
+     "iopub.status.busy": "2026-08-08T02:18:21.869271Z",
+     "iopub.status.idle": "2026-08-08T02:18:22.040836Z",
+     "shell.execute_reply": "2026-08-08T02:18:22.040153Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAG4CAYAAAC5CgR7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAld9JREFUeJzs3XdYU+fbB/Bv2CBTBEFBQFEUce8tahVbB45WKmq1atVqrbb9aatWq7WOvm3VCmrdtg7ce7WI1j1xK24QUYbI3iHn/SMlElkhBA6B7+e6uJqcPOecO4L15sn93I9EEAQBRERERERaRkfsAIiIiIiI1MFEloiIiIi0EhNZIiIiItJKTGSJiIiISCsxkSUiIiIircREloiIiIi0EhNZIiIiItJKTGSJiIiISCsxkSUiIiIircRElohIS5w6dQoSiQTHjh0rdNyNGzcgkUiwa9euMoqMiEgcTGSJiMqAu7s7JBIJ/u///k/sUEpVWloa1q1bhy5dusDa2hpWVlZo2bIlVqxYAalUmmd8fHw8Jk6cCHt7exgZGaFJkyb4888/84zz8/ODRCJRfBkZGcHOzg5dunTB3Llz8eLFi7J4e0RUzjCRJSIqZefOncP9+/fh4OCAtWvXih1Oqdq+fTvu3LmDRYsWITQ0FA8ePICPjw8mTZqEcePGKY3Nzs6Gl5cX/v77bxw9ehRxcXGYOHEiRo4ciVWrVuV7/ZMnT0IQBCQnJyM4OBhffPEFDh06hAYNGmDnzp1l8RaJqBxhIktEVMrWrFmDWrVqYc2aNXj48CH+/fdfsUMqNSNHjsSSJUvQrl07mJmZwdbWFt988w169+6NTZs2ISMjQzF2y5YtuHTpElauXImmTZvC2NgYn332GYYOHYpvv/0WqampBd5HT08PNWrUwODBg3H+/Hm0adMGvr6+uHv3blm8TSIqJ5jIEhGVosTEROzcuRPjxo1Dr169UK9evQJnZVNSUjBz5ky4ubnByMgILi4umDJlCt68eVPg9ZOTk9GvXz9YWloiMDCw0FhSUlLw3XffwdXVFQYGBqhevTpGjx6NmJgYAEBERAT09fXx7bff5jk3OjoahoaG+Oqrr4rx7t/S19eHgYEB9PT0FMd2794Nc3NzdOvWTWnswIEDkZCQgL///lvla//f//0fsrKy8Ntvv6kVHxFpJyayRESlaMuWLZBKpRgzZgwkEgnGjx+PXbt2IS4uTmlcamoqOnfujI0bN2LhwoV49eoVTp06hdq1a2PLli35XvvFixfo1KkT7ty5g/Pnz6NHjx4FxpGWlgZPT09s27YNy5cvR2xsLAIDA3H37l107doVqampqFmzJvr374/169crzZwC8lnlzMxMjB49uljv/82bN1i1ahUOHz6M+fPnQ1dXV/HarVu3ULduXejoKP9T1KBBAwDA7du3Vb5Ps2bNUK1atQo9201EeTGRJSIqRWvWrMGgQYNga2sLABg1ahQkEgk2b96sNG758uUIDg7Gtm3bMHDgQFhZWcHJyQmTJ0/GF198kee6165dQ5s2bWBsbIxLly7B3d290DhWrlyJK1euICAgAL1794aZmRkaNWqE7du34+HDh1i/fj0A4PPPP0dMTIxSxwOZTIbVq1ejTZs2aNiwoUrv28fHBxKJBNbW1pg0aRLmzJmTZzY3NjYWlpaWec7NOfb69WuV7pXDwcEBL1++LNY5RKTdmMgSEZWS4OBgXL9+HZ9//rnimKWlJT7++OM85QVHjhyBg4MDOnfuXOR19+/fj86dO6Nz584ICgqCjY1NkeccPHgQDg4OaNu2rdJxJycnuLq6KmYyu3XrhgYNGmDFihWKMYcOHcLz588Vs7GBgYFKHQQkEgmuXr2qdN2AgAAIgoCXL1/it99+w7x58/KdzZVIJAXGXNhr+REEodjnEJF2YyJLRFRK1qxZAwDo1KmTUtK3fv163Lp1C5cvX1aMjY6ORs2aNVW67q5du5CZmYnPP/8cRkZGKp0TGRmJFy9eQE9PD3p6etDV1YWOjg4kEglCQkIQGxurGDthwgScP38et27dAiCfza1SpQp8fHxUfesK9vb2mDx5MqZMmYL169fj+vXritesra3zlFgA8pZcAFC1atVi3SsiIgI1atQodoxEpL2YyBIRlYLU1FRs3boVa9euhSAIeb66dOmiSHQBwMbGBhERESpd+48//kD37t3Rq1cvHD16VKVzqlWrhvr160MqlUIqlSI7OxsymUwRT1BQkGLsJ598AlNTU6xYsQJPnz7F8ePH8eGHH8LMzAwA0KNHjzzvp2XLloXev3HjxgCAp0+fKo41atQIjx49gkwmUxp7//59pXNUERwcjNevX6Nr164qn0NE2o+JLBFRKdi+fTsSExPRq1evfF/v3bs3AgICkJycDADo06cPXrx4gdOnTxd5bRMTExw4cAB9+vRB//79sX379iLP6du3Lx48eICbN28WOdbc3By+vr7YsmULFi9eDEEQir3I6105s885C7kAeXeCxMREpSQaAPbs2QNzc3O89957Kl07KysL06ZNg4GBgdpdFYhIOzGRJSIqBWvXroWHhwccHBzyfb13795ITk5GQEAAAGDSpElo3rw5Pv74Y+zduxdxcXF4/vw5li9fjuXLl+c538DAAAEBARg5ciSGDh2K1atXFxrPF198gdatW8Pb2xt79uzB69evER8fj4sXL2LixIl5dtOaOHEikpOTsXr1ari5uaFjx44qve/hw4dj48aNePLkCdLT0xEaGor58+fD398fo0ePVlqUNmzYMLRq1QoTJkzAjRs3kJaWhjVr1mDr1q1YuHAhqlSpUuB9srOzERkZid27d6NDhw64dOkStm7dqpQoE1ElIBARkUbdu3dPACB88803hY6rWbOm0Lp1a8XzpKQkYfr06UKdOnUEAwMDwcXFRZgyZYoQGxsrCIIgnDx5UgAgHD16VOk606ZNEwAIixYtEgRBEK5fvy4AEHbu3Kk0Li0tTZg3b57QsGFDwcjISKhatarQvn17YeXKlUJqamqe+Dp16iQAEBYvXqzye3/06JEwefJkwc3NTTAwMBAsLCyETp06CevWrROys7PzjH/z5o0wfvx4wdbWVjAwMBA8PDyEDRs25Bm3fPlyAYDiy8DAQLCxsRE6deok/PDDD8KLFy9UjpGIKg6JIAiCeGk0ERGVV3369MHx48cRHh4OOzs7scMhIsqDpQVERJRHXFwc/v77b/Tt25dJLBGVW0xkiYhISWZmJubOnQupVIrvvvtO7HCIiArERJaIiBR++eUXGBoaYteuXVixYgVatWoldkhERAVijSwRERERaSXOyBIRERGRVmIiS0RERERaSU/sAEiZTCbDy5cvYWZmBolEInY4RERERGVKEAQkJSWhRo0a0NEpfM6ViWw58/LlSzg6OoodBhEREZGowsPDC9wdMQcT2XLGzMwMgPybZ25uLnI0RERERGUrMTERjo6OipyoMExky5mccgJzc3MmskRERFRpqVJiycVeRERERKSVmMgSERERkVZiIktEREREWok1sqUoMzMTW7duBQA4Ozuja9eu4gZERERaKTs7G1lZWWKHQaQR+vr60NXV1ci1mMiWIqlUilOnTuHFixewtLRkIktERMUiCAIiIyMRHx8vdihEGmVpaQk7O7sS98xnIluKTExMsHHjRhw6dAgbN24UOxwiItIyOUmsra0tTExMuFEOaT1BEJCamoro6GgAgL29fYmuJ2oiK5VKsXv3bpw/fx56enro2LEjvL29i/yLmpqaim3btuHUqVMYMGAABg4cWCrxxcfH488//8Tly5cxZsyYfGdUHz9+jPXr1yM6OhqNGzfGZ599BiMjo1KJh4iIKo/s7GxFEmttbS12OEQaY2xsDACIjo6Gra1ticoMRFvsJZPJ4O7ujn379qFOnTqwsbHBhAkT4OPjU+h5586dg6urK86ePYu///4bt27dKpX49u7dC3d3dzx69Ag7duzA48eP84y5fv06mjZtirCwMDRq1Ahr166Fp6cn65iIiKjEcv4tMTExETkSIs3L+bkuac4k2oysRCLB33//DWdnZ8WxDh06oHPnzpg+fTqaN2+e73l16tTBvXv3YGlpCVdX1yLvk5WVhS1btmDkyJF5Xtu6dSv69esHU1PTPK+1aNECjx8/homJCdasWZPvtadPn44uXbpgy5YtAIAhQ4bAyckJmzdvxqhRo4qMjYiIqCgsJ6CKSFM/16LNyEokEqUkFgBq164NAHj9+nWB59nZ2cHS0lLl+4SHh2PatGmYNm2a0vElS5Zg3LhxCAkJyfe8WrVqFfpbcFpaGoKCgvDRRx8pxda1a1ccOnRIcSwgIAAnTpxAWFgYNm7ciIiICJVjJyIiovLj7t27kEqlJb5Oamoq7ty5A0EQNBBV+ZOYmIhnz56Vyb3K1WKvFStWwMzMDK1bt9bYNWvXro3AwEB069YNurq6WLhwIZYtW4bvv/8ehw8fRsuWLdW6blhYGLKzs+Hk5KR03MnJCVeuXFE8P3fuHJKSktCwYUOcOnUKLVq0QM2aNfNcz9/fH/7+/sjOzlYrHiIiovIoISEB0dHRsLGxyXci6smTJzAxMYGlpSWePHlS6LVq1KiBqlWrKh179eoVYmNjAcgnyXJWwxdWdxkZGYmkpCTUqFEDVapUUel9bNu2Db///jsCAwMLnATLUbNmTVhZWRX4enBwMDp16oS0tLQC19VkZWXhwYMHAOTvy8rKCvb29oqZzNyv52ZqagpnZ2fF6yYmJoqJwhyhoaEwMDBAjRo1Cn0fhZFKpQgPD4ednZ2i5jV37K1bt8bFixdRp04dte+hEqGc2Lt3r6Crqyts3rxZ5XPq1KkjzJkzR6WxwcHBgpWVldCzZ0/BxMREOHHihMr3MTQ0FNasWZPnegCEK1euKB3/6quvBDc3N5Wv/a6EhAQBgJCQkKD2NVQVkxojRCRFlPp9iIio+NLS0oR79+4JaWlpYoeilsDAQKFNmzaCkZGR4OrqKlhbWwvVq1cXZs2aJcTHxyvGtWjRQpg4caJw8+ZNoWHDhoovKysrwcjISOnY1q1b89xn4sSJSuOqV68u2NraCn/++Weesbt27RLq1asnWFpaCq6uroKxsbHg7e0thIeHF/pesrKyBEdHR+HYsWPC5cuXlWKytLQUTExMlI7t3r270OudOXNGAFDo9/bZs2cCAMHZ2Vlo2LChYGtrK1SrVk1Yv359vq/nfI0ZM0bpdUNDQyE0NFTp2t27dxfGjRtXaIwFCQ8PF0aPHi2YmpoKzs7OgqGhoeDj46P0PRUEQZg+fbrw0UcfFXidwn6+i5MLlYsZ2WPHjsHHxwe//vorfH19S+UezZo1w+jRo/HLL79g2LBh6NatW4muZ2FhAQCIi4tTOv7mzRvFa+WVVCbF+s19sT47HB6ZMvi9SUdRlSoysxow/mgtYFu/TGIkIiLttWvXLvj4+ODHH3/EyZMnFTN2r1+/xurVq/Ho0aM8n4g2btwYd+7cUTwfP348rl69iqtXrxZ5v4YNGyqNW7BgAUaNGgUvLy/Y2NgAADZt2oTRo0fDz88PY8eOha6uLmJiYvDpp5+iffv2uHbtmmLsu3bv3g0AeO+996Cjo6MU58iRI/H48WOcPXsWgHymMiQkBHfu3IG+vj6cnJwK7WaUlZWF8PBw1KxZE4aGhnle37Bhg6Jr0vz58zF27Fi0atVKsb4n9+v5MTU1xaxZs/DXX38VOCaHTCbDvXv34OzsnGf90N27d+Hg4ICbN2+iXbt28Pf3h6GhISIiItCtWzd88cUX+PPPPxXjR40aBQ8PD0REROT7SbSmiL5F7fHjxzFgwAAsXLgQX375Zand548//oC/vz9+++03HDx4EHPnzi3R9ZycnGBmZqb0wwwAt2/fRqNGjUp07dKWJcvCNukrpOhIcMlIF2d1U2GYEVvol/Hr23h2+BexQycionIuMzMTkyZNgo+PD7777julj52rVauGGTNmqF3Wp6r33nsP2dnZePnyJQB5TepXX32FTz75BOPHj1eUHdjY2GDz5s1ITk7G/PnzC7zenj17FElsURISEuDj4wMfHx/07dsXlpaWGD16dL6r82fNmgUbGxu0b98ednZ22LNnT6HXnjp1KrKzs3Hu3Lki48gxY8YMbN26FTdu3ChyrI6ODj766CMsXbpU6fiVK1fg4eGB169f44MPPsDo0aMVSXfNmjUxbNgwBAUFKZ3j5uaGGjVq4MCBAyrHqg5RE9l//vkH3t7eWLBgAaZOnZrvmB9//BG///57ie6zfv16TJ06FXv27MHUqVPx999/47fffsNPP/2k9jV1dXUxZMgQrF27FsnJyQCAM2fO4Nq1axg6dGiJ4i1txnrGGJD8ti5mQVVrPBRs8FyW9ytc9va3U2lM3hZkREREuV24cAFRUVEYPXp0md0zPT0dd+7cwZ07d3Dq1CnMmjULLVu2hIeHBwD5v89v3rzJNyYLCwsMHjwY+/btK/D6ly5dQpMmTVSKxdraWhHLw4cP8fTpU5w7dw4rVqzIMzY4OBgRERGIjIzEzJkzMWLECMTExBR47Tdv3gAAzMzMFMeePXumuN+dO3eQlJSkdE779u3Rr18/TJ8+XaX4fX19Fd2YcmzZsgXt2rUrsN717t27cHR0zHO8efPmOH/+vEr3VZdopQVJSUno378/zM3Nce3aNQwbNkzxWu7NB44fPw47OztMnjwZgPxjiSlTpgAAoqKisGfPHjx+/BgNGjTAzJkz89znwYMHmDRpEnbu3AkvLy8AQOvWrXH8+HH06tULHTp0yHdK/uHDh5g3bx4A+bT/unXrcOrUKXTo0AETJkwAACxatAg9e/aEh4cHGjRogDNnzmDatGklLlsoC7W7rIVDyHS8SL+BGH0dLGg6Aq0s8ybg6VnZGHOuKywkqbDMfCVCpERElFvf5WcRk5RR5ve1MTPEwS86Fjnu+fPnAAAXFxfFsZyP2xXXsrFB9erVNRbbkydPFH3oExISkJ6ejrVr1ypmXnNienfRU47atWsjPDwcMpks31nXyMhIVKtWrVgxpaenIyIiAmlpaejWrRsCAwPzfPL8448/KhabffXVV1i2bBm2bt2qNO7Zs2eoVq0aXr9+jblz58LOzg69evVSJKzz5s1TWrC2YsUKdO7cWek+CxcuhIeHB06cOIHu3bsXGvfQoUPx/fffIzg4GM2bN0d2djYCAgIwe/bsfMcfPHgQO3bsyHc22cbGptS7F4iWyBoYGGD16tX5vpY7q589e7bSxxLGxsaKhDTnvwAK/Avh5uamqPfIrW3btrh582ae4zmsrKzyvU/uvwTW1ta4fPkyzp49i+joaCxduhRubm75Xq+86dOkBho6z8PAAwMhlUlxO3k/fuw+Co7myr9RZWXL8OCsLSwkoagqjQaypYBuuSitJiKqlGKSMhCZmC52GAUyMDAAIP84P0fOx+0A8OjRI0ydOhWLFi0q9rWfPXuGlJQUAICenh7q15ev23i3Rvbo0aPo27cv/vnnH3h6euYbU24pKSnQ09MrsHTAwMAAmZmZKsWYkZGBsWPHYvv27ahevTrMzc0RGxub71as7u7uisc6Ojpo0KBBng2YchJVS0tLNG7cGOvWrYO1tbUikS2qRhYA6tevj1GjRmHatGlF1hy7uLigffv22Lx5M5o3b47AwEC8efMGQ4YMyTP23Llz+PjjjzFnzhx4e3vn+2eRX92vJomWkRgaGirNwhakZ8+eSs+rVKmi0nm5FZSsFnQckP8Wocp9dHV10aVLl2LFU164WLhguPtwbLizAZmyTPx85Wcs775caYy+rg5eSWzggVDoQgYkRgBWTgVckYiISpuNWekmBiW9b846kdu3bysStZyP2wEokk91zJkzB8HBwQDkE05nzpzJd1zv3r1Ru3Zt7NixA56enoqYbt68me+s7M2bN9G4ceMC7+vi4oIXL16oFOPy5ctx/vx5PHv2TNHeavbs2fnWiqalpSm16UpNTc3TDkyVRFUVc+fOhaurKwICAooc6+vrix9//BG//PILtmzZAi8vrzzbJF+4cAG9e/fGlClTMGfOnHyvExERgQYNGpQ49sJwaq2SG9d4HA4/OYzotGicenEKp1+cRmcH5Y8kXuvZATntbePDmMgSEYlIlY/3xeTu7o727dtjwYIFGDBggGI2VBNyr4ovjEwmQ2JioiIpbN68OVq0aIGFCxeiX79+Sj1mr1+/jsOHD2PlypUFXq9Lly64ePGiSvcOCQlB27ZtlXq0njhxIt+xJ0+eVHRriouLw40bN/DFF1+odJ/iqlGjBqZMmYKZM2fCwcGh0LEfffQRvvzySxw6dAh79+7FunXrlF6/ePEivLy88MUXXxS4SE4mk+HKlSv4/PPPNfYe8iN61wISVxX9Kvi65deK54suL0JGtnLtVZzB27+MQlxoWYVGRERa6q+//kJiYiKaNWuGDRs24MKFCzh//jz8/f3x6tUrlTchUFXuxV7nzp3DmDFjkJCQoPTJ6ubNm/HixQv06tULR48eRXBwMP744w94eXnBx8cHY8eOLfD6I0eOxIkTJxAfH19kLB06dMDBgwexfft2RSyXL1/Od+y0adMQEBCAU6dO4cMPP0StWrUwaNCgYr9/VU2fPh2JiYlFdj2wtraGl5cXPv/8c+jo6KBfv36K165fv45evXrhvffew8cff6y00Cy3f/75BwYGBnj//fdL5b3k4IwsobdLb+x4uAPXoq4hPCkcf979E2Mbv/0LnWxcA0iTP5bGhkFfpDiJiEg71K5dG7du3cKaNWuwc+dOREZGwtraGi4uLti7d6/SomhXV9d8d5iqWbOmSoljzrk5Nbjm5uZwc3PDhQsX0LRpU8W4+vXr4+bNm1i+fDkWLVqEpKQk1KpVC8uWLcOQIUMUO2blp3nz5ujUqRM2bNiQp8uSg4MDZDKZ4vnIkSMRFxcHPz8/ZGVloVOnTvjll1+UyiCqVKmChg0b4o8//sDy5cvx5MkTNGzYEJs2bYKenjw1MzAwQMOGDQtM+lV93cTERHHMwsICP/30E5YvX15kb9exY8fiu+++g6+vr1If3ODgYDg6OiIkJETxZ54jdzK7atUqTJ48udAeupogEYQKutGvlkpMTISFhQUSEhJgbm5eZvd9GPcQHx38CNlCNox0jXDA+wDsTeWF6XPX7cKccHnLktT6g2His66wSxERkQakp6fj2bNncHFxKfVkgIp27949fPHFFzh+/Lgi2aT8PX36FKNGjcKxY8fybF+bo7Cf7+LkQiwtIABAPat6+Lj+xwCA9Ox0/N/V/1O8lmWWq5NBfFhZh0ZERCQ6d3d3nDhxgkmsCmrXro1///23wCRWk5jIksKEphNQ1agqAOCfsH9w4eUFAEAVU3O8FuS/EekmhosWHxEREVFuTGRJwdzAHFNbvK39WXh5IbKys2BurI8XgnyHL4PUKEBa9o24iYiIiN7FRJaU9KvTD41t5L30niU8w9aQrbA00Uf4f4msBAIQz1lZIiIiEh8TWVKiI9HBjDYzIIF89eaKGysg0UtUzMgCYJ0sERERlQtMZCmPhtYNMbjeYABAqjQVJ6LWI1ywfTuAiSwRERGVA0xkKV+Tm02GhaEFAOByTCDuG+Xq0hbHRJaIiIjExx4SlC9LI0tMbjYZP178EQDwzPYG7sQayAsOYu8Dr++WXTASoI5FHRjpsY8iERERvcVElgo0qO4g7Hq4C/ff3Ee20Wt8XNNO/kLGfeCwT+Ena5iloSWmtZqGPrX7FLr7ChEREVUeLC2gAunq6Cot/BJTfEY8ZpydgQmBExCRHCF2OEREVMlcv34dbdu2hVQq1eh1BUGAp6cnTp8+rdHrVhackaVCNbVtCr/ufpi0dxs8hQuojnj5Cy1HAbr6ZRJDRHIETr+Q/wU/9/IcBuwfgElNJ8G3gS90dXTLJAYiIiqe2NhYLF++HP/88w8iIyNhY2OD+vXrY+zYsejQoYNi3AcffIDmzZtj4MCB6Nu3b6HXnD9/PkaOHKl07Pvvv8eGDRsAABKJBJaWlmjSpAlmzpyJBg0aKI0NDw/HL7/8gn///RdJSUmoVasWfHx8MGbMGOjqFv7vyZdffomRI0cq7ewVHR2N5cuX48SJE4iKioKtrS0aNGiAcePGoU2bNopxPXr0QEhICADA2NgYtWvXxvjx4zFgwABIJBKMHj0akydPxvXr1/mpYzExkaUidXboDKv0bHRJfI6Bus/kB10/AmwbFH6iBp0KP4X5F+cjKjUKadI0/N/V/8PRZ0fxQ/sf4FbVrcziICKiooWEhKB79+5wc3PDzJkz4ebmhri4OISEhOC7777DvHnz0LVrVwBAVFQU4uLi0LBhQ1y8eFFxje+++w63bt3C4cOHFcesrKzy3CsuLg7W1taKcTExMZg7dy48PT3x7NkzxTapN27cQPfu3dG5c2esWLEC1atXx5UrVzB9+nQcOnQI+/btKzCZvXjxIq5fv44jR44ojt2+fRvvvfcemjRpgtmzZ6Nu3bp48+YN7t+/j6+++gq//vor2rZtCwCIjIxEnz59MGvWLKSmpiIgIAADBw7Evn370L9/f3z44YeYPHkyAgMD8d5775XsD7+SYSJLKrE01kd4Qq5esnFhZZrIdnXsipbVW2JZ8DIEPAgAANyJvQOfQz4Y5TEK45qMg6GuYZnFQ0REBRs+fDjs7e0RGBgIHZ23VYwtW7bEsGHDkJ2dneccAwMDODg4KJ5XqVIF+vr6SscKknucg4MDZs2ahVatWuHBgwdo2rQpBEHA8OHD4e7ujj179ihmPevUqYOmTZvCw8MD/v7+mDx5cr7X/+uvv9CzZ0+YmpoCkJcD+Pr6wtXVFceOHVO6XqtWrTBixIg879HU1FQR4+zZs7F//35s3boV/fv3h6GhIXr37o2//vqLiWwxsUaWVJJ7m1oAovSSNTUwxcy2M/Fn7z9R26I2AEAqSLHm9hoMPjAYVyKvlHlMRESk7NatW7h69SpmzJihlMTmVtTH+CUhk8mwb98+WFpaonZt+b8VV65cwZ07dzB9+vQ8H93Xr18f/fv3x7p16wq85r///otWrVopnl+5cgW3b9/GjBkzCiwFKOo9mpmZIS0tTfG8bdu2OHXqVFFvj97BGVlSiaWJwTuJ7HPRYmlm2ww7++7E2ttrseb2GkhlUoQmhuLT45+iX51+cLFwUek61U2qo2G1hnA2d4aOhL/TEZGW+KMLkBxd9vc1tQXG/VvksLt35e0Z3d3dSzsihVu3bilmO+Pi4mBiYoJ9+/bB3NwcAHDv3j0AgIeHR77ne3h44MCBAwVePywsDPb29ornJX2PJ06cwLlz5/DLL78ojtnb2+PFixfIzs4u1US/omEiSyqxMNbD9dy7e8WFihYLABjoGuDzpp+jp1NPzLkwB7dibgEADjwp+H9EBamiXwXu1u5oaN0QDas1REPrhnAwdWDBPRGVT8nRQNJLsaMoUM5H6oaGb8u9YmJi0KxZM8XziRMn4rvvvtPYPRs0aKCokU1ISMCaNWvw0Ucf4dKlS3B2dlZ0GsgdU26GhoaQyWSQyWT5ziJLpVKlRV75vccXL14oamIB4KuvvsJXX32leP7HH38gICAAaWlpyMrKwpdffolJkyYpXtfT04MgCJBKpUxki4GJbCm6cOEC5s6dC0D+l7ao1ZjlmaWxAV4JVSEVdKAnkZWbbWpdrVzxp9ef2P5gO5YFL0OqNLXY10jJSsGVyCtKpQkWhhbyxNa6IepZ1YO+Ttl0aMhPXau6qGVeS7T7E1E5Y2pb9BgR7+viIv9U7MmTJ4rH1tbWioVcXbt2RUJCglohDBw4EJcvXwYAVK1aFbduyScx3q2RXbJkCXbs2IGVK1di8eLFijgeP36sNLOa4/Hjx3ByciqwFMLe3h7R0W9nwXO/x5zr2dvbK95ju3btkJiYqHQNX19fzJo1C0ZGRqhWrVqee8TExKBq1aoFJtuUPyaypahOnTqYMmUK1q5di7Cw8pH4qcvCWB/Z0MUrwRqOkhhRSwvepauji6ENhqK3S2/cirmFbCHvIoJ3yQQZniU8w53Xd3A39i6iUqOUXk/ISMD5l+dx/uX50gpbZQY6BljXax2a2jYVOxQiKg9U+HhfTK1bt4aDgwNWrVqFHj16AAB0dHQUiWbumc3i+uOPP5CRkQGg8BpUiUSCKlWqKJLJjh07wtbWFqtWrUKnTp2UxsbGxmLXrl0YP358gddr27YtgoODFc87dOiA6tWrY9WqVejYsaMinpz3mF9suRd75efatWtKbclINUxkS5GtrS28vLwQGBgodiglZmEin5EMF2zgiBggPQFIiweMLUWNKzcrIyt0ceyi1rmv017j7uu7uBt7V5Hcvkl/o+EI1ZMpy8T/Tv8PO/vshKWRpdjhEBEVSl9fH6tWrcKAAQMwadIkzJw5UzFr+eTJEyQlJal9bRsbm6IHAdi2bRseP36MxYsXA5CXAPj7+8PHxweNGjXClClTYGRkhNDQUHz66aewt7fHjBkzCrzehx9+iAkTJihKDIyMjLBixQoMGTIENjY2mD59Ouzs5LtfPnz4ECkpKcV6X4Ig4O+//8YPP/xQrPNICxPZs2fP4tdff8X58+ehp6eHjh07YuHChYqViZoSHR2N9evXY/Xq1Xj+/DkePHiAOnXqKI1JSUnBN998g927dyMzMxM9e/bE77//rvhhrkgsjHMSWVsA8qJ5xIeVq0S2JKoZV0MXxy6KRFgQBESlRuHO6zsITwqHAEGUuALDAnH79W1EpkRi5rmZWN5tORemEVG598EHH+Dff//FnDlz4OzsDCMjI+jo6MDc3By+vr5KtaGakHuxV0JCAkxNTbFkyRIMHDhQMWbw4ME4cuQIZs2ahblz5yq6BgwaNAjbt2+HpaVlgdfv168f/ve//+HQoUPw9vYGIC9zCAoKwg8//IBatWrBxMQEEokEFhYWGDNmDD777DOV4z958iTS09MxZMgQtd5/ZSYRBEGcf6HVkJ2dja5du+Kbb75Bu3btkJqaii+++AJ37tzB7du3Ff3dNOGzzz6DlZUVGjdujGHDhuHRo0dwdXVVGuPr64srV65g165dMDMzw8iRI5GWloZLly4pLRT65ptv4OzsrNJf3MTERFhYWCAhIUGx2rI8uPQ0FkNWX8Qk3b34Rn+n/OBHfwHu/cQNrIKLSonCR4c+UswOT20xFZ96fCpyVERUFtLT0/Hs2TO4uLjAyMhI7HDUlpWVhbi4OFhZWUFfP+96g+joaBgYGORJJOPj45GZmQlb28Jrc+Pj45GcnKx4bm5uXuS/n6mpqUhOToa1tbXKC6v27duHuXPnIjg4OM9i4KLeY1RUFIyMjGBhYZHvtbt06YJPP/0Un3zyiUqxVASF/XwXJxfSqhlZXV1dnDlzRumYn58fnJ2dcenSJXTv3j3POYcOHcKePXuwdu1apSLuR48eYdKkSdixY0e+P1irV68GAKVdRnJ78eIFtm3bhj179qBx48YAgBUrVsDDwwMnT55Et27d1H6f5VFOaUF5acFVWVSvUh0LOy7E+MDxECDg9+Df0dSmKZpXby52aEREKtHX1y80GS3otcJmSN8dp+rYHCYmJjAxMSnWOd7e3mjVqhVkMlme5Leo91i9evUCXxMEAVu2bEHNmjWLFQ/Jaf1nlLGxsQDkjYXz06hRIwQFBWH06NGQyWQA5DU6np6ecHZ2VnvW88KFCxAEAZ6enopjDRs2RPXq1XH+vHyBUFhYGLy8vLB7926sWLECXl5eyMrKUut+YrM0NgAgr5FVKCedCyq69jXbY2zjsQCAbCEb/zv9v3JTv0tEVJnUrFlT462xJBIJHBzY8lFdWjUj+67s7Gx8/fXXaNKkCVq0aJHvGCcnJ5w8eRJdunTBZ599hm+//RbdunWDl5cXVq1apfYPzqtXr2BgYJBnNtfGxgaRkZEA5O1GpkyZovR6QX8B/P394e/vn++2feWBco3sf+KYyJaVz5t8juvR13El8gqiU6Mx4+wMrOi+gvWyRERUqWntv4KCIGDcuHG4e/cuduzYUehvSC4uLggKCsLRo0fRqFEjdO/eHatXry6V3350dHSQU3ZsamoKLy8vpa+CetRNnDgR9+7dw5Ur5XObVSN9HRjo6SAGFsjEf/U/LC0oM7o6uljcaTGqGlUFAJyLOIf1d9aLHBUREZG4tDKRFQQBn3/+Ofbv34+goCDUq1evyHP09PSgp6cHmUwGQ0PDEiex1atXR2ZmZp6Gx9HR0YXWwmgriUQCC2N9CNDBK8l/5QXxYYD2rBXUejYmNljceTEkkP/sLr++HFcjr4ocFRERkXi0MpGdNGkSdu3ahRMnThS4b3Ju4eHh8PT0RKdOnXDjxg0cOHCgxK0/2rVrBwD499+3jalDQkIQGRmJ9u3bl+ja5ZXlf+UFz2X/JbJZqUDKaxEjqnza2rfF+Cbypt0yQYZpp6chNi1W5KiIiIjEoXWJ7OTJk7Fjxw4EBQUpugUUJiIiAp6enmjXrh02bdqEBg0aICgoCLt378aXX36pdhy1atXChx9+iG+//RaPHj3Cq1evMGnSJDRt2rTCdSzIkVMn+zw719Z6LC8oc+Maj0Mb+zYAgJi0GHx35jtky8pnbTUREVFp0qpENjY2FsuXL0dsbCyaNWumKBfQ09PD+vX51wteuXIFrVu3xl9//aWoo61fvz5OnjyJGzduFLjf84IFCxQbLuSc8+591q1bh1atWqF58+ZwcXGBsbExDh48WGAdrLZ7u+Ard+eCUHGCqcR0dXSxqNMiVDOW/0Jx4dUFrLm9RuSoiIiIyp5WbYgAAFKpNN/jurq6Gl28JQhCvh0ENH2fd5XXDREA4KsdN7AnOAIf6FyEv8Hv8oPd5wCdvhI3sErq8qvLGPvPWMgEGXQkOljz3hq0tm8tdlhEpCEVZUMEovxUyg0RAPmirbIgkUjK7F7aImdG9oXA0oLyoLV9a0xoMgH+N/whE2SYfmY6vmrxlWgtuVwtXeFW1U2UexMRlReXL1/GqVOnMG3aNI1eNyYmBj/++CN+/fXXfHcPq6yYqZHK3m6KkKuXLDdFENXYRmMRHBWMC68u4HXaa8w4O0PUeAbWHYj/tfwfTA00t100EVVM8+fPR+3atTF06NBSu0dGRgYmTpwIY2NjLFmyRGmCavXq1ZDJZBg/frxiXH6GDx+OLl26KMZMmDChwN71MpkM48aNw8yZM5WOS6VSHDlyBBcuXEBSUhIcHBzQsmVLdO/eXfEp77sxWFhYwN3dHb6+vjAyMoKNjQ0ePXoEPz8/TJ06taR/NBVGxSzmpFJhYSz/H8AbmEGqayw/yE0RRKWro4uFnRbC1rjwvcjLyp5HezDwwEBcfJX/1s5ERDn27dun2AmztGRlZWHdunXw8/PDmjXKawmCgoIQGBioNE5fXx9t27ZV+sppqZkz5tmzZwXeb9++fXjz5g0GDhyoOPbw4UM0btwY//vf/6Cnpwd3d3ckJSXh119/RaNGjRS7jr4bg52dHRYtWoTmzZsjJSUFgHzB++LFi5GZmanRPydtxhlZUpmlicF/jyRIMq4Jq+THQEI4IJMBFXSBmzawNrbGlg+24PSL08iSibMFcmJGIjbe3YhUaSpepbzC2L/HYojbEHzV4iuY6BdvP3MiqhgOHDiAwMBA2NnZYdCgQdi+fTvat2+PHj16qHR+dnY2tm/fjgsXLsDExAT9+vVDhw4dlMakp6dj7dq1ePjwIVxdXTF48GDMnj0bc+bMgaOjo2Jc165dMXfuXAwfPhympgV/YtS9e3cMHjxYvTcM+Szvxx9/rFj0nZmZiQ8++ABOTk44cuQIDAwMlMbfv38/z7qb3DF89NFHcHZ2RkBAAEaPHo2ePXsiKysLBw4cKFGcFQkTWVJZTo0sAMTp28EKj4HsTCA5EjCvIWJkZFfFDh+5fSRqDP1c+2H2udm4HHkZALD9wXaciziHHzv8iJZ2LUWNjYjK1sKFC/HTTz/hyy+/hFQqRY8ePZCUlARzc3OVE9lBgwYhODgY48ePR2xsLLp164Zly5Zh/PjxijG9e/dGeHg4xo4di0ePHqFt27YIDw/HpEmTlBLZSZMm4auvvsKvv/6KOXPmaPz9AvKk9fTp00rlAbt378bjx4+xd+/ePEksADRo0KDQazo5OcHMzAzh4eEA5AvO27dvj7///puJ7H+YyJLKLEzeJrIxenaonfMkLoyJLKGmaU2s6bkG2x9sx5JrS5AmTcOL5Bf49Pin8G3giy+bfwkjPa68JqroXr9+jfnz52P9+vUYMmQIAKBjx47o3r27ytc4duwYDh06hJCQELi6ugKQbzf/7bffwsfHB5aWljh06BDOnz+Px48fK5LWatWq4YcffshzPUNDQ8ybNw+TJk3ChAkTYGubfznWqlWrcOzYMaVj787uFiQsLAxpaWlwcXFRHLt48SLMzMxU2rwpPzk1tbnPr127NoKDg9W6XkXERJZUlntG9pUk1za88WGAUzsRIqLyRkeig4/rf4wONTrg+3PfIzg6GAIEbL6/GWcjzmJ+x/loYtNE7DCJtNqQQ0PwOq3sd1WsZlwN2/tsL3LclStXkJ6erlQn2q1bN1SrVq2Qs5SdOnUKrVq1UiSxADBs2DB88cUXuHnzJrp06YLTp0+jTZs2Sknmhx9+mG8iC8gXbf3666+YN28e/Pz88h1Tt27dPAu5qlSpolLMSUlJAKBUupCYmJgnab5y5Qr++OMPxfOpU6eiYcOGiuc5yXRcXByOHj2KwYMHK/1ZmpqaIjExUaWYKgMmsqQyy1yJ7AulTRHYgouU1TKvhfW91mPz/c34Pfh3ZMoyEZoYihFHR2Bkw5HoWLOj2CEWSV9HHw2sG8BQ11DsUIiUvE57jejUaLHDKFB0dDTMzc3ztIgqTiIbHR2dZ7ylpSX09PQQFRUFQN6OytraWmnMu89z09HRwaJFi+Dt7Y0pU6bkO6YkNbI5946Li4OzszMAwNbWFhERERAEQVELa21tjbZt2yIxMRFff/01Bg8erJTI5iTT5ubm+OGHH9CoUSOl+8THxxf6PisbJrKkMvNciexTaa6/ROxcQPnQ1dHFJw0/QaeanTDz7Ezcib0DmSDD+jvrsf5O/jvxlTfNbJthfa/10NPh/yqp/MjZ1a+83tfR0RHx8fFISkqCmZkZAPnCrYiICJXv5ejoiKtXryodi4iIgFQqRa1atQAADg4OuH37ttKYnFrSgrz//vto3749ZsyYofFdOGvVqoWqVavi3r17aNasGQB5Yvzzzz8jMDAQ7733HgB5aUDt2rURGRmJr7/+Os91ikqm7969i5Ytue4gB//vTCrT19WBqaEekjOkeJxV9e0L7CVLhahtWRt/vf8XNtzZgBU3V0Aqy393vvLoevR1BIQEYJj7MLFDIVJQ5eN9MbVr1w52dnb4/fffFf1U165dq/joXRUDBw7E/PnzERgYqFgc9ssvv8DFxQXNmzcHAPTv3x8//fQTzp8/j/bt2wNAgSUDuf38889o27Yt6tatm2e2syQkEgm8vLxw8uRJ+Pr6AgB69uwJT09PTJo0Cfv27VNa3JXf7qFFSU1NxZUrV0ptwZo2YiJLxWJhrI/kDClephsCRhZAegITWSqSno4exjYei261uuHv0L+Rnp0udkiFyszOxOb7mwEAy68vRw+nHrCrYidyVETawdjYGH5+fvD19cXJkydhYGCAZ8+ewd7ePs/YkydPYsyYMUrHevXqhQ8//BBz5sxB//790aNHD8TGxuL27dtKq/9btmyJyZMno2fPnujZsyciIiIUW53q6uoWGF/r1q0xcOBA7N69O08im99ir/fff1+pRrUwEydOxPvvv4/ly5fD2Fjeb33v3r34/PPP0bx5czRv3hwuLi5ITk7G+fPn4eXlVWTngtz27NmDWrVqwdPTU+VzKjomslQsFsb6iIhPQ0JaFgRHJ0gibwEJEUC2FNDljxMVro5lHUxoOkHsMFSSkZ2BnQ93IlWaioWXFmJZt2Vih0SkNQYNGoSWLVvi7NmzsLOzQ7t27RSzpjm+//57xMTE5DnXyckJADB79mwMHToUly5dgrGxMTw9PWFlZaU0dunSpfD19VX0kTUxMUHjxo0VNaRGRkZYs2YNmjRRXmS6ZMkSeHl5KToM5IzLT85ispwxhX2s3759e3Tu3BkrV67EV199BUC+Q9eWLVvw8uVLXL58GUlJSbC3t4efnx8cHBwU5xZ1fZlMhp9//hkLFiwo8P6VkUQQBEHsIOitxMREWFhYICEhAebm5mKHk8fHqy/iwtNYAMDjJluh9+CQ/IUvbwJWzuIFRqRhCRkJ6L+vP2LT5T/vSz2Xonst1dsHEZVUeno6nj17BhcXF8VMozZr2rQpRo4cWeBCK3XkLisQBAHjx4/Hv//+i5CQEI3do7hevHiBK1euYMCAARq9bmxsLI4dO6YoW9B2hf18FycX4nZMVCyWuXrJplep+fYFdi6gCsbC0ALTW09XPF94aSFSslJEjIiI3hUUFAQPDw98/PHHaNq0KQ4cOIC1a9eKGpODg4PGk1hA3u2goiSxmsRElooldy/ZJKO3H4mwcwFVRF7OXuhQQ74lZlRqFPyuF72QhIjyN2fOHMXKfU2ZNWsW9uzZA29vb/z666948OABOnYs/+39SHNY1EjFknt3r3hDeyhK97ngiyogiUSCmW1nYsD+AcjIzsDWkK3oU6cPGlo3LPpkIlJSGrOUAFCvXj3Uq1evVK5N5R9nZKlYcs/Ixurl2t2LM7JUQTmaOWJ8E/ne7jJBhrnn52pVCzEiooqMiSwVi6WxgeJxpE6ubfdYI0sV2CcNP4GrpXyrzPtv7iMgJEDkiIiICGAiS8WkNCObqQ9U+W+rWpYWUAWmr6OPOe3eNiBffn05IlMiRYyIKhOZTCZ2CEQap6mfa9bIUrHk7lqQkJYFWDoBKTFA0isgKx3Q1/4WMUT5aWrbFB/W+5C9ZanMGBgYQEdHBy9fvoSNjQ0MDAwgkUjEDouoRARBQGZmJmJiYqCjo6PY4EJdTGSpWHLPyMoT2VpAxH/7YSe8AKq5ihQZUen7svmXCHoehNj0WASFB+HE8xPsLUulRkdHBy4uLnj16hVevnwpdjhEGmViYoJatWpBR6dkxQFMZKlYciey8WlZgK3T2xfjQ5nIUoWW01t22ulpAOS9Zdvat0UV/SoiR0YVlYGBAWrVqgWpVIrs7GyxwyHSCF1dXejp6WnkEwYmsqVIKpUq9my2t7dHixYtRI6o5HK330rMKS3Iwc4FVAl4OXth/+P9OPfynKK3bO6NE4g0TSKRQF9fH/r6+kUPJqpkuNirFGVkZGDVqlWYN28eFi5cKHY4GmFqoAed/36Bik/9r7QgBzsXUCWQ01vWUNcQALA1ZCvuxt4VOSoiosqJM7KlqEqVKjh06BAOHTqEjRs3ih2ORujoSGBhrI+41Cx5jayV89sX2bmAKomc3rLLgpdBJsgw59wcfOT2kdhhURmrol8FXRy6wNTAVOxQiCot0RPZpKQkbNmyBSEhIZg0aRJcXYuusXz16hV2796NFy9ewNXVFUOHDoWJiYnGY8vIyMDu3btx+fJl+Pj4oG3btnnGREZGYuvWrYiOjkbjxo0xZMgQ6OrqajyW8iQnkY1PzQQsHABIAAgsLaBK5ZOGn+Dw08N4HP8YD+Ie4MeLP4odEomgqlFVTGgyAYPqDYK+Dj/6JypropYWrF27Fm5ubjh58iSWLVuGFy9eFHnO6dOnUa9ePZw6dQpmZmbYsmULWrdujfj4eI3GduzYMdSpUwcHDx6Ev78/7ty5k2fMgwcP4OHhgX/++Qf6+vqYNWsW3n///Qrf88/CRN4qIylDimwdA8Dsv41qOSNLlUhOb1k9iejzASSiN+lv8NOlnzBg/wAEhgVCEASxQyKqVET9P3CrVq3w4MEDJCQkYMeOHSqd8/XXX6Nv377YunUrAGDGjBlo2bIlFi5ciMWLF+cZL5PJcOTIEfTp0yfPa8eOHYOnpycMDQ3zvObi4oLr16/DxsYGe/fuzTeW//3vf2jUqBGOHDkCiUSCTz/9FPXq1cP27dvx8ccfq/R+tFFO5wJBAJLSs2Bp5QQkvQRSY4GMZMCQH7NR5dDUtikC+gQg5E2I2KFQGRMg4FzEORwLlS/oDUsMw9RTU9HUpim+bvk1mto2FTdAokpC1ES2SZMmAICEhASVz3n06JFSkiiRSNCiRQvs2bMn30T2yZMn8PX1xYwZMzB9+tuVxZs2bcL48eMRFBSEdu3a5TnPzc2t0DgyMjJw7NgxrFixQtE+wsXFBZ06dcK+ffsUMf7999+4cuUKIiMjcejQIbRp0wY2NjYqv9/yyPKdXrKWlk7A8wvyA/HPgeruIkVGVPbcqrrBrWrh/7+gisnb1Rsj3Efg12u/4lrUNQDAjZgbGH50OHrU6oEvm38JZwtncYMkquC0rmtBw4YNceLECcXzzMxMnDlzBk+ePMm3x17dunVx5MgRzJ8/H7/++isA4K+//sL48eOxffv2fJNYVYSGhiIrKwt16tRROl6nTh08evRI8XzTpk24du0aLC0tsWrVKoSHh+d7PX9/f7i7u6NVq1ZqxVOWlHrJ5ulcwPICIqo8Gtk0woZeG7C823LUtqitOB74PBAD9g/ATxd/QmxarIgRElVsWlfctWzZMvTu3Rtt2rRBkyZNcPbsWdja2iIkJATp6emoUiVvY/IOHTrg8OHDeP/99xEcHIzdu3dj27Zt6Nevn9pxpKamAgDMzMyUjpubmyteA4AtW7aodL2JEydi4sSJSExMhIWFhdpxlYU829Ra5d4UgS24iKhykUgk6OrYFR1rdsTex3ux4sYKvE57DakgRcCDABx4cgBdHLpAV6diLwQuiImeCapXqY7qJtXf/tekOkz0Nb9ImyofrUtkW7ZsicePHyMoKAhRUVEYN24cTp06hcuXLxfauaBz586YNGkSFi9ejJEjR2LAgAEliiMngX13kVlcXFye5LaiybO7FzdFICKCno4ePqz3IT5w+QCb7m3ChjsbkCZNQ6o0FUdDj4odXrljbmCulNjaV7FHJ4dOcLdmeRqpTusSWQCwsLBQSkTnzJmDdu3aFbrV2Y4dO7B06VLMmDEDS5cuRYsWLTBp0iS1Y3B2doaxsTFCQkLQo0cPxfGQkBC4u1fsv4QW79TIwin3jCwTWSKq3Ez0TTChyQR8WO9DrLyxErsf7Ua2wO1l35WYmYjEzEQ8intbjud3ww8NqjbAwLoD8X7t92FuYC5ihKQNyn0i+/vvv8Pc3BwjR44EIF/sZW1tjapVqwIATp48iaNHj+LgwYMFXmPPnj0YMWIENm3ahCFDhsDT0xP9+vWDnp4exo8fr1Zcenp6GDhwIDZs2ICxY8fC0NAQ169fx8WLFzFz5ky1rqktlBLZ1EzAzAWQ6AJCNhNZIqL/VDOuhu/bfY8vW3yJ+PR4scMRhQAByZnJiEyJRGRqJKJSoxCVEqX03yxZltI599/cx0+XfsKvV39FT+eeGFh3IJrbNi90sooqL1ET2cuXL2Pr1q1ITk4GAPj5+WHfvn3w8vKCl5cXAPlMqp2dnSKRTUtLQ5cuXdCsWTOkpqbi6NGj+Pnnn/H+++/ne48HDx7A19cX69atw5AhQwAAPXr0wL59++Dt7Q13d3d07tw5z3nPnj3DsmXLAABSqRTbt2/HnTt30LJlSwwbNgwA8PPPP6NLly5o1aoVmjRpgiNHjmDUqFH44IMPNPrnVN5Y/tdHFvhvRlZXT74xQnwYEMcaWSKi3MwNzCv9zGLDag3zPS4TZIhLj0NUahTuvL6DvY/24k6svG97enY6Djw5gANPDsDZ3BkD6w5E3zp9Uc24WlmGTuWcRBCxe/O9e/fw999/5znetm1bxS5aO3fuhImJiVJy+ObNGxw9ehRSqRTdunWDo6Njofe5ceMGmjZtmuf4rVu30KhRo3x/y3v58mW+vW0bNGiAXr16KZ6npaXhyJEjiI6ORpMmTdC+fftCYylKzmKvhIQEmJuXz//xPYhMQq+lpwEAH7ZwwP992ATY1Bd4Jj+G6aGAsZV4ARIRkdZ68OYB9jzag4NPDyIpM0npNT2JHro6dkUnh07Q09HsXJyJngkczRxRy7wWjPWMNXptKp7i5EKiJrKUlzYkslGJ6WizQN4Crad7dawe0RLYPxG4vlk+YNxpwL6JiBESEZG2S5em48TzE9jzaA8uR14u03tXN6kOJ3Mn1DKvBWdzZ9QyqwUncyc4mDnAQNeg6AtQiRQnFyr3NbJU/uTpWgAAls5vB8SFMZElIqISMdIzwge1P8AHtT/A88Tn2Pt4L/Y93ofXaa9L/d5RqfL63XcTaB2JDuxM7GCol3dH0PzYmthieIPh6OzQmTW+pYSJLBWbkb4uDPV0kCGVITEnkbVi5wIiIiodtcxr4cvmX+Lzpp/j4suLeJn8UqPXFyAgPiMezxOfIywpDM8TnyM+Iz7POJkgw8sU1e/9LOEZLr26hMbVGmNi04loV6PwDktUfExkSS0WxvqITsqQ7+wFKO/uxV6yRERUCvR19NHJoVOZ3CshIwFhiWEISwzD86Tn8v8mPkdEcgSyZUW3U8sWspEqlW+QdOv1LYwLHIfmts0xqdkktLIr/7t4agsmsqQWSxN5IpugKC3g7l5ERFRxWBhaoLFNYzS2aazW+YIgICg8CH7X/fA4/jEAIDg6GJ8e/xRt7NtgUtNJaGrbVIMRV046YgdA2imnTjYtKxsZ0mzAtDqg+1/NEEsLiIiokpNIJOheqzt299uN/+v8f3CxcFG8dunVJQw/OhyfB36Ou7F3RYxS+3FGltRiYazcS9bWzAiwdARiH8tnZAUBYB0QERFVcjoSHXi5eOE9p/dw5NkRrLixAi+SXwAAzkScwZmIM+jm2A3NqzcXOVLVfVjvQ5jom4gdBgAmsqSm3J0LEhWJrJM8kc1KBVJiAFNbESMkIiIqP3R1dNG3Tl94uXjhwOMD+OPWH3iV8goAEBQehKDwIJEjVN0HtT8oN4ksSwtILZYmuVpw5Sz4snB4OyAxoowjIiIiKv/0dfQxqN4gHBpwCDPbzISNsY3YIWk1zsiSWnLPyCoWfJnXeDsg8RVQo1kZR0VERKQdDHQN4FPfB96u3rgadRWpWalih6QyMwMzsUNQYCJLalHaFCFnRtbM/u2ApFdlHBEREZH2MdIzQseaHcUOQ2uxtIDUkru0IN8ZWSayREREVMqYyJJazPPbpjb3jGwiE1kiIiIqXUxkSS2W73QtAPDOjKxmtw8kIiIiehcTWVKLco1spvyBsdXbTRE4I0tERESljIksqcXSRHlDBADyDRDM/ysv4IwsERERlTImsqQWc6O3DS8UNbIAYPZfeUF6ApCpPa1EiIiISPswkSW16OnqwMxQnswm5E5kzdmCi4iIiMoGE1lSW07ngoTU3DOyuTsXsLyAiIiISg8TWVJbTi/ZhLQsCIIgP8heskRERFRGmMiS2nI6F0hlAlIys+UHOSNLREREZYSJLKmNu3sRERGRmJjIktry7SVrZvd2AGdkiYiIqBQxkSW1WRjn00vWjF0LiIiIqGwwkSW15Z6RVXQu0DMETKzlj7m7FxEREZUiJrKlKDExEXZ2drCzs8PYsWPFDkfj8q2RBd5uipAcCchkZRwVERERVRZMZEuRmZkZbty4gV9++QVxcXFih6NxSjWy+W2KIJMCKTFlHBURERFVFuUikU1KSkJISAhSU1Xf0jQ9PR2hoaFITk4uxciAjIwMhISEICEhocAxiYmJCA0NhVQqVToukUhgZ2cHS0vLUo1RLJbGBc3I5q6T5YIvIiIiKh2iJrIhISEYP348XFxc0KBBA1y+fLnIc9LT0zF8+HBYWVmha9eusLGxQffu3REREaHR2CIiIjB9+nTUrl0b7u7u2LlzZ54xUqkUY8aMgY2NDVq1aoXq1asjICBAo3GUZ+ZKXQtyz8jmasHFOlkiIiIqJaImsidOnECTJk1w5swZlc/5+eefcfToUdy7dw+hoaF49eoV3rx5g8mTJxd4TmZmZrGOA8CFCxdQtWpV3LhxAwYGBvmOmT9/Pg4dOoR79+4hJiYGCxcuxLBhw3D37l2V3482y10jm8gZWSIiIipjoiayEydOxIQJE2BmZqbyOWFhYWjYsCFcXFwAAJaWlujUqRPCwsLyHf/gwQPUr18fISEhSscjIiLQpEkTnD17Nt/zBg8ejOnTp8PGxqbAWP744w989tlnqFOnDgDgs88+g7OzM9auXavy+9FmyjWyuX4p4IwsERERlYFyUSNbHOPHj8fdu3exYsUK3Lx5Ezt27MCOHTswbdq0fMe7ubnh/fffR7du3fDw4UMAwKtXr9CtWzd4eHigbdu2asXx4sULREZG5jm/Xbt2uHbtmuJ5w4YNMXz4cBw6dAh2dnY4efKkWvcrj0wN9aCrIwFQWI0sE1kiIiIqHXpiB1BcLVu2xFdffYWvvvoKtra2iI6Ohq+vL/r27VvgOcuXL4dUKoWnpycCAgIwduxYeHh4YNu2bdDTU++PIDY2FgBQrVo1pePVqlVTSmRPnjwJWa4WVFWrVs33ev7+/vD390d2drZa8YhBIpHAwlgfb1IylRNZpRlZlhYQERFR6dC6Gdk5c+bA398f9+7dw/Pnz/Hy5Uvcv38fH3/8cYHnSCQSrFy5Et26dUPnzp3h4uKCgIAAtZNYANDV1QWQt842IyND6bq2traKXrJ2dnYF1ttOnDgR9+7dw5UrV9SOSQw55QVKi72MrQBdQ/ljzsgSERFRKdG6RDYgIABDhw5F7dq1AchnOCdOnIgDBw4U2r4rJiYG165dQ82aNXH37l2Eh4eXKA4HBwcA8jKF3CIjIxWvVQY5iWxSuhTZMkF+UCJ520uWNbJERERUSsp9Ipsz65rD0tJS8bF+jtevX8PIyAhGRkb5XuP169fo3r07ateujcePH6Nbt27o1q1bgQvEVGFpaYmmTZvi2LFjimPp6ekICgpC165d1b6utsm94Csxv929MhKAzJQyjoqIiIgqA1FrZBMSEvDq1StERUUBkCetISEhqFatmqL2dOjQobCzs8OuXbsAAGPGjMGkSZPQpEkTdO7cGffv38f8+fMxcuRI6OjkzcvfvHmDHj16wMHBAbt374ahoSHWr1+PkSNHwtPTE6dOnUKtWrXynJeWlqZIdAVBQGRkJEJCQmBhYQF7e/ls49y5czFo0CB4eHigdevW+PXXX2FqaorPPvusVP68yqN3t6m1qvJf6YR57gVfkYB1nTKOjIiIiCo6UWdkg4KC4O3tjXHjxsHNzQ0LFiyAt7e30qYCTk5OqFmzpuL5Z599hq1btyIwMBCffvopNm7ciNmzZ2PZsmX53iM7OxsdOnTA3r17YWgor9vU0dHBxo0b4e3tnWc3rhz379+Ht7c3vL294eLigs2bN8Pb2xtLlixRjOnXrx92796NI0eO4PPPP4epqSnOnDlTYXfyyk+B29Tm7lzABV9ERERUCiSCIAhiB0FvJSYmwsLCAgkJCTA3Nxc7nCL99vcD/B70GACw6dPW6FLvv767F/yB4zPkjweuARp/JFKEREREpE2KkwupNSPr5+en1mtU8ShvU5urgwNnZImIiKiUqZXIfvHFF2q9RhWPpcnbdmKJBfWSZQsuIiIiKgUarZENCwsrsOE/VUxKNbKprJElIiKislOsrgUeHh75PgYAmUyG58+fY8CAAZqJjLTCu10LFLhNLREREZWyYiWyY8aMAQBMnTpV8TiHvr4+nJ2d4eXlpbnoqNwrsGuBngFgUg1Ifc1NEYiIiKhUFCuRnTJlCgCgWrVqGDZsWGnEQ1rG0riAGVlA3ks29TWQHAnIZEA+fX6JiIiI1KVWZpGTxEqlUjx79kyjAZF2yd21ICH1nUQ2Z3cvmRRIiSnDqIiIiKgyUCuRTU1NxZgxY2BiYoLatWsrjvv6+uLGjRuaio20gJG+Loz05T9G+c7I5kjigi8iIiLSLLUS2ZkzZyIkJASnTp1SOu7j44O5c+dqIi7SIjl1svFpmcovmOVqwcU6WSIiItKwYtXI5ti1axdOnjwJV1dXpePt27eHr6+vRgIj7WFpbICoxAzOyBIREVGZUmtGNiYmBvb28iRFIpEojmdkZCA7O1szkZHWyJmRTc+SIT0r1/dfqZcsZ2SJiIhIs9RKZBs3bozjx48DUE5kV6xYgVatWmkmMtIaFrl6ySaylywRERGVEbVKC+bNm4chQ4bg8uXLAIBly5bh2LFj+Oeff/DPP/9oNEAq/97tJWtrbiR/knubWu7uRURERBqm1oysl5cX9u/fj+vXr8PS0hI//PADMjMzERgYCE9PT03HSOVcgb1kja0AXUP5Y87IEhERkYapvdhr8ODB6Nq1q4bDIW2kNCObu5esRCJf8BUXyhpZIiIi0ji1ZmQ//vhjyGQyTcdCWsrSpJDdvXJacGUkAJkpZRgVERERVXRqJbJ169bFnTt3NB0LaSnzorapzcFZWSIiItIgtUoLpkyZAl9fXyxcuBDu7u4wMDBQet3BwUEjwZF2sDR5+/1PSH13U4R3eslWU+49TERERKQutRLZcePGAQD69u2b7+uCIKgfEWkdi0JnZLm7FxEREZUOtRLZ+/fvazoO0mLvtt9S8u6MLBEREZGGqJXI1q9fX9NxkBYrsP0WwBlZIiIiKjVqJbI3btwo8DVDQ0PUqlULVapUUTcm0jLmBbXfAri7FxEREZUatRLZZs2aFfq6rq4uPvroI6xduxYmJiZqBUbaQ1dHAjMjPSSlS5W3qAWYyBIREVGpUav91po1a+Dm5oY9e/YgNDQUYWFh2L17N+rWrYvly5fj8OHDuHHjBmbOnKnpeKmcyqmTzVMjq2cAmFSTP2ZpAREREWmQWjOyy5Ytw44dO9C4cWPFsVq1aqFOnToYPnw4bt26hY0bN8LHxwdLlizRWLBUflma6ONFXBoS0rIgCAIkEsnbF83tgdTXQHIkIJMBOmr9/kRERESkRK2M4vHjx/n2inVwcMDjx48BAO7u7nj9+nXJoiOtkTMjmy0TkJwhVX4xZ3cvmRRIiSnjyIiIiKiiUiuRrVevHubPnw+p9G3CIpVK8eOPP6JevXoAgOvXr6NVq1aaiVJLZWVlYd++fdi3bx+uXLkidjilytI416YIhe3uxRZcREREpCFqlRb4+/ujb9++2L59O5o2bQpBEHDz5k2kpqbi0KFDAIB//vkHixcv1miw2iYzMxMbN25EVFQUatasiV27dokdUql5t3OBg1WuF83eacFVo/DFgkRERESqUCuR7dixI549e4ZNmzbh/v37kEgk6NWrFz755BNYWloCAObNm6fJOLVSlSpVsG/fPhw6dAgbN24UO5xSZWnyNpHN07mAM7JERERUCtRKZAHA0tISX375ZYkDSEhIwF9//YWQkBB8+eWXqFu3bqHjV61ahTt37uQ5bmNjgzlz5pQ4ntzS09OxY8cOXL58Gb6+vmjXrl2eMS9fvsTmzZsRHR2Nxo0bY+jQodDTU/uPVWsVvrsXN0UgIiIizVN7+XhKSgr279+v1JXg4cOHEARB5WusXr0aDRo0wIULF+Dv74+IiIgiz3F0dET9+vWVvjZu3KjxbXOPHDmCOnXq4J9//sEff/yBu3fv5hlz//59eHh44PTp0zAzM8O8efPg5eWF7OxsjcaiDQrf3Yu9ZImIiEjz1Jo6fPjwIXr27In09HRERUVh6tSpAIAff/wRH3zwAXx8fFS6Trt27fDo0SPExcVh69atKp3zwQcfKD0/d+4cUlJSMHbs2HzHy2QyHDhwAN7e3nleO3z4MLp37w4jI6M8r9WtWxe3b99G1apVsXPnznyvPW3aNDRr1gwHDx6ERCLByJEj4erqiu3bt2Po0KEqvZ+KwkLV3b0SWVpAREREmqHWjOyUKVPw0Ucf4dUr5dm1L7/8Er/88ovK12nUqFGJt7Jdt24dateujW7duuX7+pMnTzBy5Ej89NNPec778MMPC9xut27duqhatWqB983IyMDx48fh6+ur6Jnq5OSEzp07Y//+/YpxR48excWLF/Hy5Uvs27cP0dHRxXyH2sHCpJAZWWMrQO+/XxY4I0tEREQaotaM7IULF7B161blpvcA6tevj9u3b2skMFUkJydjx44dmDlzZp5YctStWxfHjh1Dz549oaenh+nTp2Pjxo2YNGkSdu3ahbZt26p179DQUGRlZcHFxUXpeO3atXHt2jXF823btiExMRG2trbYuHEjnJycYGtrm+d6/v7+8Pf319qyBAul0oJM5RclEvmsbNwz1sgSERGRxqiVyMpkMmRmypOV3AlkaGgoLCwsNBOZCgICApCRkYGRI0cWOq5t27Y4evQovLy8EBwcjAMHDmD79u15yhSKIy0tDQBgZmamdNzc3BypqamK53/++adK15s4cSImTpyIxMTEMv0z1BRLk0L6yAKAeQ15IpuRAGSmAAYlm4knIiIiUqu04L333lOUEOQksq9fv8bkyZPh5eWlueiKsG7dOvTp0wf29vZFju3QoQMmTpyIHTt2YMiQIejXr1+J7m1qagoAiI+PVzoeFxcHc3PzEl1bGxVaIwu8UyfLWVkiIiIqObUS2V9//RU7d+5EgwYNIAgCPD094eLigtDQUCxatEjTMebr3r17uHjxYoGLvN61bds2LF26FLNnz8auXbuwdOnSEt3f2dkZJiYmebol3L9/H+7u7iW6tjaqYqALPR35LzX5z8iylywRERFpllqlBU5OTrh16xY2b96Mq1evQiaTYeDAgfjkk080Phu5ZMkSmJubY/To0UrH165dC0dHR5VmgHfu3IlRo0Zh8+bNGDx4MLp27Yo+ffpAT08PkyZNUisuPT09DBo0CBs2bMDYsWNhZGSEq1ev4tKlS5g9e7Za19RmEokEFsb6iE3JLGBGlr1kiYiISLPUSmSHDRuGzZs3Y8KECSW6+aVLl/DXX38hJSUFALBs2TLs2rUL77//Pt5//30AwO7du2FnZ6eUyGZmZuKvv/7CxIkToaNT+KTygwcPMGLECGzatAmDBw8GAHh6euLAgQPo168fGjVqhC5duuQ57+nTp/jtt98AAFKpFFu3bsWNGzfQunVrjBgxAgDw888/o0uXLmjRogUaN26MY8eOYezYsejdu3eJ/ly0lYWJPJHNs7MXAJjZvX3MGVkiIiLSALUS2b179yI9PT3f/qvFYWFhgfr16wMAWrRooTherVo1xeOvvvoKJiYmSufFxcVhzpw5isS0MG5ubrhy5Qo8PDyUjnfv3h2XL18usAzA2NhYEVvuMoTc9bh2dna4efMmjh8/jujoaEydOhWtW7cuMqaKKqdONilDipvh8dDJtRDQJN0cdf57/PplKF69SFD5uhIJUMfGFMYGupoMl4iIiLScRCjOVlz/6d27N8aMGYNBgwaVRkyVWk7XgoSEBK1bNDZqw2WcfBCT72sOkhicNZRvaXw0uxUmZE0t1rUdrIxxcFJHWFUxKHowERERaa3i5EJqzch6eHhg2LBhOHr0KNzd3WFgoJxcqFt3Stqtnp1ZgYlslGCleGwniSv2tV/EpeHHQ/fw25Cm6oZHREREFYxaM7I5H7kXJCQkRO2AKjttnpFNSMvC5othiEpMz/f1abc/gKk0Hgn6tvjVY6/K1913PQKJ6VIAwIaRreBZP++GEkRERFQxFCcXUiuRpdKjzYlskVZ1BCJvAxJd4PsYQEe1mtedV8Pxv123AAD2FkY4PrUzzI30iziLiIiItFFxciG1+sgSqSWnBZeQDaTkX4KQn8EtHNC5ng0A4FVCOhYe4Yw/ERERMZGlspR7U4RE1VtwSSQSLBjggSr/dS3Ydvk5zj9+renoiIiISMswkaWyk3tThKTibYrgYGWCb99voHg+fc8tpGZKNRUZERERaSEmslR2lLapLf7uXr6ta6G1S1UAQPibNPzf8QeaioyIiIi0EBNZKjsl3KZWR0eCnwc1hpG+/Md24/lQXA19o6noiIiISMuoncieOXMGo0aNUtreddWqVUhMTNRIYFQBlXBGFgCcq1XB1++5AQAEAZi2+xbSs7I1ER0RERFpGbUS2T179sDLywv6+vo4ffq04nhCQgJ++eUXjQVHFYyZeou93vVpRxc0cbQEADyNScGyE49KGBgRERFpI7US2Xnz5iEgIACrV69WOj5w4EBs2rRJI4FRBWRsBegZyR+rOSMLALo6Evzf4MYw0JX/+K4+/RS3XyRoIkIiIiLSImolsg8ePECPHj0AyFsj5bC3t8erV+onKFTBSSRvZ2XVqJHNrV51M3zRzRUAkC0T8L9dN5EplZU0QiIiItIiaiWy1apVw9OnTwEoJ7L//vsvnJycNBMZVUzm/y34ykgAMlNKdKnxXevA3V6+40dIZBJWnnpS0uiIiIhIi6iVyI4YMQLjx49HSEgIJBIJEhISsH37dowZMwYjR47UcIhUoSjVyZZsVlZfVwc/D24MXR35L1N+Jx/hQWRSia5JRERE2kNPnZN++OEHjB8/Hg0bNoRMJoOlpSUkEgk+/fRTTJ8+XdMxUkWi1LngJVDNtUSX86hpgfFdasP/5BNkZQuYtusmfv+4GSSQFH1yKahuYQhDPV1R7k1ERFTZSARBENQ9OSIiAsHBwZDJZGjatCnLCjQgMTERFhYWSEhIgLm5udjhaN6FFcDx7+SPB6wGmgwp8SXTs7LRZ/lZPI5OLvG1SqqGhRG2fdYWTtZVxA6FiIhIKxUnFyrRhgg1a9ZE37590b9/fyaxpJp3Z2Q1wEhfF4sHNYZEnElYJS8T0jF83WXEJGWIHQoREVGFp3JpwaJFi1S+6LfffqtWMFQJlHB3r4K0cLLCSt/mOH43CjL1P2QokRvh8QiLTcXzN6kYueEyAj5rCzMjfVFiISIiqgxULi1o2bKlyhe9evWq2gFVdhW+tCD+ObC0kfxxg77AkM3ixqNBrxLSMGjFebxMSAcAtK9jjQ2jWrFmloiIqBiKkwupPCPL5JQ0wtTu7WMNzsiWB/YWxvhzdGsMXnUB8alZOP8kFlO338Dyj5srOisQERGR5pSoRpao2PQMgCo28scl2N2rvHK1NcOGka1grC+fhT1yOxJzD95FCdZUEhERUQHUTmQDAgLQpk0bmJubw9zcHG3btsWOHTs0GRtVVDm9ZJMiAVm2uLGUgma1rLBiWHPo/TcL++eFMCwPeixyVERERBWPWonsokWLMHr0aLRr1w4rV67EypUr0bZtW4waNQo///yzpmOkiiZndy8hG0iJETeWUuLpZoufBzdWPP/tn4fYeum5iBERERFVPGptiLBkyRJs3boV/fv3Vxzz9fWFp6cnxo0bh2nTpmksQKqAlHb3egmY2RU8VosNbO6A2ORM/HTkPgBg1r7bqFpFH14e9kWcSURERKpQa0Y2MzMTnp6eeY57enoiMzOzxEFRBZc7ka2AdbK5je1cG591rg0AkAnA5IAbuPg0VuSoiIiIKga1Etl27dph9+7deY7v2rUL7dq1K3FQVMGZvzMjW8F961UfA5vXBABkSmUYu+kq7r1MFDkqIiIi7adWaYG7uzvGjh2LgwcPolWrVhAEAVevXsWBAwcwdepU+Pn5KcZOmjRJY8FSBZF7U4RrG4EXV4o4QQK4eQENB5RmVKVGR0eCxYMa401KJk49iEFShhSfbLiMAc1qavQ+Rno68GldCzUsjTV6XSIiovJK5Q0Rcqtfv77KY0NCQop7+Uqtwm+IAABR94CVxZ25lwCfXwRsVf/ZK29SM6XwXXsJ15/Hl9o9nK1NsH9iR1iYcEcxIiLSTsXJhdRKZEk1UqkUZ8+eBQDY2NigYcOGRZ5TKRJZmQzY0BsIv1i889pNAnr9VDoxlZG4lEz4rL6IB1FJpXaPLvVssH5kK27CQEREWomJbDmRnJyMPn36IDY2Fm5ubti1a1eR51SKRBYABAGIDyu6j2xmCrC2O5CdCZhUA74OAXS1e7YxPSsbd18mQqbBv3ppmdmYsv0G3qTIF1tO6FoH0720d/aaiIgqr1LZovZdMTExCA4ORlxcXJ7XfHx81L1shWJqaopTp07h0KFD2Lhxo9jhlC8SCWDlrNpYt/eBe/uA1NfAw+NAgz6lGVmpM9LXRQsnK41f129oMwxfdxnZMgErTz1Bwxrm6NO4RtEnEhERaSm1Etnt27dj1KhRyM7OhpmZWZ7Xi5PIpqenY9euXQgJCcHo0aPh4uKi0nnh4eE4ePAgUlJS0Lt3b3h4eKh8T1VlZ2fj8OHDuHz5MgYMGIAWLVrkGfPmzRvs2rUL0dHRaNy4Mfr27QuJhB/palSz4fJEFgCub9b6RLa0tK9TDbM+aIC5B+8BAP638xZqVzOFe40KPLNPRESVmlrtt6ZPn45FixYhLS0Nr1+/zvOlqr/++gt16tTB9u3b8dNPPyEsLEyl8zZu3Ij69evjzJkzSEhIwOjRo7F9+3Z13kqBTpw4AVdXV6xZswaLFy/G9evX84x5+vQpPDw8sHnzZsTGxuLzzz/HwIEDwWoNDavj+bbTwaO/5VvbUr5GtnfGoOYOAIC0rGx89tdVxKWwtzMREVVMaiWy0dHRGD16NHR01Dpdwc3NDTdv3sTKlStVPufOnTsYO3Ys/Pz8sG3bNsyfPx/nz59H06ZNCzzn5MmT+R4/ffo0pFJpvq9Vr14dp0+fxsGDB6Grq5vvmP/973+oXbs2Tp48iSVLliAoKAgHDx7Mt8culYCOLtB0qPyxkA3cDBA3nnJMIpHgpwEeaOJgAQB4EZeGSduCIc2WiRwZERGR5qm9IcL58+dLfPPWrVujWrVqxTpnxYoVqFWrFkaNGqU4pqurCzc3t3zHP3jwAH369FHqbQsAO3fuRK9evXDxYv4r5z08PODo6FhgHJmZmTh8+DBGjBihSHTr1auHDh06YM+ePYpx586dw+3btxETE4NTp07hzZs3Kr9XyiUnkQWA63/JF4tRvoz0dbFqeAtUMzUAAJx7HItFR9kGj4iIKh61amT9/f3x/vvv46OPPkKdOnXy1ISOGTNGI8Hl5/Lly+jcuTNu376NQ4cOwdzcHN27dy+wt62bmxsOHDiAvn37Qk9PD+PHj8fu3bsxfPhwbNq0CR07dlQrjtDQUGRkZMDV1VXpeN26dZXKEH7++WckJCRAIpHghx9+wM8//4zWrVvnuZ6/vz/8/f2RnV3EKv7KyroO4NQRCDsLxD4Gwi8BtdqKHVW5ZW9hjJXDWmDomovIyhaw9uwzuNcwx8D/yg6IiIgqArUS2T179uDZs2f4448/YGFhkef10kxk4+PjERwcDB8fH/Tp0wd3797F119/jeXLl2Ps2LH5ntO9e3fs3bsX3t7euH79OjZt2oR169ZhyJAhaseRkpICAHnaQlhYWCheA4D9+/erdL2JEydi4sSJipYTlI/mw+WJLCCflWUiW6hWzlXxQ7+GmLn3DgDg2z234WprisYOluIGRkREpCFqJbJLlizB2rVrMXr0aE3HUyRTU1OEhobi6dOnqFq1KgCgQYMGmDJlCkaNGgU9vfzfUq9evTBlyhQsWrQII0eOhK+vb4njAICEhASl4/Hx8YrXSMMa9AMOfwNkJgF39gJeiwFD/lkXxreNE+5EJGLb5efIlMow7q9rODCpI2zMDMUOjYiIqMTUqpGVSqWi9Ypt0KAB6tWrp0hiAXnNbmpqKiIiIgo879ChQ1i6dCkmT56MgIAAbNiwoURxODs7w8jICA8fPlQ6/vDhw2Jt4UvFYGACNBokf5yV8rYlFxXqh37uir61rxLSMXFLMLK4+IuIiCoAtWZkW7ZsiVOnTuGDDz7QdDx5rFmzBmZmZorEeciQIRgxYgRiYmJgY2MDADhz5gwsLCzg4JB//d/Ro0fx4YcfYsWKFRg1ahR69OiBjz76CLq6uhgxYoRacenr66Nv377YtGkTxo4dCz09Pdy7dw/nz5/H119/rd6bpaI1Gw5c2yh/fH0z0GyYqOFoA0M9Xaz0bY6+fmcRlZiBy6FvMGlrMEsMiErI0kQf/ZrUgJmRdu82SKTN1Epk3dzc4OPjg08//RSurq55FntNmjRJpetcv34du3fvRlKSfN/5devWITAwEN26dUO3bt0AAJs2bYKdnZ0ikfX29oa3tzdatWoFb29vRERE4MiRI9iwYUO+bbIePHiAQYMG4ffff1d0Oujbty8CAgLg4+MDFxcXdOrUKc95z58/x+rVqwHIZ6D37duH0NBQNG3aFIMHDwYA/N///R86deqEjh07olmzZti7dy8+/PBDeHt7q/T+SQ01WwA29YGYEOD5BeD1Y6Caa9HnVXK25kZYNawFhvxxEZnZMhy/G4Xjd6PEDotI6917mYifBjQSOwyiSksiqNG9v6iPzkNCVGv1c+vWLRw4cCDP8c6dO6Nz584AgD///BNVqlTBoEGDlMacPHkS165dg7W1NXr06FFoq6zz58+jffv2eY5funQJLVu2zDcBDg8Px6ZNm/Icb9SoEfr37694npiYiL179yI6OhpNmjRBz549C37DKijO/sKV1vnlwN+z5I87TgV6/CBqONpk59Vw/G/XLbHDIKowHKyMcXZ6N7HDIKpQipMLqZXIUulhIquC5GjgtwaATAqY2gFT7wK6an24UCndf5WIF3FpYodBpNV+/fsBQiLlnyZe//49WFUxEDkiooqjOLkQ//Un7WNqC9TzAkIOAcmRwONAwM1L7Ki0RgN7czSw5y9JRCVx7vFrRSJ752UCOtW1ETkiospJ5UR20aJFAIBvv/1W8bgg3377bcmiIipKs+HyRBaQ95RlIktEZahRzbf9vm9HMJElEovKieyuXbsAyJPUnMcFYSJLpc61B2BaHUiOAh4eA5JjAFP+Q0JEZaORw9tE9k5EQiEjiag0qZzIXr16Nd/HRKLQ1QOafAycWyqvlb21HWivWrcMIqKSqmNjCmN9XaRlZeM2E1ki0ai1IQIAREW9bd3z6tUrLF26FAcPHtRIUEQqyd1D9vpfANctElEZ0dWRoGENea15+Js0xKVkihwRUeWkViK7du1azJkzBwCQlZWFLl264LfffoOPjw/8/Pw0GiBRgarVBRzbyh/HhAARweLGQ0SVikeuOtk7LzkrSyQGtRLZ3377TbF71alTpwAAT58+xeHDh5nIUtl6d1aWiKiMvLvgi4jKnlqJbGhoqGIDgpMnT6J///7Q09ND27Zt8fz5c40GSFSoht6AfhX54zu7gcxUUcMhosqDC76IxKdWIuvk5ITDhw8jNTUVO3bsQI8ePQAAz549g7OzsybjIyqcoRnQcID8cUYicD/vTnFERKUhZ8EXwBlZIrGolcjOnDkTQ4YMQdWqVWFtbY3u3bsDANavX49PP/1UowESFan58LePr28WLw4iqlR0dSRwz7XgKz6VC76IyppaO3sNGzYMHTp0QHh4ONq0aQM9PfllOnbsiF69emk0QKIiObYBrF2B2MdA6BngSRBgUk2cWKrVBfSNxbk3EZW5RjUtcC0sDgBwJyIRHeuK9P8eokpK7S1qXVxc4OLionSsf//+JQ6IqNgkEvmir8Af5M//GiBeLGb2wITzgElV8WIgojLj8c6CLyayRGVL7T6yROVKk48BXUOxowCSXskXnRFRpdCYC76IRKX2jCxRuWJmBwzbBdw7AAjZZX//rHTg5lb543v7gdZjyz4GIipzuXf4uhURL3Y4RJUOE1mqOFw6y7/EIAhA+CXgzRMg7ByQHA2Y2ooTCxGVmZwFX9fC4hQLvixNDMQOi6jSYGkBkSZIJPKetgAgyID73K6ZqLLIvTHCnYhEESMhqnyYyBJpirv328f39okVBRGVsXcXfBFR2WEiS6Qpdo0Aq/86eYSeBZJjxI2HiMqE8owsE1missRElkhT3i0vCDkkajhEVDbq2FSBkb78n1POyBKVLSayRJrE8gKiSkdPVwfu9vIdvp6/SUVCapbIERFVHkxkiTTJvglg6SR//OwMkBIrbjxEVCYaO1gqHt95yVlZorLCRJZIk5TKC7KBEHYvIKoMci/4uvWCiSxRWWEiS6RpSuUF+0ULg4jKDhd8EYmDiSyRptVoBljWkj9++i+Q+kbceIio1HHBF5E4mMgSaZpEArj3lz8Wstm9gKgS4IIvInEwkSUqDe4D3j5meQFRpaBUXsAFX0RlgoksUWmo2RywcJQ/fnqK5QVElQB3+CIqe0xkiUpD7vICmRR4cETceIio1DVyYCJLVNaYyBKVltzdC+7uEysKIiojrjamigVf7FxAVDaYyBKVlpotAPOa8sdPTwFpcaKGQ0SlK/eCr7BYLvgiKgtMZIlKi45OrvKCLODBUXHjIaJSxwVfRGWLiWwpyszMhJ+fH/z8/HDs2DGxwyExsLyAqFLhgi+isqUndgAVWXZ2NkJCQhAaGgojIyN4eXmJHRKVNYdWgFkNIOkl8CQISE8AjCyKPo+ItBIXfBGVLc7IliJjY2P4+flh/PjxYodCYtHRAdz7yR+zvICowuOCL6KyJXoi+/TpU3z77bfw9vbGnTt3ihx/9uxZeHt75/lKSkrSeGxRUVFYsGABvL29ERgYmO+Y27dvY/LkyfDx8cGCBQtKJQ7SciwvIKo09HR10CD3gq80LvgiKk2iJrKLFy9Gz549IZVKsX//frx+/brIc168eIGgoCCMHDlS6cvQ0FCjse3YsQMtW7ZEUlISjhw5gtDQ0DxjLl26hNatWyMjIwPvvfce9u7di86dOyMjI0OjsZCWc2wDmNrJHz85IS8vIKIKK/eCr7uclSUqVaImskOHDsXDhw8xZcqUYp1nYGCQZ0bWwMAg37Hp6enw8/ODIAh5Xlu9ejXi4+PzPa9Tp054+vQpFi5cCB2d/P+Yvv32W3h5eeGPP/7A6NGjcezYMYSEhGDTpk3Fej9UweUuL8jOBB4eFzceIipVXPBFVHZETWQdHR0LTBILk5qaik8//RQjR47EkiVLkJKSUuDYqKgoLFy4EJMmTVI6/uOPP2LatGkICwvL9zx7e3vo6+sXGsPp06cxaNAgxTFra2t4enri6NG3dZDr1q3D4cOH8eTJE/j5+eH58+eqvk2qSFheQFRpNOaCL6IyI3qNrDo6duyINm3aoE2bNti0aRM8PDwQGxub71gnJycEBQVhz549mDx5MgBgwYIF+OWXX3D8+HE0adJErRjCwsIgk8ng6OiodNzR0RHPnj1TPH/06BF0dXXRoUMHhISEFJh0+/v7w93dHa1atVIrHirnarUFqtjKHz8OBNITxY2HiEoNF3wRlR2ta7/Vu3dv+Pj4KJ6PGDECDRo0wI8//oilS5fme46bmxtOnDiBrl27Ijg4GLdu3cKxY8fQpk0btePIqYM1MTFROm5qaor09HTF80WLFql0vYkTJ2LixIlITEyEhQXbM1U4Orry8oIra4HsDODR30CjwWJHRUSlIGfB1/Xn8Qj9b8GXhXHBn/ARkfq0bkb23SSvSpUq6NGjB65evVroee7u7vD19cW5c+fwwQcfoH379hqJIy5OedvR2NhYWFlZlejaVEEplRfsFS0MIip9XPBFVDa0LpHNT3x8PPT0Cp9c/u2337BmzRqsXr0agYGBmDZtWonu6eTkBAsLC9y8eVPp+I0bN9C4ceMSXZsqKKf2QBUb+ePHgUBGsrjxEFGp4YIvorJR7ksLZsyYAUtLS0XiuWXLFgwYMEDxkf7p06dx6NAhLF68uMBrLF++HLNnz8bhw4fRpUsXtG7dGt27d4eenh4WLFigVlw6Ojrw9fXFmjVrMHbsWFhaWuKff/7BzZs34efnp9Y1qYLT0QUa9AWurgek6UDQfMC2gdhRUUH0DAHX94Aq1mJHQlqoERNZojIhaiIbFBSE33//XVFTOmvWLFSrVg0+Pj6KOtjTp0/Dzs5OcU5iYiLc3d3h5OSE9PR03Lp1C19++aViIde7Hjx4gBkzZuDAgQPo0qULAKBJkyYIDAxE9+7d0bNnT3Tt2jXPeffv38d3330HAMjKyoK/vz8OHTqErl27KtqFLViwADdv3oSbmxvq1auHa9euYd68eejYsaOm/oioonH3lieyAHBppaihkArsmwCf/QtIJGJHQlqmrq0pDPV0kCGVccEXUSmSCPk1WC0jz58/R3BwcJ7j9evXR/369QEAZ86cgZGRkdJq/pSUFNy4cUMx1tq68BmTyMhIpWS4qOMA8ObNG5w+fTrPcUdHR7Ro0ULxXBAEBAcHIzo6Go0aNYKDg0OhsRQlZ7FXQkICzM3NS3QtKoeypYB/a+DNE7EjIVVNvALY1BM7CtJC3v7ncCM8HgBw64eeMDfigi8iVRQnFxI1kaW8mMhWAklRwJMgQMatK8ut0HPArQD5Y69FQNsJ4sZDWun7fXfw10V5r/KtY9ugfZ1qIkdEpB2KkwuV+xpZogrHrDrQ9GOxo6DC1GzxNpF9fIKJLKmlUa6NEe5EJDCRJSoFFaJrARGRRtm6A2b28sehZwFphrjxkFZSXvDFTVCISgMTWSKid0kkQJ1u8sfSNOD5BXHjIa2Us+ALAG6/iBc3GKIKiqUFRET5qdMNuLFF/vjxCaB2V1HDIe2Ts8PXjXD5Dl/9/c6KHVKlo6+rg54Nq2NEO2cY6euKHQ6VAiayRET5qdMNgASAIF+chx9FDoi0UWMHC0Xngpsv2IZLDFfD4rDhXCim9qiHgc1rQk+XH0ZXJPxuEhHlx6QqUKOZ/HHUHSApUtx4SCuNaOcMJ2sT6EjALxG+crxKSMe03bfQe9kZ/H03EmzYVHGw/VY5w/ZbROVI0Hzg9P/JH3uvBJoOFTceIiqWB5FJ+L/jIQi8H610vIWTFb7rXR8tnauKFBkVpji5EGdkiYgKkrPgC5DXyRKRVnGzM8PaT1phx7h2aF7LUnH8WlgcBq+6gDGbruJhVJJ4AVKJcUa2nOGMLFE5kp0FLHYBMpMAE2vgm8eADn//J9JGgiDgn3tRWHwsBE9iUhTHdSTAoOYOGNOpNkwMyv+CsGqmhjDWgjhLgjt7aTEmskTlTIAvEHJI/njsSaBmc3HjIaISkWbLsDv4BX775yGiErWvR7SJgS62jm2Lpo6WYodSalhaQESkKbnLC56wvIBI2+np6mBIq1o49Y0npnvVh5mRdjVwSs3Mxq5r4WKHUW5o13ePiKisuXZ/+/hxEND5f+LFQkQaY2ygiwld6+Dj1o7YdD4Mj2OSxQ6pUDJBwOFbrwAAj6PLd6xliYksEVFhrJyBqnWAN0+AF5eB9ETAiGU/RBWFpYkBvuxRV+wwVHL5WSBikjKYyObC0gIioqLkzMrKpMCz0+LGQkSVVl1bUwDA6+RMvEnJFDma8oGJLBFRUerkKi94EiReHERUqeUksgDwiG3DADCRJSIqmnNHQEdf/pgLvohIJHWrmykeP2J5AQAmskRERTM0BWq1lT+OCwVin4gaDhFVTrlnZFknK8dElohIFa4sLyAicSnPyLK0AGAiS0Skmtx1styulohEULWKAayrGAAAHkVxRhZgIktEpJrqHkAVG/nj0DOAlCuGiajsuf5XXhCdlIGE1CyRoxEfE1kiIlXo6Lzd5SszGQi/JG48RFQp1a2eq042huUFTGSJiFSl1IaL5QVEVPbq2uaqk2V5ARNZIiKV5czIAqyTJSJR5O5c8JCJLBNZIiKVmdoAdo3ljyNvAcnR4sZDRJWOa67SAnYuYCJLRFQ8Sm24TooXBxFVSjamhrA0kW/Qwl6yTGSJiIqHdbJEJCKJRKIoL3iVkI6k9MrduYCJLBFRcTi2AQz++2jvSRAgk4kbDxFVOq65FnxV9llZJrJERMWhZwA4d5I/TokBou6IGw8RVTq5F3w9YiJLRETF4sryAiISj1IvWSayRERULGzDRUQiyt1L9mFU5e5cwESWiKi4rOsAVs7yx88vAhmVe0aEiMpWdXNDmBnqAeCmCExkiYjUkdO9QJYFhJ4VNxYiqlQkEomin2xEfBpSMqQiRyQeJrJEROrIXV7AOlkiKmP1cpUXPImpvLOyTGSJiNTh0hnQkX+0xzpZIipruRd8VebyAj2xA6jIMjMzsXr1agCAq6srvLy8RI6IiDTGyBxwaA08Pw+8eQKcWwbom4gdFVH5Y9sAcO4odhQVjitbcAFgIluqsrOzERISgtDQUBgZGTGRJapoXLvJE1kA+Ge2uLEQlWeD1gGNBosdRYVSt3ruTREqb+cClhaUImNjY/j5+WH8+PFih0JEpaHhQEDXQOwoiMq/Q1OBuFCxo6hQalgYoYqBLgDgIUsLxPP06VOsXr0aISEhmD9/Pjw8PFQ+NywsDFOnToWTkxOWLFmi8diioqKwbt06XL58GZMmTUKPHj3yjLl9+zbWrFmD6OhoNG7cGF988QXMzMzyuRoRVTjWdYDx54CXwWJHQlQ+3TsAPDgMZCQCu8cAo44BuqKnHhWCRCKBq60pbr5IQHhcKtIys2H8X2JbmYj607R48WKsWbMG3t7e2L9/P6ZMmaLyuVKpFB9//DEiIyPx9OlTjce2Y8cOfP311xg2bBiOHDmCPn365Blz6dIldO3aFSNGjMB7772HVatWYefOnbh48SIMDQ01HhMRlUM29eRfRJSX2/vAqo5AfBjw4grw7yKg2yyxo6owXG3NcPNFAgRB3rnAo6aF2CGVOVFLC4YOHYqHDx8WK4HN8f3338PJyQn9+vUrdFx6ejr8/PwgCEKe11avXo34+Ph8z+vUqROePn2KhQsXQkcn/z+mb7/9Fl5eXvjjjz8wevRoHDt2DCEhIdi0aVOx3w8REVGFY2Qur4+V/DdTePoX9l3WIG5VK3Ii6+joWGCSWJjAwEAEBARg5cqVRY6NiorCwoULMWnSJKXjP/74I6ZNm4awsLB8z7O3t4e+vn6B101NTcXp06cxaNAgxTFra2t4enri6NGjimPr1q3D4cOH8eTJE/j5+eH58+dFxkxERFRhOLYCPGf890QA9nwGpL4RNaSKoq5S54LKueBL6xZ7RUdH45NPPsHGjRthaWlZ5HgnJycEBQVhz549mDx5MgBgwYIF+OWXX3D8+HE0adJErTjCwsIgk8ng6OiodNzR0RHPnj1TPH/06BF0dXXRoUMHhISEICUlJd/r+fv7w93dHa1atVIrHiIionKr41TAuZP8cWIEcHAykM8npVQ89XJ1LqisvWS1quJaEASMGDECn3zyCbp06aLyeW5ubjhx4gS6du2K4OBg3Lp1C8eOHUObNm3UjiUjIwMAYGKi3DfS1NQU6enpiueLFi1S6XoTJ07ExIkTkZiYCAuLylfjQkREFZiOLjDgD2BleyA9Hrh/EAj+E2jxidiRabWalsYw0tdBepaMpQXa4P79+zh+/Dhu3rwJb29veHt74+DBg3j27Bm8vb1x69atAs91d3eHr68vzp07hw8++ADt27cvUSw5yWZcXJzS8djYWFhZWZXo2kRERBWORU2gv9/b58e+BWIeihdPBaCjI1FsjBAam4IMabbIEZU9rUpkHR0dsXfvXowdOxYjR47EyJEj4e7ujqpVq2LkyJGwt7cv8NzffvsNa9aswerVqxEYGIhp06aVKBYnJydYWFjg5s2bSsdv3LiBxo0bl+jaREREFVKDvkCLUfLHWanA7k8BaYa4MWm5urby8gKZADyNyb98sSIr96UFM2bMgKWlJaZNmwYzMzN4e3srvX7q1CmEh4fnOZ7b8uXLMXv2bBw+fBhdunRB69at0b17d+jp6WHBggVqxaWjowNfX1+sWbMGY8eOhaWlJf755x/cvHkTfn5+RV+AiIioMuq1AAg7D7x+AETeBgLnAl7q/VtMebeqbWBvLmI0ZU/UGdmgoCB4e3tjzJgxAIBZs2bB29sbAQEBijGnT5/G5cuX1b7HgwcPMGPGDBw4cEBRV9ukSRMEBgbijz/+wKlTp/I97/79+4ryhaysLPj7+8Pb2xtLly5VjFmwYAFsbW3h5uaGTp06oX///pg3bx46duSe0kRERPkyMAEGr3u7K95Ff+BRoLgxabHcnQseR1W+zgUSIb8Gq2Xk+fPnCA7OuyNO/fr1Ub9+fQDAmTNnYGRkVOBq/tu3b+P169fw9PQs8D6RkZGws7NT+TgAvHnzBqdPn85z3NHRES1atFA8FwQBwcHBiI6ORqNGjeDg4FBgHKrIWeyVkJAAc/PK9VsVERFVIhdXyutkAaCKDTDhPGBqK25MWujZ6xR4/nIKANDbww4rh7Uo/AQtUJxcSNRElvJiIktERJWCIABbPgQe/yN/7voeMHQHoEZ/+cosWyagwexjyJTK4GprisCvVO/qVF4VJxcq9zWyREREVAFJJID3SnlLrpRoeUK7og2gWwm3eNfVA1qOBpoPL/6pOhLUsTHF/VeJCH2dgkypDAZ6leeXASayREREJA5TG2DASmDzf7tkvq7E7bgOTQHqecn/TIqprq08kZXKBITFpqBuro0SKjomskRERCQe1x5Ajx+AM0uA7ErYiksmfft1ZxfQdkKxL5F7wdfDqGQmskRERERlpuNU+VdlFPMA8G8tf3xzm3qJbPXcLbiSABTcV7+iqTxFFERERETljY0bUKOZ/PGrm0D0/WJfwtX27Qzso0q2VS0TWSIiIiIxNfn47eObAQWPK4CTtQn0dSUAgMdRTGSJiIiIqKx4DAJ0/qv2vL0TkGUX63R9XR24VKsCAHj6OhnSbJmmIyy3mMgSERERialKNXkfXQBIjABCzxT7EnX/Ky/IyhYQ9iZVk9GVa0xkiYiIiMTWZMjbxze3F/t0pQVflai8gIksERERkdjq9QYMLeSP7+0HMlOKdXrd3Au+opI0GVm5xkSWiIiISGz6RoDHAPnjrBTg/qFina7cgoszskRERERUlhr7vH18q3jdC5ytq0BXR965gIksEREREZWtWm0BSyf546engMRXKp9qoKcDZ2sTAMCTmGRky4RSCLD8YSJLREREVB5IJECT/2ZlBZm8FVcx5NTJZkplCK8knQuYyBIRERGVF41zdy/YBgiqz6xWxjpZJrJERERE5YV1HcCxjfxx9D0g8rbKp7ra5k5kK0fnAiayREREROVJ7lnZW6r3lM3dgquybFXLRJaIiIioPGk4ANA1kD++tQPIlqp0Wm2bKvivcQEeckaWiIiIiMqcSVWgXi/545RoeQcDFRjp68LJugoA4HF0MmSVoHMBE1kiIiKi8qbJx28f39ym8mk5dbLpWTJExKdpOqpyh4ksERERUXnj+h5gXFX+OOQQkJ6o0ml1K9mCLyayREREROWNngHgMUj+WJoO3D+g0mlKLbgqwYIvJrJERERE5ZFSeYFqW9bm7lxQGXrJ6okdABERERHlo2ZzwNoViH0MhJ4B4p8DlrUKPaWOjSkkEvk+CnciEnD3ZYLGw6pX3Qz6uuVjLpSJLBEREVF5lLNlbdB8+fNbO4DO3xR6irGBLhysjBH+Jg0hkUn44PezGg/ryswesDEz1Ph11VE+0mkiIiIiyuvdzRFU2LK2pVPVUgyofOGMLBEREVF5ZVkLcOoIhJ0FXj8EXgYDNVsUesp379eHg5Ux3qRklkpIRvrlZx6UiSwRERFRedbER57IAvJFX0UksrZmRvi6p1sZBCY+JrJERERE5Zl7f+DIN/I2XHd2A92+B3T1xYtHz0hev1sOMJElIiIiKs+MzIH6H8iT2NRYYJGjuPF88wgwtRU3hv+UnyIHIiIiIspfk6FiR1AucUaWiIiIqLxz7Q54zgKe/St2JIBO+UkfJYKgQh8HKjOJiYmwsLBAQkICzM3NxQ6HiIiIqEwVJxdiaQERERERaSUmskRERESklZjIEhEREZFWYiJLRERERFqJiSwRERERaSUmsqUoOTkZLVu2RMuWLTF9+nSxwyEiIiKqUMpPI7AKyNjYGKtWrcLZs2dx9uxZscMhIiIiqlDKxYxsdnY24uPjIZVKi3VeZmZmKUX0liAIiI+PL/RegiAgPT09z3FdXV20bNkSrq6upRkiERERUaUkaiL78uVL/PDDD3BycoKVlZVKs5ZRUVGYMmUK7OzsYG5uDnt7e8yePRsymUyjscXHx2PJkiWoX78+rKys8Oeff+YZIwgCZs2aBUtLS5iamqJevXr4559/NBoHEREREeVP1ER206ZNEAQBu3btUvmcw4cPo1GjRrh79y7S09OxY8cOLF26FEuXLtVobPv378fz589x4MABGBoa5jtm6dKl8PPzw7Fjx5CSkoLhw4ejX79+ePr0qUZjISIiIqK8RE1kv/vuO8ydOxcODg4qn/Ppp59i9OjRsLa2BgB06tQJLVu2xI0bN/Id//jxY7Rq1QovXrxQOh4XF4eOHTvi0qVL+Z73ySefYMmSJXBzcyswlmXLlmHcuHFo164dDA0NMWvWLFSrVg2rV69W+f0QERERkXrKRY2sOuLj4xEVFYWAgABcu3YNvr6++Y5zcXFB7dq10a1bN7x8+VJxbs+ePWFoaIjGjRurdf/IyEiEhYWhU6dOimMSiQSdOnVSSo579OiBqVOnIigoCC1btsSFCxfUuh8RERERKdPKrgUZGRlwdnZGWloapFIp5s6di169euU7VldXF1u2bMGQIUPg6emJ/fv3Y8SIEahSpQoOHjwIY2NjtWKIjo4GAFSrVk3puK2tLW7evKl4/uuvvyIrK0vxvF69evlez9/fH/7+/ooFb4mJiWrFRURERKTNcnIgQRCKHKuViayhoSHi4+Mhk8lw+vRpDBw4EBKJBDNnzsx3vJ6eHgICAjB48GB4eHigXbt2OHz4MExMTEocy7uLzKRSKSQSieJ5kyZNVLrOxIkTMXHiRLx48QKOjo5wdHQscWxERERE2iopKQkWFhaFjtHKRDaHjo4Ounbtis8++wwbNmwoMJEFgPT0dERHR8PExASxsbFISUlBlSpV1L53zZo1Aci7KOQWHR2NGjVqqH3dGjVqIDw8HGZmZkoJcWlITEyEo6MjwsPDYW5uXqr3IvXwe1T+8XtU/vF7VP7xe6Qdyur7JAgCkpKSVMqnyn0im5ycDB0dnUJnTxMTE2FgYFDoNXr37g0dHR08e/YMn3zyCbp164aTJ0/CxsZGrbisra1Rv359nDhxAgMGDAAgn409efIkvvjiC7WuCciT8+IsftMEc3Nz/o+jnOP3qPzj96j84/eo/OP3SDuUxfepqJnYHKIu9srMzER8fLyiFiI5ORnx8fFKmwt4eXlhxIgRiue+vr4ICAjAs2fP8OzZM/j7+2PdunWYMGFCvvdITU1Fnz59IJVKcfToUVhbW2P37t1wcnJCjx49EBsbm+95OZs0xMfHAwDS0tIQHx+P1NRUxZgZM2Zg7dq12LZtG548eYIJEyZAJpNh3LhxJf2jISIiIqIiiJrI7tq1C87Ozmjfvj0sLCwwbNgwODs7K/WENTMzUyoB+OmnnxAYGIiePXuiW7du2L9/PwICAgqcBY2NjYW1tTWOHz+u+O3B0NAQe/bsQcOGDRWdDN515coVODs7w9nZGUZGRvj+++/h7OyMqVOnKsYMHz4cy5cvx4IFC9C+fXuEhYUhKCgI1atX18CfDhEREREVRiKosiSMKqSMjAwsXLgQ3333XYGbPpC4+D0q//g9Kv/4PSr/+D3SDuXx+8REloiIiIi0ktZuiEBERERElRsTWSIiIiLSSkxkiYiIiEgrlfs+slQ6EhIS8OjRI9jZ2ZV531rK36tXr/DkyRM0atSowP554eHhiIqKQr169dhrUQShoaFITk5GnTp1CtzeOjY2Fk+fPoWjoyPs7OzKOEJKTEzE48ePUb16dcXGNe9KSUlBSEgIrKysULt27TKOkHI8fPgQ0dHRaN68eZ5e8VKpFHfv3oWenh7c3d1LfYMgeuvWrVuKtqg5bG1tUa9evTxjHzx4gJSUFDRs2FC8xV8CVTpLliwRjIyMhAYNGgjGxsbC4MGDhfT0dLHDqrSuXLkiDBo0SLCxsREACCdPnswzJi0tTRg4cKBgbGws1K9fXzA2NhZ+//33sg+2ktq6datQt25dwcnJSWjYsKFgZmYm/Pbbb3nGzZgxQzA0NBTc3d0FQ0ND4bPPPhOys7NFiLjyiYiIEHx8fARra2uhefPmgrm5udChQwchPDxcadyWLVsEMzMzoV69eoKZmZng6ekpxMfHixR15fXgwQPB3NxcACDcvn1b6bVLly4JDg4OgqOjo1C9enWhXr16wv3790WKtPJp06aNUKtWLaFDhw6Kr3nz5imNefnypdCiRQvByspKqF27tmBtbS0cOXJElHiZyFYyZ8+eFSQSiXD48GFBEAQhPDxcsLOzE77//nuRI6u8NmzYIOzYsUN4+vRpgYnst99+Kzg4OAgvX74UBEEQ9u7dKwAQLl68WMbRVk6LFy8WHj9+rHi+f/9+QSKRCIGBgYpju3btEgwMDIQLFy4IgiAI9+7dE8zMzAR/f/8yj7cyunDhgnDo0CFBJpMJgiAISUlJQrNmzYRBgwYpxjx69EjQ19cXVq9eLQiCIMTFxQlubm7CqFGjRIm5skpPTxeaNWsmTJs2LU8im56eLjg4OAifffaZIAiCkJ2dLfTr109o3LixWOFWOm3atBF+/PHHQsd4eXkJ7du3F9LS0gRBEIQ5c+YI5ubmQkxMTFmEqISJbCXz6aefCi1btlQ69u233wo1a9YUKSLKER4eXmAiW716deGHH35QOubh4SGMGzeujKKjdzk4OAhz585VPH///feFPn36KI0ZOXKk0KJFi7IOjf7z2WefCW3btlU8nz17tmBvb69IdgVBEPz8/AQjIyMhNTVVjBArpS+++EIYOXKkcOXKlTyJ7IEDBwQASjPpFy9eFAAIV65cESPcSqdNmzbCN998I1y+fFl48eJFntcjIiIEiUQi7Nu3T3EsOTlZMDY2FlauXFmWoQqCIAhc7FXJXL9+HS1atFA61rp1a0RERCAmJkakqKgwL1++RFRUVL7ft+vXr4sUVeX24sULREZGwtXVVXGsoL9bt27dgkwmK+sQK62rV6/i5MmTWPr/7d17UFTlH8fxtxdAkE1UvGZr4i1NUtQsnSTHWHWmUbylU4YXFMO0pgQbqGaaShtNo195Q3NGR2W0MGM1L4VmkyCDNCKBosJI4wgo5maDAsay+/vD4fxcwUv9inXl85rhj/OcZ8/zPTxzzvnu2ec55z//YefOnbz77rvGuuzsbAYOHOgy3nLIkCFUVVVx6tQpd4Tb6OzevZu9e/fy+eef17s+OzubDh06uMzdGDx4ME2aNNH5rgGtWbOGqKgo+vbty8CBA/nll1+MdcePH8fpdLqc71q2bEmfPn3c0kea7NXI2Gw22rZt61JWu2yz2WjXrp07wpI7sNlsAPX2W+06aTh2u52ZM2fSq1cvJk2aZJTf7tiqrq6mvLz8thP45J+1bNkyfv31V06dOsXYsWMZOnSosc5ms9G9e3eX+jef/+TfVVxcTFRUFCkpKZhMpnrr1HccNWvWjICAAPVRA5k/fz6TJ0/G19eXq1evMm3aNMaPH09eXh5+fn733TVJd2QbGS8vL6qqqlzKKisrAfD29nZHSHIXXl5eAPX2m/qsYTkcDmbOnEl+fj67du1ymaWrY+v+kJycTFZWFufPn6e4uNjly4b6yL3mzZvHsGHDsNvtpKWlkZOTA9y4C1tQUADU30dw4/ynPmoYERERxlNZ/P39+eSTTygqKiIzMxO4/65JSmQbma5du1JcXOxSVlxcTLNmzejcubObopI7eeSRR2jatGm9/WY2m90UVePjcDiYNWsWP/zwA4cOHapzZ+92x1ZgYOBtH9Ul/55WrVoxd+5cfvzxRyNZvV0fATqWGkDbtm0pKysjLi6OuLg4Vq5cCcCnn35KcnIycKOPLl68SE1NjfE5m81GZWWl+shNOnToAPzvWOnatavLci13XZOUyDYyFouF1NRUl29SVquV0NBQ9z0DTu7Iz8+PYcOGsWvXLqPs2rVrHDhwAIvF4sbIGg+Hw0FkZCSpqakcOnSo3ucpWiwW9uzZ43IBtlqt6qMGcu3atTplhYWFmEwm49xmsVjIzMykrKzMqGO1WunZs6dxcZZ/z8aNG0lLSzP+NmzYAMDmzZt5++23AQgLC+PatWscPHjQ+JzVasXLy4tnn33WLXE3JpWVlXXG9H///fcA9OvXD4BBgwbRpk0bl2tSbm4uRUVFbjnfaYxsIxMdHU1iYiITJkxg3rx5HD58mH379nHo0CF3h9ZolZWVcebMGWOyXW5uLs2bN8dsNhvfbhcvXozFYiE+Pp6hQ4eycuVK2rdvz9y5c90ZeqOxYMECtm3bxtq1a7l06ZLRV506dTLuzMbGxrJ161ZeeuklXn75ZXbt2sXJkyfZuHGjO0NvNOLj43E4HIwYMQJ/f3/S09NZvnw5ixcvpmnTG/dspk6dSkJCAuHh4bz11lvk5+ezbt06vvzySzdHL7Uee+wxZs2axezZs1m6dClVVVXExsayaNEiAgMD3R3eA6+goICoqCgiIyPp1q0bOTk5fPTRR0RERDBgwADgxtCCDz/8kJiYGPz9/enUqRPvvfceo0aNYuTIkQ0ecxOn0+ls8FbFrUpLS1m6dCl5eXl07NiRBQsWuEyIkIa1b98+lixZUqc8MjKSyMhIYzk9PZ3Vq1dz8eJFgoODiYuL05ujGsgLL7xAaWlpnfLx48cTGxtrLJ89e5aPP/6YgoICzGYzCxcuJDg4uCFDbbRqampISkpi7969/PHHHzz66KNMnz69zrntypUrLFu2jKysLFq3bs2cOXMYPXq0m6Ju3E6fPs3s2bPZsmUL3bp1M8rtdjurVq1i//79NG/enPHjxzN79my93auB5OXlkZiYyJkzZ+jcuTPjxo1j4sSJdeolJyeTlJRERUUFoaGhLFy4sM4b2hqCElkRERER8UgaIysiIiIiHkmJrIiIiIh4JCWyIiIiIuKRlMiKiIiIiEdSIisiIiIiHkmJrIiIiIh4JCWyIiIiIuKRlMiKiDxgsrKyyMjIcHcYddyvcYmI59IrakVEGlBJSQk//fSTsezr60tQUNBt3wBmt9v5+eefKSkpoU2bNgwZMuSub89Zt24dV69eNd5qlZmZidPp5Omnn/7nduQu6mvz1rhERP5fSmRFRBrQsWPHePHFF5kwYQLe3t5UVFSQlpZG//79+fbbb2nZsqVRd8+ePURHR+Pn58fjjz/OuXPnKCwsZOnSpURHR9+2jSFDhlBVVWUsr127Frvd3qCJbH1t3hqXiMj/S4msiIgbrF+/nsDAQABKS0vp2rUrSUlJzJ07F4C0tDTCw8P54IMPiI+PN94zb7VamTRpEi1atGDmzJn1bjskJAS73Q7A8ePHKSoqwuFwsH37dgDCwsKMtnNycigqKsJsNjNgwACaNv3fiLOMjAyaN29O7969ycjIwOl0MmbMGHJzczlx4gQAAQEBPPHEE3Tu3Nn43O3avDmuWjU1NWRkZHDp0iV69+5N3759XdbXxtC3b1+ys7OpqKjgqaeeolWrVn/9ny4iDxwlsiIibta+fXv8/Py4evWqUfbOO+/Qv39/lyQWIDw8nIiICOLj44mIiKBZs2Z1tnfzT/gnTpzg3LlzOJ1OUlJSgBuJrpeXF5MmTaKgoID+/fuTn59PYGAgu3fvNpLczz77jMLCQq5cuULPnj3p168fY8aMIT8/39jW5cuXOXLkCEuWLOGNN94AuG2btw4tKCkpYfTo0ZSXl9OnTx+OHDnC2LFj2bJli7HPtTGUl5cTFBTE+fPnuXz5MocPH6Z79+7/ZDeIiAdSIisi4gbffPMNJpOJyspKUlJS6NKlC9OmTQOgoqKC9PR03n//fZckttbkyZPZtGkTOTk5DBw48I7tTJs2jdTUVOx2O1u3bjXKZ8yYgclkorCwEC8vL2pqaggPDycuLo4NGzYY9XJzc8nOzna5UzplyhSmTJliLGdmZhIaGsrkyZON/aivzVvFxMRgMpk4evQovr6+nDlzhpCQELZs2cL06dONeqdPnyY7O5sePXrgcDgIDQ0lISGB1atX33HfReTBp0RWRMQN9u3bh7e3N1VVVeTk5DBy5EhjEtelS5eoqanBbDbX+9na8gsXLvyttquqqti+fTsxMTFYrVacTidOpxOz2cx3333nUve5556r83M/wJUrV8jJyeHixYs4HA58fX3Jzs6mS5cu9xRDTU0NX3/9NUlJSfj6+gLQq1cvpkyZwvbt210SWYvFQo8ePQBo2rQpw4cPJysr62/tu4g8WJTIioi4wc1jZK9fv86TTz7Ja6+9xqZNm/D39wdu/Gxfn99++w3AqPdXlZSU8Oeff3Ls2DHOnj3rsm748OEuy506darz+W3bthEdHU2vXr3o0qULPj4+VFdXU1ZWds8xFBcXU11dTVBQkEt59+7dOXr0qEtZmzZtXJZ9fHw0aUxEACWyIiJu5+PjQ1hYGMnJyQC0bduWoKAgMjIyjHGnN8vIyMDb25uQkJC/1d5DDz0EwKuvvsq4cePuWLe+oQ0LFixgxYoVREVFGWUmkwmn03nPMdQm8TabzaXcZrMZ60RE7kYvRBARuQ8UFhbSsWNHY/nNN99kx44dZGZmutS7cOECCQkJzJkzB5PJdE/b9vf3d7mDGRgYyKBBg0hMTKxTt7i4+I7bun79Or///ju9e/c2yvbv3+8yUa2+Nm/l5+dHSEgIO3fuNMqqq6uxWq0888wzd90nERHQHVkREbeonex1/fp10tLS2LNnDzt27DDWz58/n7y8PMLCwpg3bx7BwcGcO3eONWvWMHjwYFasWHHPbQ0ePJiYmBgSExMJCAggLCyMdevWYbFYsFgsTJw4kYqKClJTUwkODmb58uW33ZaPjw9jxoxh/vz5vP7665SWlrJq1SpjnOud2rxVQkICo0ePxul0EhISwrZt27Db7SxatOie901EGjclsiIiDejhhx9m6tSpHDx4ELiRGJrNZnJzc10mVTVp0oTExERmzJhBSkoKqamptG7dmvXr1/P888/fsY1bXzwQERFBdXU1R48epby8nJCQEAYNGsTJkyfZtGkTmZmZtG/fntjYWJeEc9iwYbRo0aLO9r/66ivWrFlDWloa7dq148CBA3zxxRcuj8Oqr81b4xoxYgRZWVls3ryZ9PR0Ro0axSuvvEJAQMAdY+jXr99d/ssi0lg0cf6VQU0iIiIiIvcJjZEVEREREY+kRFZEREREPJISWRERERHxSEpkRURERMQjKZEVEREREY+kRFZEREREPJISWRERERHxSEpkRURERMQjKZEVEREREY+kRFZEREREPJISWRERERHxSEpkRURERMQj/RcY9yvGwtn/fAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 700x450 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(7, 4.5))\n",
+    "for name, Y in results.items():\n",
+    "    best = torch.cummax(Y.squeeze(-1), dim=0).values[N_INIT - 1 :]\n",
+    "    # the global optimum is 0, so the simple regret is just -best\n",
+    "    ax.plot(range(len(best)), -best, label=name, linewidth=2)\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.set_xlabel(\"BO iteration\")\n",
+    "ax.set_ylabel(\"simple regret\")\n",
+    "ax.set_title(f\"Ackley-{DIM}D\")\n",
+    "ax.legend()\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "613c1f03",
+   "metadata": {},
+   "source": [
+    "## Discussion\n",
+    "\n",
+    "GIT-BO concentrates its candidate sets inside the estimated active subspace — the\n",
+    "directions in which the surrogate's posterior mean currently changes the most —\n",
+    "centered at the mean of the evaluated points, while the vanilla `qLogNEI` baseline\n",
+    "must optimize its acquisition over the full 30-dimensional box. For a rigorous\n",
+    "comparison, repeat the runs over multiple seeds and use the paper-scale budgets noted\n",
+    "above; the paper [1] benchmarks GIT-BO against state-of-the-art high-dimensional BO\n",
+    "methods on problems up to 500 dimensions.\n",
+    "\n",
+    "*Built with PriorLabs-TabPFN.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_community/acquisition/test_gitbo.py
+++ b/test_community/acquisition/test_gitbo.py
@@ -202,6 +202,9 @@ class TestActiveSubspace(BotorchTestCase):
         for bad_rank in (0, -1, -0.5):
             with self.assertRaisesRegex(ValueError, "rank must be positive"):
                 compute_active_subspace(gradients, rank=bad_rank)
+        # all-zero gradients in percent mode fall back to rank 1
+        subspace, _ = compute_active_subspace(torch.zeros(4, d, **tkwargs), rank=0.5)
+        self.assertEqual(subspace.shape, torch.Size([d, 1]))
         with self.assertRaisesRegex(ValueError, "gradients must be"):
             compute_active_subspace(gradients.unsqueeze(0), rank=2)
 

--- a/test_community/acquisition/test_gitbo.py
+++ b/test_community/acquisition/test_gitbo.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import MagicMock
+
+import torch
+from botorch.fit import fit_gpytorch_mll
+from botorch.models import SingleTaskGP
+from botorch.models.transforms.outcome import Standardize
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.acquisition.gitbo import (
+    compute_active_subspace,
+    gitbo_step,
+    quantile_ucb,
+    sample_subspace_candidates,
+)
+from botorch_community.models.prior_fitted_network import PFNModel
+from gpytorch.mlls import ExactMarginalLogLikelihood
+from torch import nn, Tensor
+
+
+class GradDummyPFN(nn.Module):
+    def __init__(self, n_buckets: int = 100):
+        """A dummy PFN whose logits depend differentiably on the test inputs.
+
+        Args:
+            n_buckets: Number of buckets for the output distribution.
+        """
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.criterion = MagicMock()
+        self.criterion.borders = torch.linspace(0, 1, n_buckets + 1)
+        self.style_encoder = None
+        self.y_style_encoder = None
+
+    def forward(
+        self,
+        x: Tensor,
+        y: Tensor,
+        test_x: Tensor,
+        style: Tensor | None = None,
+        y_style: Tensor | None = None,
+    ) -> Tensor:
+        bucket_scores = torch.linspace(
+            -1.0, 1.0, self.n_buckets, dtype=test_x.dtype, device=test_x.device
+        )
+        return torch.sin(test_x * 3.0).sum(dim=-1, keepdim=True) * bucket_scores
+
+
+def _get_gp(
+    n: int = 6, d: int = 3, fit: bool = False, **tkwargs
+) -> tuple[SingleTaskGP, Tensor, Tensor]:
+    train_X = torch.rand(n, d, **tkwargs)
+    train_Y = (train_X[:, :2] ** 2).sum(dim=-1, keepdim=True)
+    model = SingleTaskGP(train_X, train_Y, outcome_transform=Standardize(m=1))
+    if fit:
+        fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))
+    else:
+        model.eval()
+    return model, train_X, train_Y
+
+
+def _get_pfn(n: int = 6, d: int = 3, **tkwargs) -> tuple[PFNModel, Tensor, Tensor]:
+    train_X = torch.rand(n, d, **tkwargs)
+    train_Y = torch.rand(n, 1, **tkwargs)
+    model = PFNModel(train_X, train_Y, model=GradDummyPFN())
+    return model, train_X, train_Y
+
+
+class TestQuantileUCB(BotorchTestCase):
+    def test_shapes_and_batch_limit(self):
+        for dtype in (torch.float, torch.double):
+            with self.subTest(dtype=dtype):
+                tkwargs = {"device": self.device, "dtype": dtype}
+                model, _, _ = _get_gp(**tkwargs)
+                X = torch.rand(17, 3, **tkwargs)
+                scores, grads = quantile_ucb(model, X)
+                self.assertEqual(scores.shape, torch.Size([17]))
+                self.assertEqual(grads.shape, torch.Size([17, 3]))
+                self.assertTrue(torch.isfinite(scores).all())
+                self.assertTrue(torch.isfinite(grads).all())
+                # chunked evaluation is exact (quantile-UCB is deterministic)
+                scores_c, grads_c = quantile_ucb(model, X, batch_limit=7)
+                self.assertAllClose(scores, scores_c)
+                self.assertAllClose(grads, grads_c)
+                # no-gradient mode
+                scores_ng, grads_ng = quantile_ucb(
+                    model, X, compute_mean_gradients=False
+                )
+                self.assertIsNone(grads_ng)
+                self.assertAllClose(scores, scores_ng)
+
+    def test_raises(self):
+        model, _, _ = _get_gp(device=self.device)
+        X = torch.rand(5, 3, device=self.device)
+        with self.assertRaisesRegex(ValueError, "X must be"):
+            quantile_ucb(model, X.unsqueeze(0))
+        with self.assertRaisesRegex(ValueError, "quantile must be"):
+            quantile_ucb(model, X, quantile=1.2)
+        with self.assertRaisesRegex(ValueError, "batch_limit must be"):
+            quantile_ucb(model, X, batch_limit=0)
+
+    def test_gradients_match_finite_differences_gp(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        model, _, _ = _get_gp(**tkwargs)
+        X = torch.rand(4, 3, **tkwargs)
+        _, grads = quantile_ucb(model, X)
+
+        def posterior_mean(X_eval: Tensor) -> Tensor:
+            with torch.no_grad():
+                return model.posterior(X_eval.unsqueeze(-2)).mean.reshape(-1)
+
+        eps = 1e-5
+        for i in range(X.shape[0]):
+            for j in range(X.shape[1]):
+                X_plus, X_minus = X.clone(), X.clone()
+                X_plus[i, j] += eps
+                X_minus[i, j] -= eps
+                fd = (posterior_mean(X_plus)[i] - posterior_mean(X_minus)[i]) / (
+                    2 * eps
+                )
+                self.assertAllClose(grads[i, j], fd, atol=1e-4)
+
+    def test_score_exceeds_mean(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        model, _, _ = _get_gp(**tkwargs)
+        X = torch.rand(16, 3, **tkwargs)
+        scores, _ = quantile_ucb(model, X, quantile=0.975)
+        with torch.no_grad():
+            mean = model.posterior(X.unsqueeze(-2)).mean.reshape(-1)
+        self.assertTrue((scores > mean).all())
+
+    def test_pfn_gradients_and_batching(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+        model, _, _ = _get_pfn(**tkwargs)
+        X = torch.rand(8, 3, **tkwargs)
+        scores, grads = quantile_ucb(model, X, eval_in_q_batch=True)
+        self.assertEqual(scores.shape, torch.Size([8]))
+        self.assertEqual(grads.shape, torch.Size([8, 3]))
+        self.assertTrue(torch.isfinite(scores).all())
+        self.assertTrue((grads.abs().sum(dim=-1) > 0).all())
+        # the q-batch and the (N, 1, d) layouts agree on gradients and scores
+        scores_b, grads_b = quantile_ucb(model, X, eval_in_q_batch=False)
+        self.assertAllClose(scores, scores_b, atol=1e-5)
+        self.assertAllClose(grads, grads_b, atol=1e-5)
+        # gradients match finite differences of the Riemann posterior mean
+        eps = 1e-3
+        for i in range(3):
+            for j in range(X.shape[1]):
+                X_plus, X_minus = X.clone(), X.clone()
+                X_plus[i, j] += eps
+                X_minus[i, j] -= eps
+                with torch.no_grad():
+                    mean_plus = model.posterior(X_plus).mean.reshape(-1)
+                    mean_minus = model.posterior(X_minus).mean.reshape(-1)
+                fd = (mean_plus[i] - mean_minus[i]) / (2 * eps)
+                self.assertAllClose(grads[i, j], fd, atol=1e-3)
+
+
+class TestActiveSubspace(BotorchTestCase):
+    def test_known_span_recovery(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d, r = 5, 2
+        basis = torch.linalg.qr(torch.randn(d, r, **tkwargs)).Q
+        coeffs = torch.tensor(
+            [[2.0, 0.0], [-2.0, 0.0], [0.0, 1.0], [0.0, -1.0]], **tkwargs
+        )
+        gradients = coeffs @ basis.transpose(-2, -1)
+        subspace, eigenvalues = compute_active_subspace(gradients, rank=r)
+        self.assertEqual(subspace.shape, torch.Size([d, r]))
+        self.assertEqual(eigenvalues.shape, torch.Size([d]))
+        self.assertAllClose(
+            subspace @ subspace.transpose(-2, -1),
+            basis @ basis.transpose(-2, -1),
+            atol=1e-8,
+        )
+        # eigenvalues are descending: 2.0, 0.5, then zeros
+        self.assertAllClose(
+            eigenvalues[:2], torch.tensor([2.0, 0.5], **tkwargs), atol=1e-8
+        )
+        self.assertTrue((eigenvalues.diff() <= 1e-12).all())
+
+    def test_rank_modes(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d = 5
+        basis = torch.linalg.qr(torch.randn(d, 2, **tkwargs)).Q
+        coeffs = torch.tensor(
+            [[2.0, 0.0], [-2.0, 0.0], [0.0, 1.0], [0.0, -1.0]], **tkwargs
+        )
+        gradients = coeffs @ basis.transpose(-2, -1)
+        # integer rank larger than d is clamped
+        subspace, _ = compute_active_subspace(gradients, rank=10)
+        self.assertEqual(subspace.shape, torch.Size([d, d]))
+        # percent-variance mode: eigenvalue ratios are 0.8 and 1.0
+        subspace, _ = compute_active_subspace(gradients, rank=0.3)
+        self.assertEqual(subspace.shape, torch.Size([d, 1]))
+        subspace, _ = compute_active_subspace(gradients, rank=0.99)
+        self.assertEqual(subspace.shape, torch.Size([d, 2]))
+        for bad_rank in (0, -1, -0.5):
+            with self.assertRaisesRegex(ValueError, "rank must be positive"):
+                compute_active_subspace(gradients, rank=bad_rank)
+        with self.assertRaisesRegex(ValueError, "gradients must be"):
+            compute_active_subspace(gradients.unsqueeze(0), rank=2)
+
+    def test_sample_subspace_candidates(self):
+        for dtype in (torch.float, torch.double):
+            with self.subTest(dtype=dtype):
+                tkwargs = {"device": self.device, "dtype": dtype}
+                d, r = 6, 2
+                subspace = torch.linalg.qr(torch.randn(d, r, **tkwargs)).Q
+                origin = torch.full((d,), 0.5, **tkwargs)
+                bounds = torch.stack(
+                    [torch.zeros(d, **tkwargs), torch.ones(d, **tkwargs)]
+                )
+                X = sample_subspace_candidates(
+                    subspace, origin, bounds, num_candidates=64, scale=0.1
+                )
+                self.assertEqual(X.shape, torch.Size([64, d]))
+                self.assertTrue((X >= bounds[0]).all() and (X <= bounds[1]).all())
+                # with an interior origin and small scale, samples stay in the
+                # affine subspace: residual after projection is zero
+                diff = X - origin
+                proj = diff @ subspace @ subspace.transpose(-2, -1)
+                self.assertAllClose(diff, proj, atol=1e-5)
+                # scale=0 collapses onto the origin
+                X0 = sample_subspace_candidates(
+                    subspace, origin, bounds, num_candidates=8, scale=0.0
+                )
+                self.assertAllClose(X0, origin.expand(8, d))
+
+
+class TestGITBOStep(BotorchTestCase):
+    def test_first_iteration_sobol(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        model, train_X, _ = _get_gp(**tkwargs)
+        bounds = torch.stack([torch.zeros(3, **tkwargs), torch.ones(3, **tkwargs)])
+        result = gitbo_step(
+            model, train_X, gradients=None, bounds=bounds, num_candidates=32
+        )
+        self.assertIsNone(result.subspace)
+        self.assertIsNone(result.eigenvalues)
+        self.assertEqual(result.candidate_set.shape, torch.Size([32, 3]))
+        self.assertEqual(result.candidate.shape, torch.Size([1, 3]))
+        self.assertEqual(result.gradients.shape, torch.Size([32, 3]))
+        self.assertTrue(
+            torch.equal(
+                result.candidate,
+                result.candidate_set[result.acq_values.argmax()].unsqueeze(0),
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "bounds must be"):
+            gitbo_step(model, train_X, gradients=None, bounds=bounds[0])
+
+    def test_degenerate_gradients_fall_back_to_sobol(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        model, train_X, _ = _get_gp(**tkwargs)
+        bounds = torch.stack([torch.zeros(3, **tkwargs), torch.ones(3, **tkwargs)])
+        result = gitbo_step(
+            model,
+            train_X,
+            gradients=torch.zeros(32, 3, **tkwargs),
+            bounds=bounds,
+            num_candidates=32,
+        )
+        self.assertIsNone(result.subspace)
+        self.assertIsNone(result.eigenvalues)
+
+    def test_two_iteration_loop_gp(self):
+        tkwargs = {"device": self.device, "dtype": torch.double}
+        d = 4
+        bounds = torch.stack([torch.zeros(d, **tkwargs), torch.ones(d, **tkwargs)])
+        train_X = torch.rand(5, d, **tkwargs)
+        train_Y = -((train_X - 0.5) ** 2).sum(dim=-1, keepdim=True)
+        gradients = None
+        for iteration in range(2):
+            model = SingleTaskGP(train_X, train_Y, outcome_transform=Standardize(m=1))
+            fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))
+            result = gitbo_step(
+                model,
+                train_X,
+                gradients,
+                bounds,
+                num_candidates=64,
+                rank=2,
+                scale=0.2,
+            )
+            new_Y = -((result.candidate - 0.5) ** 2).sum(dim=-1, keepdim=True)
+            train_X = torch.cat([train_X, result.candidate])
+            train_Y = torch.cat([train_Y, new_Y])
+            gradients = result.gradients
+            if iteration == 0:
+                self.assertIsNone(result.subspace)
+            else:
+                self.assertEqual(result.subspace.shape, torch.Size([d, 2]))
+                self.assertEqual(result.eigenvalues.shape, torch.Size([d]))
+                self.assertTrue((result.candidate_set >= bounds[0]).all())
+                self.assertTrue((result.candidate_set <= bounds[1]).all())
+            self.assertTrue(torch.isfinite(result.acq_values).all())
+        self.assertEqual(train_X.shape, torch.Size([7, d]))
+
+    def test_two_iteration_loop_pfn(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+        d = 3
+        bounds = torch.stack([torch.zeros(d, **tkwargs), torch.ones(d, **tkwargs)])
+        train_X = torch.rand(5, d, **tkwargs)
+        train_Y = torch.rand(5, 1, **tkwargs)
+        pfn_module = GradDummyPFN()  # loaded once, reused across iterations
+        gradients = None
+        for iteration in range(2):
+            model = PFNModel(train_X, train_Y, model=pfn_module)
+            result = gitbo_step(
+                model,
+                train_X,
+                gradients,
+                bounds,
+                num_candidates=32,
+                rank=2,
+                eval_in_q_batch=True,
+                batch_limit=16,
+            )
+            train_X = torch.cat([train_X, result.candidate])
+            train_Y = torch.cat([train_Y, torch.rand(1, 1, **tkwargs)])
+            gradients = result.gradients
+            if iteration == 1:
+                self.assertEqual(result.subspace.shape, torch.Size([d, 2]))
+            self.assertTrue(torch.isfinite(result.acq_values).all())
+            self.assertTrue(torch.isfinite(result.gradients).all())
+        self.assertEqual(train_X.shape, torch.Size([7, d]))

--- a/test_community/models/test_pfn_licenses.py
+++ b/test_community/models/test_pfn_licenses.py
@@ -58,8 +58,7 @@ class TestModelLicenses(BotorchTestCase):
     def test_gated_license_accepted_via_kwarg_and_marker_persists(self):
         with tempfile.TemporaryDirectory() as cache_dir:
             with patch(
-                "botorch_community.models.utils.prior_fitted_network."
-                "save_license_copy"
+                "botorch_community.models.utils.prior_fitted_network.save_license_copy"
             ) as mock_save:
                 ensure_license_accepted(
                     GATED_LICENSE, accept_license=True, cache_dir=cache_dir
@@ -84,7 +83,7 @@ class TestModelLicenses(BotorchTestCase):
             response = MagicMock()
             response.text = "LICENSE TEXT"
             with patch(
-                "botorch_community.models.utils.prior_fitted_network." "requests.get",
+                "botorch_community.models.utils.prior_fitted_network.requests.get",
                 return_value=response,
             ) as mock_get:
                 path = save_license_copy(GATED_LICENSE, cache_dir=cache_dir)

--- a/test_community/models/test_pfn_licenses.py
+++ b/test_community/models/test_pfn_licenses.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.models.utils.prior_fitted_network import (
+    ACCEPT_LICENSE_ENV_VAR,
+    ensure_license_accepted,
+    MODEL_LICENSES,
+    ModelLicense,
+    ModelPaths,
+    save_license_copy,
+)
+
+NOTICE_LICENSE = ModelLicense(
+    name="Apache-2.0",
+    url="https://example.com/license",
+    text_url="https://example.com/LICENSE.txt",
+    requires_acceptance=False,
+)
+GATED_LICENSE = ModelLicense(
+    name="Example Gated License",
+    url="https://example.com/gated-license",
+    text_url="https://example.com/gated/LICENSE.txt",
+    requires_acceptance=True,
+    attribution="Built with Example",
+)
+
+
+class TestModelLicenses(BotorchTestCase):
+    def test_registry_covers_default_models(self):
+        for model_path in ModelPaths:
+            self.assertIn(model_path.value, MODEL_LICENSES)
+        self.assertIn("Prior-Labs/TabPFN-v2-reg", MODEL_LICENSES)
+        self.assertTrue(MODEL_LICENSES["Prior-Labs/TabPFN-v2-reg"].requires_acceptance)
+
+    def test_notice_only_license_never_raises(self):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            ensure_license_accepted(NOTICE_LICENSE, cache_dir=cache_dir)
+            # no acceptance marker is needed or written
+            self.assertEqual([f for f in os.listdir(cache_dir) if "accepted" in f], [])
+
+    def test_gated_license_raises_without_acceptance(self):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            env = {k: v for k, v in os.environ.items() if k != ACCEPT_LICENSE_ENV_VAR}
+            with patch.dict(os.environ, env, clear=True):
+                with patch("sys.stdin") as mock_stdin:
+                    mock_stdin.isatty.return_value = False
+                    with self.assertRaisesRegex(RuntimeError, "accept_license"):
+                        ensure_license_accepted(GATED_LICENSE, cache_dir=cache_dir)
+
+    def test_gated_license_accepted_via_kwarg_and_marker_persists(self):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            with patch(
+                "botorch_community.models.utils.prior_fitted_network."
+                "save_license_copy"
+            ) as mock_save:
+                ensure_license_accepted(
+                    GATED_LICENSE, accept_license=True, cache_dir=cache_dir
+                )
+                mock_save.assert_called_once()
+            # acceptance was recorded: subsequent calls need no consent
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                ensure_license_accepted(GATED_LICENSE, cache_dir=cache_dir)
+
+    def test_gated_license_accepted_via_env_var(self):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            with patch.dict(os.environ, {ACCEPT_LICENSE_ENV_VAR: "1"}):
+                with patch(
+                    "botorch_community.models.utils.prior_fitted_network."
+                    "save_license_copy"
+                ):
+                    ensure_license_accepted(GATED_LICENSE, cache_dir=cache_dir)
+
+    def test_save_license_copy(self):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            response = MagicMock()
+            response.text = "LICENSE TEXT"
+            with patch(
+                "botorch_community.models.utils.prior_fitted_network." "requests.get",
+                return_value=response,
+            ) as mock_get:
+                path = save_license_copy(GATED_LICENSE, cache_dir=cache_dir)
+                self.assertTrue(os.path.exists(path))
+                with open(path) as f:
+                    self.assertEqual(f.read(), "LICENSE TEXT")
+                # cached: a second call does not re-download
+                path2 = save_license_copy(GATED_LICENSE, cache_dir=cache_dir)
+                self.assertEqual(path, path2)
+                mock_get.assert_called_once()
+            # licenses without a text_url are skipped
+            no_text = ModelLicense(name="X", url="https://example.com/x")
+            self.assertIsNone(save_license_copy(no_text, cache_dir=cache_dir))
+
+    def test_download_model_checks_license(self):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            with patch(
+                "botorch_community.models.utils.prior_fitted_network."
+                "ensure_license_accepted"
+            ) as mock_ensure:
+                import torch
+
+                # the cached-file branch avoids any network access
+                from botorch_community.models.utils.prior_fitted_network import (
+                    download_model,
+                )
+
+                cache_path = os.path.join(
+                    cache_dir, ModelPaths.pfns4bo_hebo.value.split("/")[-1]
+                )
+                torch.save(torch.nn.Linear(1, 1), cache_path)
+                download_model(ModelPaths.pfns4bo_hebo, cache_dir=cache_dir)
+                mock_ensure.assert_called_once()

--- a/test_community/models/test_prior_fitted_network.py
+++ b/test_community/models/test_prior_fitted_network.py
@@ -342,8 +342,13 @@ class TestPriorFittedNetworkUtils(BotorchTestCase):
             # $RUNNER_TEMP is set by GitHub Actions as tmp, /tmp does not work there
         )
 
-        # Assertions for cache miss
-        mock_requests_get.assert_called_once()
+        # Assertions for cache miss. requests.get is called twice: once for
+        # the model weights and once to save a copy of the model license.
+        self.assertEqual(mock_requests_get.call_count, 2)
+        self.assertEqual(
+            mock_requests_get.call_args_list[0].args[0],
+            ModelPaths.pfns4bo_hebo.value,
+        )
         mock_gzip.assert_called_once()
         mock_torch_load.assert_called_once()
         mock_torch_save.assert_called_once()

--- a/test_community/models/test_tabpfn_v2.py
+++ b/test_community/models/test_tabpfn_v2.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest.mock import patch
+
 import torch
 from botorch.utils.testing import BotorchTestCase
 from botorch_community.acquisition.gitbo import gitbo_step, quantile_ucb
@@ -71,6 +73,19 @@ class TestTabPFNv2Model(BotorchTestCase):
         train_Y = torch.rand(5, 1, device=self.device)
         with self.assertRaisesRegex(ValueError, "bar_distribution"):
             TabPFNv2Model(train_X, train_Y, model=DummyTabPFNv2())
+
+    def test_downloads_model_when_not_provided(self):
+        train_X = torch.rand(5, 3, device=self.device)
+        train_Y = torch.rand(5, 1, device=self.device)
+        with patch(
+            "botorch_community.models.tabpfn_v2.download_tabpfn_v2_regressor",
+            return_value=(DummyTabPFNv2(), DummyBarDistribution()),
+        ) as mock_download:
+            model = TabPFNv2Model(train_X, train_Y, accept_license=True)
+        mock_download.assert_called_once_with(accept_license=True)
+        with torch.no_grad():
+            posterior = model.posterior(torch.rand(4, 3, device=self.device))
+        self.assertTrue(torch.isfinite(posterior.mean).all())
 
     def test_posterior_in_raw_units(self):
         tkwargs = {"device": self.device, "dtype": torch.float}

--- a/test_community/models/test_tabpfn_v2.py
+++ b/test_community/models/test_tabpfn_v2.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from botorch.utils.testing import BotorchTestCase
+from botorch_community.acquisition.gitbo import gitbo_step, quantile_ucb
+from botorch_community.models.tabpfn_v2 import TabPFNv2Model
+from torch import nn, Tensor
+
+
+class DummyBarDistribution(nn.Module):
+    def __init__(self, n_buckets: int = 64):
+        """A stub bar distribution exposing standardized-space borders.
+
+        Args:
+            n_buckets: Number of buckets for the output distribution.
+        """
+        super().__init__()
+        self.register_buffer("borders", torch.linspace(-3.0, 3.0, n_buckets + 1))
+
+
+class DummyTabPFNv2(nn.Module):
+    def __init__(self, n_buckets: int = 64):
+        """A dummy TabPFN v2 with differentiable logits over the test block.
+
+        Mimics the TabPFN v2 interface: sequence-first ``x`` containing the
+        training block followed by the test block, with the number of
+        training points inferred from the length of ``y``.
+
+        Args:
+            n_buckets: Number of buckets for the output distribution.
+        """
+        super().__init__()
+        self.n_buckets = n_buckets
+
+    def forward(
+        self,
+        x: Tensor,
+        y: Tensor,
+        only_return_standard_out: bool = True,
+        **kwargs,
+    ) -> Tensor:
+        n_train = y.shape[0]
+        test_x = x[n_train:]  # (q, b, d)
+        bucket_scores = torch.linspace(
+            -1.0, 1.0, self.n_buckets, dtype=test_x.dtype, device=test_x.device
+        )
+        return torch.sin(test_x * 3.0).sum(dim=-1, keepdim=True) * bucket_scores
+
+
+def _get_model(
+    n: int = 8, d: int = 4, y_mean: float = 100.0, y_std: float = 20.0, **tkwargs
+) -> tuple[TabPFNv2Model, Tensor, Tensor]:
+    train_X = torch.rand(n, d, **tkwargs)
+    train_Y = y_mean + y_std * torch.randn(n, 1, **tkwargs)
+    model = TabPFNv2Model(
+        train_X,
+        train_Y,
+        model=DummyTabPFNv2(),
+        bar_distribution=DummyBarDistribution(),
+    )
+    return model, train_X, train_Y
+
+
+class TestTabPFNv2Model(BotorchTestCase):
+    def test_raises_without_bar_distribution(self):
+        train_X = torch.rand(5, 3, device=self.device)
+        train_Y = torch.rand(5, 1, device=self.device)
+        with self.assertRaisesRegex(ValueError, "bar_distribution"):
+            TabPFNv2Model(train_X, train_Y, model=DummyTabPFNv2())
+
+    def test_posterior_in_raw_units(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+        model, train_X, train_Y = _get_model(**tkwargs)
+        # borders are mapped from standardized to raw units
+        expected_borders = (
+            torch.linspace(-3.0, 3.0, 65, **tkwargs) * train_Y.std() + train_Y.mean()
+        )
+        self.assertAllClose(model.borders, expected_borders)
+        with torch.no_grad():
+            posterior = model.posterior(torch.rand(6, 4, **tkwargs))
+        mean = posterior.mean.reshape(-1)
+        # raw-unit posterior: means live inside the raw-space borders, far
+        # from the standardized [-3, 3] range
+        self.assertTrue((mean >= expected_borders.min()).all())
+        self.assertTrue((mean <= expected_borders.max()).all())
+        self.assertGreater(mean.abs().min().item(), 10.0)
+        # icdf at a high quantile exceeds the mean
+        ucb = posterior.icdf(0.975).reshape(-1)
+        self.assertTrue((ucb > mean).all())
+
+    def test_gradients_and_batch_layouts(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+        model, _, _ = _get_model(**tkwargs)
+        X = torch.rand(7, 4, **tkwargs)
+        scores, grads = quantile_ucb(model, X, eval_in_q_batch=True)
+        self.assertEqual(scores.shape, torch.Size([7]))
+        self.assertEqual(grads.shape, torch.Size([7, 4]))
+        self.assertTrue(torch.isfinite(scores).all())
+        self.assertTrue((grads.abs().sum(dim=-1) > 0).all())
+        scores_b, grads_b = quantile_ucb(model, X, eval_in_q_batch=False)
+        self.assertAllClose(scores, scores_b, atol=1e-4)
+        self.assertAllClose(grads, grads_b, atol=1e-4)
+
+    def test_constant_train_y(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+        train_X = torch.rand(5, 3, **tkwargs)
+        train_Y = torch.full((5, 1), 7.0, **tkwargs)
+        model = TabPFNv2Model(
+            train_X,
+            train_Y,
+            model=DummyTabPFNv2(),
+            bar_distribution=DummyBarDistribution(),
+        )
+        with torch.no_grad():
+            posterior = model.posterior(torch.rand(4, 3, **tkwargs))
+        self.assertTrue(torch.isfinite(posterior.mean).all())
+
+    def test_two_iteration_gitbo_loop(self):
+        tkwargs = {"device": self.device, "dtype": torch.float}
+        d = 5
+        bounds = torch.stack([torch.zeros(d, **tkwargs), torch.ones(d, **tkwargs)])
+        train_X = torch.rand(6, d, **tkwargs)
+        train_Y = 50.0 - 100.0 * ((train_X[:, :2] - 0.5) ** 2).sum(-1, keepdim=True)
+        network = DummyTabPFNv2()  # loaded once, reused across iterations
+        bardist = DummyBarDistribution()
+        gradients = None
+        for iteration in range(2):
+            model = TabPFNv2Model(
+                train_X, train_Y, model=network, bar_distribution=bardist
+            )
+            result = gitbo_step(
+                model,
+                train_X,
+                gradients,
+                bounds,
+                num_candidates=32,
+                rank=2,
+                eval_in_q_batch=True,
+            )
+            train_X = torch.cat([train_X, result.candidate])
+            new_Y = 50.0 - 100.0 * ((result.candidate[:, :2] - 0.5) ** 2).sum(
+                -1, keepdim=True
+            )
+            train_Y = torch.cat([train_Y, new_Y])
+            gradients = result.gradients
+            if iteration == 1:
+                self.assertEqual(result.subspace.shape, torch.Size([d, 2]))
+            self.assertTrue(torch.isfinite(result.acq_values).all())
+        self.assertEqual(train_X.shape, torch.Size([8, d]))

--- a/website/notebooks_community.json
+++ b/website/notebooks_community.json
@@ -12,6 +12,10 @@
     "title": "Feasibility-driven Trust Region Bayesian Optimization (FuRBO)"
   },
   {
+    "id": "gitbo",
+    "title": "Gradient-Informed Bayesian Optimization (GIT-BO)"
+  },
+  {
     "id": "hentropy_search",
     "title": "H-Entropy Search"
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

This PR implements GIT-BO from the ICLR 2026 paper "GIT-BO: High-Dimensional Bayesian Optimization with Tabular Foundation Models". It closes the feature request in [#3199](https://github.com/meta-pytorch/botorch/issues/3199). GIT-BO samples candidates inside an active subspace built from the surrogate's own posterior-mean gradients. It works with any BoTorch model, and this PR includes a new TabPFN v2 wrapper plus a license-consent flow for its gated weights.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. The code follows the community-contribution guidelines and lives in `botorch_community`, `test_community`, and `notebooks_community`. I am the paper author and will maintain these files.

## Test Plan

All new code has unit tests with no network downloads, including finite-difference checks of the input gradients. `pytest test_community` passes with 187 tests, and `flake8` plus `ufmt` are clean. The notebook was executed end to end on CPU. On Ackley-30D, GIT-BO reaches a regret of 13.3 with both surrogates, while a standard SingleTaskGP + qLogNEI baseline reaches 18.6.

## Related PRs

None. The new notebook is registered in `website/notebooks_community.json`, and the community modules are not part of the Sphinx docs, so no separate docs change is needed. Related issue: [#3199](https://github.com/meta-pytorch/botorch/issues/3199).
