### PR TITLE
Fix dependent qHVKG fantasy samplers

### DIFF
--- a/botorch/acquisition/multi_objective/hypervolume_knowledge_gradient.py
+++ b/botorch/acquisition/multi_objective/hypervolume_knowledge_gradient.py
@@ -42,7 +42,7 @@ from botorch.models.deterministic import PosteriorMeanModel
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
 from botorch.sampling.list_sampler import ListSampler
-from botorch.sampling.normal import SobolQMCNormalSampler
+from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.sampling.stochastic_samplers import StochasticSampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     FastNondominatedPartitioning,
@@ -83,7 +83,7 @@ class qHypervolumeKnowledgeGradient(
         ref_point: Tensor,
         num_fantasies: int = 8,
         num_pareto: int = 10,
-        sampler: ListSampler | None = None,
+        sampler: MCSampler | None = None,
         objective: MCMultiOutputObjective | None = None,
         inner_sampler: MCSampler | None = None,
         X_evaluation_mask: list[Tensor] | None = None,
@@ -109,7 +109,8 @@ class qHypervolumeKnowledgeGradient(
                 As the number of fantasies increases, the estimation of the
                 expectation over fantasies becomes more accurate, but the one-
                 shot optimization problem gets harder as there are more "fantasy"
-                designs that need to be optimized.
+                designs that need to be optimized. If an evaluation mask is used,
+                this must be a ``ListSampler``.
             objective: The objective under which the samples are evaluated. If
                 ``None``, then the analytic posterior mean is used. Otherwise, the
                 objective is MC-evaluated (using inner_sampler).
@@ -142,13 +143,12 @@ class qHypervolumeKnowledgeGradient(
         if sampler is None:
             # base samples should be fixed for joint optimization over X, X_fantasies
             samplers = [
-                SobolQMCNormalSampler(sample_shape=torch.Size([num_fantasies]))
+                IIDNormalSampler(sample_shape=torch.Size([num_fantasies]))
                 for _ in range(model.num_outputs)
             ]
             sampler = ListSampler(*samplers)
         else:
-            sample_shape = sampler.samplers[0].sample_shape
-            if sample_shape != torch.Size([num_fantasies]):
+            if sampler.sample_shape != torch.Size([num_fantasies]):
                 raise ValueError(
                     f"The sampler shape must match num_fantasies={num_fantasies}."
                 )

--- a/test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py
+++ b/test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py
@@ -28,9 +28,10 @@ from botorch.exceptions.errors import BotorchError, UnsupportedError
 from botorch.exceptions.warnings import NumericsWarning
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model import ModelList
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.sampling.list_sampler import ListSampler
-from botorch.sampling.normal import SobolQMCNormalSampler
+from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.multi_objective.box_decompositions.dominated import (
     DominatedPartitioning,
 )
@@ -47,6 +48,24 @@ def cost_fn(X):
 
 
 class TestHypervolumeKnowledgeGradient(BotorchTestCase):
+    def test_default_sampler_draws_independent_samples(self):
+        train_X = torch.rand(4, 2, device=self.device)
+        train_Y = torch.rand(4, 2, device=self.device)
+        model = ModelList(
+            SingleTaskGP(train_X, train_Y[:, :1]),
+            SingleTaskGP(train_X, train_Y[:, 1:]),
+        )
+        acqf = qHypervolumeKnowledgeGradient(
+            model=model,
+            ref_point=torch.zeros(2, device=self.device),
+            num_fantasies=1024,
+        )
+        for seed, sampler in enumerate(acqf.sampler.samplers):
+            sampler.seed = seed
+        samples = acqf.sampler(model.posterior(train_X[:1])).squeeze()
+        correlation = torch.corrcoef(samples.T)[0, 1]
+        self.assertLess(correlation.abs().item(), 0.1)
+
     def test_initialization(self):
         tkwargs = {"device": self.device}
         for dtype, acqf_class in product(
@@ -69,6 +88,9 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
             acqf = acqf_class(model=model, ref_point=ref_point, **mf_kwargs)
 
             self.assertIsInstance(acqf.sampler, ListSampler)
+            self.assertTrue(
+                all(isinstance(s, IIDNormalSampler) for s in acqf.sampler.samplers)
+            )
             self.assertEqual(acqf.sampler.samplers[0].sample_shape, torch.Size([8]))
             # test ref point
             self.assertTrue(torch.equal(acqf.ref_point, ref_point))
@@ -99,6 +121,16 @@ class TestHypervolumeKnowledgeGradient(BotorchTestCase):
             self.assertIsInstance(acqf.inner_sampler, SobolQMCNormalSampler)
             self.assertEqual(acqf.inner_sampler.sample_shape, torch.Size([32]))
             self.assertIsNone(acqf._cost_sampler)
+            # A sampler for a joint posterior does not need to be a ListSampler.
+            joint_sampler = SobolQMCNormalSampler(sample_shape=torch.Size([4]))
+            acqf = acqf_class(
+                model=model,
+                ref_point=ref_point,
+                num_fantasies=4,
+                sampler=joint_sampler,
+                **mf_kwargs,
+            )
+            self.assertIs(acqf.sampler, joint_sampler)
             # test objective
             mc_objective = GenericMCMultiOutputObjective(lambda Y, X: 2 * Y)
             acqf = acqf_class(


### PR DESCRIPTION
## Motivation

Fixes #3303.

`qHypervolumeKnowledgeGradient` currently creates one `SobolQMCNormalSampler` per model output. Independently constructed one-dimensional Sobol streams can remain strongly correlated, so independent outputs receive correlated fantasy base samples. In the issue reproducer, the two default streams had a correlation of about 0.42.

This change uses independent IID normal samplers for the default `ListSampler`, matching the existing `get_sampler(PosteriorList)` behavior introduced for #2658. The same reproducer now has a correlation of about -0.01.

The constructor now also validates custom samplers through the common `MCSampler.sample_shape` interface instead of assuming `ListSampler.samplers`. This allows a joint sampler returned by `get_sampler` for a `ModelListGP` posterior. The documentation notes that decoupled evaluation masks still require a `ListSampler`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/meta-pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- `python -m pytest -q test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py` (4 passed)
- `python -m pytest -q test/acquisition/multi_objective` (68 passed, 6 skipped, 48 subtests passed)
- `python -m pytest -q test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py test/sampling/test_get_sampler.py test/models/test_model_list_gp_regression.py` (16 passed, 12 subtests passed)
- `ufmt check botorch/acquisition/multi_objective/hypervolume_knowledge_gradient.py test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py`
- `flake8 botorch/acquisition/multi_objective/hypervolume_knowledge_gradient.py test/acquisition/multi_objective/test_hypervolume_knowledge_gradient.py`
- Ran the issue reproducer and verified that the default sample correlation drops from about 0.42 to -0.01.
- Constructed qHVKG with the joint `SobolQMCNormalSampler` returned for a `ModelListGP` posterior and verified a real forward evaluation returns a finite value.

## Related PRs

- Follow-up to #2977.
