### PR TITLE
Fix stale/graph-attached normalizer cache in OrthogonalAdditiveKernel

### DIFF
--- a/botorch/models/kernels/orthogonal_additive_kernel.py
+++ b/botorch/models/kernels/orthogonal_additive_kernel.py
@@ -552,21 +552,47 @@ class OrthogonalAdditiveKernel(Kernel):
         Returns:
             A ``(*batch_shape, d, 1, 1)``-dim tensor of normalization constants.
         """
-        if self.training or getattr(self, "_normalizer", None) is None:
-            # Computes w.T @ K @ w for each dimension d.
-            # The ... handles any batch dimensions from the base kernel.
-            w = self.w.squeeze(-1)  # (q, 1) -> (q,)
-            normalizer = torch.einsum(
-                w,
-                [0],
-                self.k(self.z, self.z),
-                [..., 2, 0, 1],
-                w,
-                [1],
-                [..., 2],
-            ).clamp(eps)  # (*batch_shape, d)
-            self._normalizer = normalizer[..., None, None]
+        if self.training:
+            # Recompute on every call, and deliberately do not populate the cache:
+            # a train-mode normalizer is attached to the training iteration's
+            # autograd graph, which `backward()` frees. Caching it would hand that
+            # dead graph to eval-mode callers.
+            return self._compute_normalizer(eps=eps)
+        if getattr(self, "_normalizer", None) is None:
+            # Detach before caching: the cache outlives the autograd graph of the
+            # call that populated it, so keeping it attached makes any subsequent
+            # `backward()` through the kernel fail with "Trying to backward through
+            # the graph a second time". Hyperparameters are fixed in eval mode, so
+            # gradients w.r.t. them are not needed here.
+            with torch.no_grad():
+                self._normalizer = self._compute_normalizer(eps=eps)
         return self._normalizer
+
+    def _clear_cache(self) -> None:
+        if hasattr(self, "_normalizer"):
+            del self._normalizer
+
+    def _compute_normalizer(self, eps: float = 1e-6) -> Tensor:
+        """Computes ``w.T @ K @ w`` for each dimension ``d``.
+
+        Args:
+            eps: Minimum value constraint on the normalizers. Avoids division by zero.
+
+        Returns:
+            A ``(*batch_shape, d, 1, 1)``-dim tensor of normalization constants.
+        """
+        # The ... handles any batch dimensions from the base kernel.
+        w = self.w.squeeze(-1)  # (q, 1) -> (q,)
+        normalizer = torch.einsum(
+            w,
+            [0],
+            self.k(self.z, self.z),
+            [..., 2, 0, 1],
+            w,
+            [1],
+            [..., 2],
+        ).clamp(eps)  # (*batch_shape, d)
+        return normalizer[..., None, None]
 
 
 def leggauss(

--- a/test/models/kernels/test_orthogonal_additive_kernel.py
+++ b/test/models/kernels/test_orthogonal_additive_kernel.py
@@ -34,6 +34,7 @@ class TestOrthogonalAdditiveKernel(BotorchTestCase):
         self._test_non_reduced_forward()
         self._test_non_reduced_forward_batch_shape()
         self._test_normalizer_preserves_eval_mode()
+        self._test_repeated_backward_through_eval_kernel()
         self._test_component_indices()
 
     def _test_kernel(self):
@@ -571,6 +572,43 @@ class TestOrthogonalAdditiveKernel(BotorchTestCase):
         norm1 = oak.normalizer()
         norm2 = oak.normalizer()
         self.assertIs(norm1, norm2)
+
+        # The cached normalizer must not hold an autograd graph -- it outlives the
+        # graph of the call that populated it.
+        self.assertIsNone(norm1.grad_fn)
+
+        # Switching back to training must invalidate the eval cache so that a
+        # subsequent eval uses the updated kernel hyperparameters.
+        oak.train()
+        oak.base_kernel.lengthscale = 0.2
+        expected_normalizer = oak.normalizer().detach()
+        oak.eval()
+        updated_normalizer = oak.normalizer()
+        self.assertIsNot(norm1, updated_normalizer)
+        self.assertAllClose(updated_normalizer, expected_normalizer)
+
+    def _test_repeated_backward_through_eval_kernel(self):
+        """Repeated `backward()` calls w.r.t. the inputs of a fitted OAK model."""
+        tkwargs = {"dtype": torch.double, "device": self.device}
+        d = 3
+        train_X = torch.rand(8, d, **tkwargs)
+        train_Y = train_X.sum(dim=-1, keepdim=True)
+        model = SingleTaskGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            covar_module=OrthogonalAdditiveKernel(dim=d, **tkwargs),
+        )
+        # Fitting leaves `normalizer()` having been called in train mode, whose
+        # autograd graph is freed by the fitting backward passes.
+        fit_gpytorch_mll(ExactMarginalLogLikelihood(model.likelihood, model))
+        model.eval()
+
+        # Each iteration builds and frees its own graph, as batched sensitivity
+        # analysis does.
+        for _ in range(3):
+            X = torch.rand(4, d, **tkwargs).requires_grad_(True)
+            model.posterior(X).mean.sum().backward()
+            self.assertIsNotNone(X.grad)
 
     def _test_component_indices(self):
         """Test component_indices property returns correct mappings."""


### PR DESCRIPTION
Summary:
`OrthogonalAdditiveKernel.normalizer()` cached tensors attached to autograd graphs. A training cache could survive into evaluation, and an evaluation cache failed on the second independent `backward()`.

This change recomputes without caching in training mode, computes a graph-free cache in eval mode, and clears that cache through the GPyTorch lifecycle hook on mode changes and state-dict loads. This preserves training gradients while making repeated input-gradient evaluation safe and efficient.

This fixes sensitivity analysis for models using `OrthogonalAdditiveKernel`.

Differential Revision: D117368070


