### PR TITLE
docs: clarify the Yvar scale expected by the Log outcome transform

### DIFF
--- a/botorch/models/transforms/outcome.py
+++ b/botorch/models/transforms/outcome.py
@@ -741,8 +741,9 @@ class Log(OutcomeTransform):
 
     When observation noise is provided, the variance is transformed using the
     delta method approximation: Var[log(Y)] ≈ Var[Y] / Y^2. This assumes that
-    the observation noise is Gaussian in the log-transformed space, which
-    corresponds to log-normal observation noise in the original space.
+    the observation noise will be Gaussian in the log-transformed space, which
+    corresponds to log-normal observation noise in the original space (input as
+    user-provided Yvar).
     """
 
     def __init__(self, outputs: list[int] | None = None) -> None:


### PR DESCRIPTION
Addresses #3351.

Applies the wording @esantorella suggested in
https://github.com/meta-pytorch/botorch/issues/3351#issuecomment-5245760377.

The previous sentence described the noise model that *results* from the delta
method transform, but sitting directly under the formula it reads as guidance on
what scale to supply `Yvar` in. The new wording makes the tense and the input
explicit.

Docstring-only — no code change. Verified by parsing the file before and after
and comparing the ASTs with all docstrings stripped.
