### PR TITLE
Make OrthogonalAdditiveKernel's hypercube check optional

### DIFF
--- a/botorch/models/kernels/orthogonal_additive_kernel.py
+++ b/botorch/models/kernels/orthogonal_additive_kernel.py
@@ -49,6 +49,7 @@ class OrthogonalAdditiveKernel(Kernel):
         offset_prior: Prior | None = None,
         coeffs_1_prior: Prior | None = None,
         coeffs_2_prior: Prior | None = None,
+        check_hypercube: bool = True,
     ):
         """
         Args:
@@ -75,8 +76,13 @@ class OrthogonalAdditiveKernel(Kernel):
                 non-negative support.
             coeffs_2_prior: Prior on the parameter interactions. Should
                 be prior with non-negative support.
+            check_hypercube: If True (default), raise on inputs outside [0, 1]^d,
+                where the quadrature no longer enforces orthogonality. Set to
+                False to evaluate them anyway, accepting components that are
+                only approximately orthogonal.
         """
         super().__init__(batch_shape=batch_shape)
+        self.check_hypercube = check_hypercube
         self.per_dim_lengthscales = per_dim_lengthscales
         expected_base_batch = (
             self.batch_shape + torch.Size([dim])
@@ -518,9 +524,11 @@ class OrthogonalAdditiveKernel(Kernel):
             A ``batch_shape x d x n1 x n2``-dim Tensor, or a `batch_shape x d x n1`-dim
             Tensor if `diag=True`.
         """
-        _check_hypercube(x1, "x1")
+        if self.check_hypercube:
+            _check_hypercube(x1, "x1")
         if x1 is not x2:
-            _check_hypercube(x2, "x2")
+            if self.check_hypercube:
+                _check_hypercube(x2, "x2")
             if diag:
                 raise UnsupportedError(
                     "OrthogonalAdditiveKernel does not support `diag=True` "

--- a/test/models/kernels/test_orthogonal_additive_kernel.py
+++ b/test/models/kernels/test_orthogonal_additive_kernel.py
@@ -98,6 +98,19 @@ class TestOrthogonalAdditiveKernel(BotorchTestCase):
                 with self.assertRaisesRegex(UnsupportedError, "does not support"):
                     oak.forward(x1=X, x2=X, last_dim_is_batch=True)
 
+                with self.subTest("check_hypercube=False evaluates outside the cube"):
+                    unchecked = OrthogonalAdditiveKernel(
+                        d,
+                        MaternKernel().to(device=self.device),
+                        per_dim_lengthscales=False,
+                        batch_shape=batch_shape,
+                        check_hypercube=False,
+                        **tkwargs,
+                    )
+                    K = unchecked(X_out_of_hypercube, X).to_dense()
+                    self.assertEqual(K.shape, (*batch_shape, n, n))
+                    self.assertTrue(K.isfinite().all())
+
                 X2 = torch.rand(*batch_shape, n, d, **tkwargs)
                 with self.assertRaisesRegex(UnsupportedError, "diag=True"):
                     oak.forward(x1=X, x2=X2, diag=True)


### PR DESCRIPTION
Summary: OAK's components are only orthogonal inside the unit cube, so the kernel refuses any input outside it. That guard is right when the decomposition is the product, but it is a hard crash on paths that only need a rough number -- notably `qLogNEI`'s fallback probe, which is reached whenever no observation is feasible. This makes the check optional, on by default, and turns it off for the two SPORE OAK surrogates.

Differential Revision: D117411279


