### PR TITLE
Sync .pre-commit-config.yaml with requirements-fmt.txt (ruff-api 0.2.1, ufmt 2.9.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
             - PyYAML
 
 -   repo: https://github.com/omnilib/ufmt
-    rev: v2.9.0
+    rev: v2.9.1
     hooks:
     -   id: ufmt
         additional_dependencies:
         - black==25.11.0
         - usort==1.1.0
-        - ruff-api==0.2.0
+        - ruff-api==0.2.1
         - stdlibs==2025.10.28
         args: [format]
 


### PR DESCRIPTION
Summary:
The `check-requirements-versions` pre-commit hook is failing on every BoTorch
diff, which is land-blocking:

```
Check pre-commit formatting versions.....................................Failed
- hook id: check-requirements-versions
Version mismatches found:
	ruff-api: requirements-fmt.txt has 0.2.1, pre-commit config has 0.2.0
	ufmt: requirements-fmt.txt has 2.9.1, pre-commit config rev has v2.9.0
```

Cause: D115805604 ([MSDK] Update pyfmt component on FBS:master, landed
2026-08-12, ca3823eca614) bumped exactly these two components in
`tools/lint/pyfmt/reqs/requirements-fmt.txt`, which the hook treats as the
source of truth:

```
-ruff-api==0.2.0
+ruff-api==0.2.1
-ufmt==2.9.0
+ufmt==2.9.1
```

BoTorch's `.pre-commit-config.yaml` was not updated with it and went stale. That
the other three pins still agree exactly confirms the config tracks this file
and only these two drifted:

| component | botorch pin (before) | requirements-fmt.txt |
|---|---|---|
| black | 25.11.0 | 25.11.0 |
| usort | 1.1.0 | 1.1.0 |
| stdlibs | 2025.10.28 | 2025.10.28 |
| ruff-api | 0.2.0 | **0.2.1** |
| ufmt | v2.9.0 | **2.9.1** |

This is deliberately standalone rather than folded into any feature stack: it is
repo hygiene that unblocks every BoTorch diff, and it should land on its own.

Differential Revision: D116043058


